### PR TITLE
Unify spinner tracker across repository and fileset processing

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -75,6 +75,12 @@ func runApply(path, filterRepo string, autoApprove, forceSecrets, failOnUnknown 
 	var targetRepos []*manifest.Repository
 	var fileChanges []fileset.FileChange
 
+	// Collect all target names and start a single spinner display
+	var allNames []string
+	allNames = append(allNames, repository.FetchTargetNames(parsed.Repositories, filterRepo)...)
+	allNames = append(allNames, fileset.PlanTargetNames(parsed.FileSets)...)
+	tracker := ui.RunRefresh(allNames)
+
 	g := new(errgroup.Group)
 
 	if len(parsed.Repositories) > 0 {
@@ -82,7 +88,7 @@ func runApply(path, filterRepo string, autoApprove, forceSecrets, failOnUnknown 
 		diffOpts := repository.DiffOptions{ForceSecrets: forceSecrets, Resolver: resolver}
 		g.Go(func() error {
 			var fetchErr error
-			repoChanges, targetRepos, fetchErr = repository.FetchAllChanges(parsed.Repositories, filterRepo, fetcher, p, diffOpts)
+			repoChanges, targetRepos, fetchErr = repository.FetchAllChanges(parsed.Repositories, filterRepo, fetcher, p, tracker, diffOpts)
 			return fetchErr
 		})
 	}
@@ -91,14 +97,16 @@ func runApply(path, filterRepo string, autoApprove, forceSecrets, failOnUnknown 
 		processor := fileset.NewProcessor(runner)
 		g.Go(func() error {
 			var planErr error
-			fileChanges, planErr = processor.Plan(parsed.FileSets)
+			fileChanges, planErr = processor.Plan(parsed.FileSets, tracker)
 			return planErr
 		})
 	}
 
 	if err := g.Wait(); err != nil {
+		tracker.Wait()
 		return err
 	}
+	tracker.Wait()
 
 	hasRepo := repository.HasRealChanges(repoChanges)
 	hasFile := fileset.HasChanges(fileChanges)

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -70,6 +70,12 @@ func runPlan(path, filterRepo string, ci, failOnUnknown bool) error {
 	var repoChanges []repository.Change
 	var fileChanges []fileset.FileChange
 
+	// Collect all target names and start a single spinner display
+	var allNames []string
+	allNames = append(allNames, repository.FetchTargetNames(parsed.Repositories, filterRepo)...)
+	allNames = append(allNames, fileset.PlanTargetNames(parsed.FileSets)...)
+	tracker := ui.RunRefresh(allNames)
+
 	g := new(errgroup.Group)
 
 	if len(parsed.Repositories) > 0 {
@@ -77,7 +83,7 @@ func runPlan(path, filterRepo string, ci, failOnUnknown bool) error {
 		g.Go(func() error {
 			var fetchErr error
 			diffOpts := repository.DiffOptions{Resolver: resolver}
-			repoChanges, _, fetchErr = repository.FetchAllChanges(parsed.Repositories, filterRepo, fetcher, p, diffOpts)
+			repoChanges, _, fetchErr = repository.FetchAllChanges(parsed.Repositories, filterRepo, fetcher, p, tracker, diffOpts)
 			return fetchErr
 		})
 	}
@@ -86,14 +92,16 @@ func runPlan(path, filterRepo string, ci, failOnUnknown bool) error {
 		processor := fileset.NewProcessor(runner)
 		g.Go(func() error {
 			var planErr error
-			fileChanges, planErr = processor.Plan(parsed.FileSets)
+			fileChanges, planErr = processor.Plan(parsed.FileSets, tracker)
 			return planErr
 		})
 	}
 
 	if err := g.Wait(); err != nil {
+		tracker.Wait()
 		return err
 	}
+	tracker.Wait()
 
 	// Phase 2: Print unified plan
 	hasRepo := repository.HasRealChanges(repoChanges)

--- a/internal/fileset/fileset.go
+++ b/internal/fileset/fileset.go
@@ -69,8 +69,19 @@ func (u planUnit) fullName() string {
 	return u.owner + "/" + u.target.Name
 }
 
+// PlanTargetNames returns the full "owner/repo" names for all FileSet targets.
+func PlanTargetNames(fileSets []*manifest.FileSet) []string {
+	var names []string
+	for _, fs := range fileSets {
+		for _, target := range fs.Spec.Repositories {
+			names = append(names, fs.Metadata.Owner+"/"+target.Name)
+		}
+	}
+	return names
+}
+
 // Plan computes changes for all FileSets concurrently.
-func (p *Processor) Plan(fileSets []*manifest.FileSet) ([]FileChange, error) {
+func (p *Processor) Plan(fileSets []*manifest.FileSet, tracker *ui.RefreshTracker) ([]FileChange, error) {
 	// Build work units (order-preserving index).
 	var units []planUnit
 	for _, fs := range fileSets {
@@ -85,13 +96,6 @@ func (p *Processor) Plan(fileSets []*manifest.FileSet) ([]FileChange, error) {
 			})
 		}
 	}
-
-	// Start spinner display for all targets.
-	names := make([]string, len(units))
-	for i, u := range units {
-		names[i] = u.fullName()
-	}
-	tracker := ui.RunRefresh(names)
 
 	// Process each unit concurrently; collect results in order.
 	type unitResult struct {
@@ -126,7 +130,6 @@ func (p *Processor) Plan(fileSets []*manifest.FileSet) ([]FileChange, error) {
 		}(i, u)
 	}
 	wg.Wait()
-	tracker.Wait()
 
 	// Flatten in original order; return first error.
 	var changes []FileChange

--- a/internal/fileset/fileset_test.go
+++ b/internal/fileset/fileset_test.go
@@ -67,7 +67,7 @@ func TestPlan_NewFile(t *testing.T) {
 		{Path: ".github/ci.yml", Content: "name: CI"},
 	})
 
-	changes, _ := p.Plan(fileSets)
+	changes, _ := p.Plan(fileSets, nil)
 
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change, got %d", len(changes))
@@ -92,7 +92,7 @@ func TestPlan_NoChange(t *testing.T) {
 		{Path: ".github/ci.yml", Content: "name: CI"},
 	})
 
-	changes, _ := p.Plan(fileSets)
+	changes, _ := p.Plan(fileSets, nil)
 
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change, got %d", len(changes))
@@ -114,7 +114,7 @@ func TestPlan_DriftWarn(t *testing.T) {
 		{Path: ".github/ci.yml", Content: "new content"},
 	})
 
-	changes, _ := p.Plan(fileSets)
+	changes, _ := p.Plan(fileSets, nil)
 
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change, got %d", len(changes))
@@ -143,7 +143,7 @@ func TestPlan_DriftOverwrite(t *testing.T) {
 		{Path: ".github/ci.yml", Content: "new content"},
 	})
 
