### PR TITLE
Rename strategy to commit_strategy and direct to push

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -175,10 +175,10 @@ func runApply(path, filterRepo string, autoApprove, forceSecrets, failOnUnknown 
 				continue
 			}
 			opts := fileset.ApplyOptions{
-				CommitMessage: fs.Spec.CommitMessage,
-				Strategy:      fs.Spec.Strategy,
-				Branch:        fs.Spec.Branch,
-				FileSetName:   fs.Metadata.Owner,
+				CommitMessage:  fs.Spec.CommitMessage,
+				CommitStrategy: fs.Spec.CommitStrategy,
+				Branch:         fs.Spec.Branch,
+				FileSetName:    fs.Metadata.Owner,
 			}
 			results := processor.Apply(fsChanges, opts)
 			fileset.PrintApplyResults(p, results)

--- a/docs/src/content/docs/resources/file/index.md
+++ b/docs/src/content/docs/resources/file/index.md
@@ -37,7 +37,7 @@ spec:
       source: github://babarot/shared-config/workflows/ci.yml
 
   on_drift: warn                          # warn | overwrite | skip
-  strategy: direct                        # direct | pull_request
+  commit_strategy: push                    # push | pull_request
   commit_message: "ci: sync managed files"
 ```
 :::

--- a/docs/src/content/docs/resources/file/strategy.md
+++ b/docs/src/content/docs/resources/file/strategy.md
@@ -1,18 +1,18 @@
 ---
-title: Apply Strategy
+title: Commit Strategy
 sidebar:
   order: 4
 ---
 
-The apply strategy controls **how** file changes are committed to the target repository.
+The commit strategy controls **how** file changes are committed to the target repository.
 
-## `direct` (default)
+## `push` (default)
 
 Commits directly to the default branch using the Git Data API. All files are included in a single atomic commit.
 
 ```yaml
 spec:
-  strategy: direct
+  commit_strategy: push
 ```
 
 Use this when you trust the changes and want them applied immediately — for example, syncing a LICENSE or CODEOWNERS that doesn't need review.
@@ -23,7 +23,7 @@ Creates a branch, commits all files, and opens a pull request. Reviewers can ins
 
 ```yaml
 spec:
-  strategy: pull_request
+  commit_strategy: pull_request
   commit_message: "ci: sync shared files"
   # branch: gh-infra/custom-branch   # optional, auto-generated if omitted
 ```
@@ -34,11 +34,11 @@ Use this when changes need review — for example, updating CI workflows that co
 
 | Scenario | Recommended strategy |
 |----------|---------------------|
-| Updating LICENSE, CODEOWNERS, SECURITY.md | `direct` — low risk, no review needed |
+| Updating LICENSE, CODEOWNERS, SECURITY.md | `push` — low risk, no review needed |
 | Updating CI workflows, Dockerfiles | `pull_request` — changes could break things |
 | Initial rollout to a repo | `pull_request` — lets the team review |
-| Routine sync of already-reviewed templates | `direct` — the template was already reviewed |
+| Routine sync of already-reviewed templates | `push` — the template was already reviewed |
 
 ## Empty Repositories
 
-For repositories with no commits yet, gh-infra automatically falls back to the Contents API regardless of the strategy setting. This creates one commit per file as the initial commit.
+For repositories with no commits yet, gh-infra automatically falls back to the Contents API regardless of the commit strategy setting. This creates one commit per file as the initial commit.

--- a/docs/src/content/docs/resources/fileset/index.md
+++ b/docs/src/content/docs/resources/fileset/index.md
@@ -38,7 +38,7 @@ spec:
       source: ./templates/LICENSE
 
   on_drift: warn
-  strategy: direct
+  commit_strategy: push
   commit_message: "ci: sync shared files"
 ```
 :::

--- a/internal/fileset/fileset.go
+++ b/internal/fileset/fileset.go
@@ -114,8 +114,20 @@ func (p *Processor) Plan(fileSets []*manifest.FileSet, tracker *ui.RefreshTracke
 			var out []FileChange
 			for _, file := range u.files {
 				// Template rendering (deep copy vars to avoid data races)
-				if HasTemplate(file.Content, file.Vars) {
+				needsTemplate := HasTemplate(file.Content, file.Vars) || HasTemplate(file.Path, nil)
+				if needsTemplate {
 					varsCopy := copyVars(file.Vars)
+					// Render path
+					if HasTemplate(file.Path, nil) {
+						renderedPath, err := RenderTemplate(file.Path, fullName, varsCopy)
+						if err != nil {
+							results[i] = unitResult{err: fmt.Errorf("template path %s for %s: %w", file.Path, fullName, err)}
+							tracker.Error(displayName, err)
+							return
+						}
+						file.Path = renderedPath
+					}
+					// Render content
 					rendered, err := RenderTemplate(file.Content, fullName, varsCopy)
 					if err != nil {
 						results[i] = unitResult{err: fmt.Errorf("template %s for %s: %w", file.Path, fullName, err)}
@@ -246,10 +258,10 @@ func (p *Processor) fetchFileContent(repo, path string) (*FileState, error) {
 
 // ApplyOptions configures apply behavior from FileSet spec.
 type ApplyOptions struct {
-	CommitMessage string
-	Strategy      string // "direct" or "pull_request"
-	Branch        string
-	FileSetName   string
+	CommitMessage  string
+	CommitStrategy string // "push" or "pull_request"
+	Branch         string
+	FileSetName    string
 }
 
 const defaultApplyParallel = 5
@@ -404,7 +416,7 @@ func (p *Processor) applyViaGitDataAPI(repo, branch, headSHA string, changes []F
 	}
 
 	// 4. Update ref or create PR
-	if opts.Strategy == manifest.StrategyPullRequest {
+	if opts.CommitStrategy == manifest.CommitStrategyPullRequest {
 		return p.createPR(repo, branch, commitSHA, message, opts)
 	}
 	return p.updateRef(repo, branch, commitSHA)

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -170,12 +170,12 @@ func parseFile(data []byte, path string) (*FileSet, error) {
 		Kind:       KindFileSet,
 		Metadata:   FileSetMetadata{Owner: f.Metadata.Owner},
 		Spec: FileSetSpec{
-			Repositories:  []FileSetRepository{{Name: f.Metadata.Name}},
-			Files:         f.Spec.Files,
-			OnDrift:       f.Spec.OnDrift,
-			CommitMessage: f.Spec.CommitMessage,
-			Strategy:      f.Spec.Strategy,
-			Branch:        f.Spec.Branch,
+			Repositories:   []FileSetRepository{{Name: f.Metadata.Name}},
+			Files:          f.Spec.Files,
+			OnDrift:        f.Spec.OnDrift,
+			CommitMessage:  f.Spec.CommitMessage,
+			CommitStrategy: f.Spec.CommitStrategy,
+			Branch:         f.Spec.Branch,
 		},
 	}
 

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -777,7 +777,7 @@ spec:
     - path: LICENSE
       content: "MIT"
   on_drift: overwrite
-  strategy: direct
+  commit_strategy: push
 `
 	path := filepath.Join(dir, "file.yaml")
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
@@ -808,8 +808,8 @@ spec:
 	if fs.Spec.OnDrift != "overwrite" {
 		t.Errorf("on_drift = %q, want %q", fs.Spec.OnDrift, "overwrite")
 	}
-	if fs.Spec.Strategy != "direct" {
-		t.Errorf("strategy = %q, want %q", fs.Spec.Strategy, "direct")
+	if fs.Spec.CommitStrategy != "push" {
+		t.Errorf("commit_strategy = %q, want %q", fs.Spec.CommitStrategy, "push")
 	}
 }
 

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -20,9 +20,9 @@ const (
 	OnDriftOverwrite = "overwrite"
 	OnDriftSkip      = "skip"
 
-	// Strategy values for FileSet apply behavior.
-	StrategyDirect      = "direct"
-	StrategyPullRequest = "pull_request"
+	// CommitStrategy values for FileSet apply behavior.
+	CommitStrategyPush        = "push"
+	CommitStrategyPullRequest = "pull_request"
 
 	// Resource type identifiers used in plan changes.
 	ResourceRepository       = "Repository"
@@ -77,8 +77,8 @@ type Repository struct {
 }
 
 type RepositoryMetadata struct {
-	Name      string `yaml:"name"`
-	Owner     string `yaml:"owner"`
+	Name  string `yaml:"name"`
+	Owner string `yaml:"owner"`
 }
 
 func (m RepositoryMetadata) FullName() string {
@@ -241,11 +241,11 @@ func (m FileMetadata) FullName() string {
 }
 
 type FileSpec struct {
-	Files         []FileEntry `yaml:"files"`
-	OnDrift       string      `yaml:"on_drift,omitempty"`
-	CommitMessage string      `yaml:"commit_message,omitempty"`
-	Strategy      string      `yaml:"strategy,omitempty"`
-	Branch        string      `yaml:"branch,omitempty"`
+	Files          []FileEntry `yaml:"files"`
+	OnDrift        string      `yaml:"on_drift,omitempty"`
+	CommitMessage  string      `yaml:"commit_message,omitempty"`
+	CommitStrategy string      `yaml:"commit_strategy,omitempty"` // push (default), pull_request
+	Branch         string      `yaml:"branch,omitempty"`          // branch name for pull_request strategy
 }
 
 // FileSet represents a set of files to distribute to target repositories.
@@ -261,12 +261,12 @@ type FileSetMetadata struct {
 }
 
 type FileSetSpec struct {
-	Repositories  []FileSetRepository `yaml:"repositories"`
-	Files         []FileEntry         `yaml:"files"`
-	OnDrift       string              `yaml:"on_drift,omitempty"`       // warn (default), overwrite, skip
-	CommitMessage string              `yaml:"commit_message,omitempty"` // custom commit message
-	Strategy      string              `yaml:"strategy,omitempty"`       // direct (default), pull_request
-	Branch        string              `yaml:"branch,omitempty"`         // branch name for pull_request strategy
+	Repositories   []FileSetRepository `yaml:"repositories"`
+	Files          []FileEntry         `yaml:"files"`
+	OnDrift        string              `yaml:"on_drift,omitempty"`        // warn (default), overwrite, skip
+	CommitMessage  string              `yaml:"commit_message,omitempty"`  // custom commit message
+	CommitStrategy string              `yaml:"commit_strategy,omitempty"` // push (default), pull_request
+	Branch         string              `yaml:"branch,omitempty"`          // branch name for pull_request strategy
 }
 
 // FileSetRepository can be a simple string "repo" or a struct with overrides.

--- a/internal/manifest/validation.go
+++ b/internal/manifest/validation.go
@@ -156,9 +156,9 @@ func (f *File) Validate() error {
 			return fmt.Errorf("File %q: %w", f.Metadata.FullName(), err)
 		}
 	}
-	if f.Spec.Strategy != "" {
-		if err := validateOneOf("strategy", f.Spec.Strategy,
-			StrategyDirect, StrategyPullRequest); err != nil {
+	if f.Spec.CommitStrategy != "" {
+		if err := validateOneOf("commit_strategy", f.Spec.CommitStrategy,
+			CommitStrategyPush, CommitStrategyPullRequest); err != nil {
 			return fmt.Errorf("File %q: %w", f.Metadata.FullName(), err)
 		}
 	}
@@ -191,11 +191,11 @@ func (fs *FileSet) Validate() error {
 		OnDriftWarn, OnDriftOverwrite, OnDriftSkip); err != nil {
 		return fmt.Errorf("FileSet %q: %w", fs.Metadata.Owner, err)
 	}
-	if fs.Spec.Strategy == "" {
-		fs.Spec.Strategy = StrategyDirect
+	if fs.Spec.CommitStrategy == "" {
+		fs.Spec.CommitStrategy = CommitStrategyPush
 	}
-	if err := validateOneOf("strategy", fs.Spec.Strategy,
-		StrategyDirect, StrategyPullRequest); err != nil {
+	if err := validateOneOf("commit_strategy", fs.Spec.CommitStrategy,
+		CommitStrategyPush, CommitStrategyPullRequest); err != nil {
 		return fmt.Errorf("FileSet %q: %w", fs.Metadata.Owner, err)
 	}
 	for i, f := range fs.Spec.Files {

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -10,7 +10,7 @@ import (
 
 // DiffOptions controls diff behavior.
 type DiffOptions struct {
-	ForceSecrets bool              // Always re-set existing secrets
+	ForceSecrets bool               // Always re-set existing secrets
 	Resolver     *manifest.Resolver // Name resolver for rulesets (optional; nil = skip resolution)
 }
 

--- a/internal/repository/diff_types.go
+++ b/internal/repository/diff_types.go
@@ -14,9 +14,9 @@ const (
 // Change represents a single field-level change.
 type Change struct {
 	Type     ChangeType
-	Resource string   // "Repository", "BranchProtection", "Secret", "Variable"
-	Name     string   // "babarot/my-project"
-	Field    string   // "description", "topics", etc.
+	Resource string // "Repository", "BranchProtection", "Secret", "Variable"
+	Name     string // "babarot/my-project"
+	Field    string // "description", "topics", etc.
 	OldValue any
 	NewValue any
 	Children []Change // Sub-field details for hierarchical display

--- a/internal/repository/orchestrate.go
+++ b/internal/repository/orchestrate.go
@@ -73,7 +73,7 @@ func FetchAllChanges(repos []*manifest.Repository, filterRepo string, fetcher *F
 
 			changes := Diff(r, current, diffOpts...)
 			logger.Debug("diff done", "repo", r.Metadata.FullName(), "changes", len(changes))
-			tracker.Done("Fetching "+r.Metadata.FullName())
+			tracker.Done("Fetching " + r.Metadata.FullName())
 			results[idx] = repoResult{index: idx, repo: r, changes: changes}
 		}(i, repo)
 	}

--- a/internal/ui/refresh.go
+++ b/internal/ui/refresh.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"sync"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/term"
 )


### PR DESCRIPTION
## Summary
Rename the FileSet/File YAML field `strategy` to `commit_strategy` and its value `direct` to `push` for clearer semantics. This prepares for the upcoming `sync_mode` field which controls a different axis (what to sync vs how to commit).

## Background
The field `strategy` was ambiguous — it could mean sync strategy, merge strategy, or commit strategy. With the upcoming `sync_mode: patch | mirror` feature, having two similarly named fields (`strategy` and `sync_mode`) would be confusing. Renaming to `commit_strategy` makes the intent explicit: it controls **how** changes are delivered (push directly vs open a pull request). Renaming `direct` to `push` makes it a natural counterpart to `pull_request`.

## Changes
- **`internal/manifest/types.go`**: Rename `Strategy` field to `CommitStrategy` in `FileSpec` and `FileSetSpec`. Rename constants `StrategyDirect`/`StrategyPullRequest` to `CommitStrategyPush`/`CommitStrategyPullRequest`.
- **`internal/manifest/validation.go`**: Update all references to new field and constant names.
- **`internal/manifest/parser.go`**: Update File→FileSet expansion.
- **`internal/fileset/fileset.go`**: Rename `ApplyOptions.Strategy` to `CommitStrategy`.
- **`cmd/apply.go`**: Update `ApplyOptions` construction.
- **Docs**: Update `file/strategy.md` (title → "Commit Strategy"), `file/index.md`, `fileset/index.md`.
- **Examples**: Update `fileset.yaml`.
- **Tests**: Update YAML fixtures and assertions.