-	changes, _ := p.Plan(fileSets)
+	changes, _ := p.Plan(fileSets, nil)
 
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change, got %d", len(changes))
@@ -169,7 +169,7 @@ func TestPlan_DriftSkip(t *testing.T) {
 		{Path: ".github/ci.yml", Content: "new content"},
 	})
 
-	changes, _ := p.Plan(fileSets)
+	changes, _ := p.Plan(fileSets, nil)
 
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change, got %d", len(changes))

--- a/internal/repository/orchestrate.go
+++ b/internal/repository/orchestrate.go
@@ -22,7 +22,19 @@ type repoResult struct {
 
 // FetchAllChanges fetches current state and computes diffs for all repos in parallel.
 // Repos that fail to fetch are skipped with a warning; successful repos are still returned.
-func FetchAllChanges(repos []*manifest.Repository, filterRepo string, fetcher *Fetcher, printer ui.Printer, diffOpts ...DiffOptions) ([]Change, []*manifest.Repository, error) {
+// FetchTargetNames returns the full names of repos that would be fetched (after filtering).
+func FetchTargetNames(repos []*manifest.Repository, filterRepo string) []string {
+	var names []string
+	for _, repo := range repos {
+		if filterRepo != "" && repo.Metadata.FullName() != filterRepo {
+			continue
+		}
+		names = append(names, repo.Metadata.FullName())
+	}
+	return names
+}
+
+func FetchAllChanges(repos []*manifest.Repository, filterRepo string, fetcher *Fetcher, printer ui.Printer, tracker *ui.RefreshTracker, diffOpts ...DiffOptions) ([]Change, []*manifest.Repository, error) {
 	var targets []*manifest.Repository
 	for _, repo := range repos {
 		if filterRepo != "" && repo.Metadata.FullName() != filterRepo {
@@ -37,13 +49,6 @@ func FetchAllChanges(repos []*manifest.Repository, filterRepo string, fetcher *F
 	if len(targets) == 0 {
 		return nil, nil, nil
 	}
-
-	// Start spinner display for all targets
-	names := make([]string, len(targets))
-	for i, r := range targets {
-		names[i] = r.Metadata.FullName()
-	}
-	tracker := ui.RunRefresh(names)
 
 	results := make([]repoResult, len(targets))
 	sem := semaphore.NewWeighted(defaultParallel)
@@ -74,7 +79,6 @@ func FetchAllChanges(repos []*manifest.Repository, filterRepo string, fetcher *F
 	}
 
 	wg.Wait()
-	tracker.Wait()
 
 	var allChanges []Change
 	var targetRepos []*manifest.Repository

--- a/internal/ui/refresh.go
+++ b/internal/ui/refresh.go
@@ -174,6 +174,9 @@ func RunRefresh(names []string) *RefreshTracker {
 
 // Done marks a task as successfully completed.
 func (t *RefreshTracker) Done(name string) {
+	if t == nil {
+		return
+	}
 	if t.fallback {
 		return
 	}
@@ -186,6 +189,9 @@ func (t *RefreshTracker) Done(name string) {
 
 // Error marks a task as failed.
 func (t *RefreshTracker) Error(name string, err error) {
+	if t == nil {
+		return
+	}
 	if t.fallback {
 		DefaultPrinter.Error(name, err.Error())
 		return
@@ -199,6 +205,9 @@ func (t *RefreshTracker) Error(name string, err error) {
 
 // Wait blocks until all tasks are reported and the display finishes.
 func (t *RefreshTracker) Wait() {
+	if t == nil {
+		return
+	}
 	<-t.done
 }
 


### PR DESCRIPTION
## Summary

Lift the spinner/refresh tracker initialization out of `repository.FetchAllChanges` and `fileset.Processor.Plan` into the command layer (`plan.go` / `apply.go`), so both subsystems share a single unified progress display.

## Background

Previously, `FetchAllChanges` and `Plan` each created their own `RefreshTracker` independently. When both repository and fileset targets were processed in parallel, two separate spinner displays competed for the terminal. By creating the tracker once at the command layer and passing it down, all targets appear in a single consolidated spinner view.

## Changes

- Add `repository.FetchTargetNames` and `fileset.PlanTargetNames` helpers to collect target names before processing
- Create a single `ui.RunRefresh` tracker in `runPlan` / `runApply` with all target names
- Pass the tracker into `FetchAllChanges` and `Plan` instead of having them create their own
- Call `tracker.Wait()` at the command layer after `errgroup.Wait()` completes
- Add nil-receiver guards to `RefreshTracker.Done`, `Error`, and `Wait` so callers (including tests) can safely pass `nil`