### PR TITLE
Add sync_mode: mirror for directory-level file sync

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -118,7 +118,7 @@ func runApply(path, filterRepo string, autoApprove, forceSecrets, failOnUnknown 
 
 	// Print unified plan
 	repoCreates, repoUpdates, repoDeletes := repository.CountChanges(repoChanges)
-	fileCreates, fileUpdates, fileDrifts := fileset.CountChanges(fileChanges)
+	fileCreates, fileUpdates, fileDeletes, fileDrifts := fileset.CountChanges(fileChanges)
 
 	p.Separator()
 
@@ -126,10 +126,11 @@ func runApply(path, filterRepo string, autoApprove, forceSecrets, failOnUnknown 
 
 	creates := repoCreates + fileCreates
 	updates := repoUpdates + fileUpdates
+	deletes := repoDeletes + fileDeletes
 	parts := []string{
 		fmt.Sprintf("%s to create", ui.Bold.Render(fmt.Sprintf("%d", creates))),
 		fmt.Sprintf("%s to update", ui.Bold.Render(fmt.Sprintf("%d", updates))),
-		fmt.Sprintf("%s to destroy", ui.Bold.Render(fmt.Sprintf("%d", repoDeletes))),
+		fmt.Sprintf("%s to destroy", ui.Bold.Render(fmt.Sprintf("%d", deletes))),
 	}
 	if fileDrifts > 0 {
 		parts = append(parts, fmt.Sprintf("%s drifted", ui.Bold.Render(fmt.Sprintf("%d", fileDrifts))))

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -119,6 +119,8 @@ func printUnifiedPlan(p ui.Printer, repoChanges []repository.Change, fileChanges
 					p.FileCreate(c.Path)
 				case fileset.FileUpdate:
 					p.FileUpdate(c.Path)
+				case fileset.FileDelete:
+					p.FileDelete(c.Path)
 				case fileset.FileDrift:
 					p.FileDrift(c.Path, c.OnDrift)
 				case fileset.FileSkip:

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -116,7 +116,7 @@ func runPlan(path, filterRepo string, ci, failOnUnknown bool) error {
 	}
 
 	repoCreates, repoUpdates, repoDeletes := repository.CountChanges(repoChanges)
-	fileCreates, fileUpdates, fileDrifts := fileset.CountChanges(fileChanges)
+	fileCreates, fileUpdates, fileDeletes, fileDrifts := fileset.CountChanges(fileChanges)
 
 	p.Separator()
 
@@ -124,10 +124,11 @@ func runPlan(path, filterRepo string, ci, failOnUnknown bool) error {
 
 	creates := repoCreates + fileCreates
 	updates := repoUpdates + fileUpdates
+	deletes := repoDeletes + fileDeletes
 	parts := []string{
 		fmt.Sprintf("%s to create", ui.Bold.Render(fmt.Sprintf("%d", creates))),
 		fmt.Sprintf("%s to update", ui.Bold.Render(fmt.Sprintf("%d", updates))),
-		fmt.Sprintf("%s to destroy", ui.Bold.Render(fmt.Sprintf("%d", repoDeletes))),
+		fmt.Sprintf("%s to destroy", ui.Bold.Render(fmt.Sprintf("%d", deletes))),
 	}
 	if fileDrifts > 0 {
 		parts = append(parts, fmt.Sprintf("%s drifted", ui.Bold.Render(fmt.Sprintf("%d", fileDrifts))))

--- a/docs/src/content/docs/resources/file/drift.md
+++ b/docs/src/content/docs/resources/file/drift.md
@@ -42,3 +42,34 @@ Use this when you've intentionally allowed a repo to diverge and don't want nois
 | `warn` | Shows drift warning | Skips the file |
 | `overwrite` | Shows diff | Overwrites with declared content |
 | `skip` | No output | No action |
+
+## Interaction with `sync_mode: mirror`
+
+`on_drift` and `sync_mode: mirror` cannot be used together. If any file entry has `sync_mode: mirror`, specifying `on_drift` explicitly is a validation error:
+
+```yaml
+# ✗ Error: on_drift cannot be set when sync_mode "mirror" is used
+spec:
+  on_drift: warn
+  files:
+    - path: .github/workflows
+      source: ./templates/workflows/
+      sync_mode: mirror
+```
+
+This is because mirror means "make the directory exactly match the source" — content drift is always resolved by overwriting, which contradicts `warn` or `skip`.
+
+If you omit `on_drift` (let it default), mirror files silently use `overwrite` while non-mirror files use the default `warn`:
+
+```yaml
+# ✓ Valid: on_drift not specified, defaults apply
+spec:
+  files:
+    - path: .github/workflows
+      source: ./templates/workflows/
+      sync_mode: mirror    # always overwrites
+
+    - path: LICENSE
+      source: ./templates/LICENSE
+      # uses default on_drift: warn
+```

--- a/docs/src/content/docs/resources/file/index.md
+++ b/docs/src/content/docs/resources/file/index.md
@@ -57,8 +57,9 @@ The combination of `owner` and `name` identifies the target repository (`babarot
 | Field | Default | Description |
 |---|---|---|
 | `files` | *(required)* | List of files to manage — see [File Sources](./sources/) |
+| `files[].sync_mode` | `patch` | Per-entry sync mode: `patch` (add/update) or `mirror` (add/update/delete) — see [Sync Mode](./sync-mode/) |
 | `on_drift` | `warn` | Drift handling: `warn`, `overwrite`, or `skip` — see [Drift Handling](./drift/) |
-| `strategy` | `direct` | Apply method: `direct` or `pull_request` — see [Apply Strategy](./strategy/) |
+| `commit_strategy` | `push` | Commit method: `push` or `pull_request` — see [Commit Strategy](./strategy/) |
 | `commit_message` | auto | Custom commit message |
 | `branch` | auto | Branch name for `pull_request` strategy |
 

--- a/docs/src/content/docs/resources/file/sources.md
+++ b/docs/src/content/docs/resources/file/sources.md
@@ -51,6 +51,17 @@ files:
 
 For example, if `./templates/workflows/` contains `ci.yaml` and `release.yaml`, this creates `.github/workflows/ci.yaml` and `.github/workflows/release.yaml` in the target repo.
 
+Add `sync_mode: mirror` to delete files in the target directory that don't exist in the source:
+
+```yaml
+files:
+  - path: .github/workflows
+    source: ./templates/workflows/
+    sync_mode: mirror
+```
+
+See [Sync Mode](../sync-mode/) for details.
+
 ## GitHub Repository
 
 Pull files directly from another GitHub repository using the `github://` scheme. This is useful when a central "shared-config" repo holds your templates — no need to clone it locally.
@@ -95,6 +106,8 @@ workflows/
 ```
 
 This creates `.github/workflows/ci.yaml`, `.github/workflows/release.yaml`, and `.github/workflows/checks/lint.yaml` in the target repo.
+
+Like local directories, `sync_mode: mirror` works with GitHub directory sources to delete orphan files. See [Sync Mode](../sync-mode/).
 
 ### Pinning to a version
 

--- a/docs/src/content/docs/resources/file/sync-mode.mdx
+++ b/docs/src/content/docs/resources/file/sync-mode.mdx
@@ -1,0 +1,78 @@
+---
+title: Sync Mode
+sidebar:
+  order: 5
+---
+
+import { FileTree } from '@astrojs/starlight/components';
+
+The sync mode controls **what happens to files in the target repository that are not declared in your manifest**.
+
+## `patch` (default)
+
+Only adds and updates files. Extra files in the target directory are left untouched.
+
+```yaml
+files:
+  - path: .github/workflows
+    source: ./templates/workflows/
+    # sync_mode: patch (default — extra files are ignored)
+```
+
+## `mirror`
+
+Makes the target directory an exact mirror of the source. Files not in the source are **deleted** from the target repository.
+
+```yaml
+files:
+  - path: .github/workflows
+    source: ./templates/workflows/
+    sync_mode: mirror
+```
+
+### Example
+
+Source (`./templates/workflows/`) contains two files. Target repo has an additional `repo-dedicated.yml` that is not in the source:
+
+<FileTree>
+- ./templates/workflows/ (source)
+  - ci.yml
+  - release.yml
+</FileTree>
+
+<FileTree>
+- .github/workflows/ (target repo after apply)
+  - ci.yml ← updated
+  - release.yml ← updated
+  - **repo-dedicated.yml** ← **deleted**
+</FileTree>
+
+### Mirror and `on_drift`
+
+`sync_mode: mirror` always overwrites content differences. If you explicitly set `on_drift` while any file uses mirror, gh-infra returns a validation error — the two settings contradict each other.
+
+If you omit `on_drift`, mirror files silently use overwrite while non-mirror files use the default (`warn`). See [Drift Handling](../drift/#interaction-with-sync_mode-mirror) for details.
+
+### Scope
+
+Mirror only affects the directory specified by `path`. Files outside that directory are never touched.
+
+```yaml
+files:
+  - path: .github/workflows
+    source: ./templates/workflows/
+    sync_mode: mirror    # only deletes from .github/workflows/
+
+  - path: README.md
+    content: "# My Project"
+    # README.md is never affected by the mirror above
+```
+
+## When to use mirror
+
+| Scenario | Recommended |
+|----------|-------------|
+| CI workflows that must be identical across repos | `mirror` |
+| Shared config files where repos may add extras | `patch` |
+| Security policies (CODEOWNERS, SECURITY.md) | `patch` |
+| Template directories that should be fully controlled | `mirror` |

--- a/docs/src/content/docs/resources/fileset/index.md
+++ b/docs/src/content/docs/resources/fileset/index.md
@@ -54,12 +54,13 @@ All repositories in the set belong to this owner. Individual repo names are list
 
 ## Shared Features
 
-All settings available in [File](../file/) — file sources, templating, drift handling, and apply strategies — work identically in `FileSet`. See the File documentation for details:
+All settings available in [File](../file/) — file sources, templating, drift handling, sync modes, and commit strategies — work identically in `FileSet`. See the File documentation for details:
 
 - [File Sources](../file/sources/) — Inline content, local files, directories, and `github://` references
 - [Templating](../file/templating/) — `<% %>` syntax, built-in variables, custom vars
+- [Sync Mode](../file/sync-mode/) — `patch` (add/update) vs `mirror` (add/update/delete orphans)
 - [Drift Handling](../file/drift/) — `warn`, `overwrite`, and `skip` behaviors
-- [Apply Strategy](../file/strategy/) — `direct` vs `pull_request`
+- [Commit Strategy](../file/strategy/) — `push` vs `pull_request`
 
 ## When to Use FileSet
 

--- a/internal/fileset/fileset.go
+++ b/internal/fileset/fileset.go
@@ -41,6 +41,7 @@ type ChangeType string
 const (
 	FileCreate ChangeType = "create"
 	FileUpdate ChangeType = "update"
+	FileDelete ChangeType = "delete"
 	FileNoOp   ChangeType = "noop"
 	FileDrift  ChangeType = "drift"
 	FileSkip   ChangeType = "skip"
@@ -136,9 +137,43 @@ func (p *Processor) Plan(fileSets []*manifest.FileSet, tracker *ui.RefreshTracke
 					}
 					file.Content = rendered
 				}
-				change := p.planFile(u.fileSetName, fullName, file, u.onDrift)
+				// Mirror mode forces overwrite (mirror = complete sync)
+				drift := u.onDrift
+				if file.SyncMode == manifest.SyncModeMirror {
+					drift = manifest.OnDriftOverwrite
+				}
+				change := p.planFile(u.fileSetName, fullName, file, drift)
 				out = append(out, change)
 			}
+			// Mirror mode: detect orphaned files in target repo
+			allPlannedPaths := make(map[string]bool)
+			for _, change := range out {
+				allPlannedPaths[change.Path] = true
+			}
+			mirrorDirs := make(map[string]bool)
+			for _, file := range u.files {
+				if file.SyncMode == manifest.SyncModeMirror && file.DirScope != "" {
+					mirrorDirs[file.DirScope] = true
+				}
+			}
+			for dirScope := range mirrorDirs {
+				repoFiles, err := p.fetchDirectoryContents(fullName, dirScope)
+				if err != nil {
+					// Directory doesn't exist in repo yet — nothing to delete
+					continue
+				}
+				for _, repoFile := range repoFiles {
+					if !allPlannedPaths[repoFile] {
+						out = append(out, FileChange{
+							Type:    FileDelete,
+							Target:  fullName,
+							Path:    repoFile,
+							FileSet: u.fileSetName,
+						})
+					}
+				}
+			}
+
 			results[i] = unitResult{changes: out}
 			tracker.Done(displayName)
 		}(i, u)
@@ -256,6 +291,36 @@ func (p *Processor) fetchFileContent(repo, path string) (*FileState, error) {
 	}, nil
 }
 
+// fetchDirectoryContents returns all file paths under a directory in a repo (recursively).
+func (p *Processor) fetchDirectoryContents(repo, dirPath string) ([]string, error) {
+	out, err := p.runner.Run("api", fmt.Sprintf("repos/%s/contents/%s", repo, dirPath))
+	if err != nil {
+		return nil, err
+	}
+
+	var items []struct {
+		Path string `json:"path"`
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(out, &items); err != nil {
+		return nil, err
+	}
+
+	var files []string
+	for _, item := range items {
+		if item.Type == "file" {
+			files = append(files, item.Path)
+		} else if item.Type == "dir" {
+			subFiles, err := p.fetchDirectoryContents(repo, item.Path)
+			if err != nil {
+				continue
+			}
+			files = append(files, subFiles...)
+		}
+	}
+	return files, nil
+}
+
 // ApplyOptions configures apply behavior from FileSet spec.
 type ApplyOptions struct {
 	CommitMessage  string
@@ -308,7 +373,7 @@ func (p *Processor) Apply(changes []FileChange, opts ApplyOptions) []FileApplyRe
 			var filesToApply []FileChange
 			for _, c := range repoChanges {
 				switch c.Type {
-				case FileCreate, FileUpdate:
+				case FileCreate, FileUpdate, FileDelete:
 					filesToApply = append(filesToApply, c)
 				case FileDrift:
 					results = append(results, FileApplyResult{Change: c, Skipped: true})
@@ -363,11 +428,12 @@ func groupChangesByTarget(changes []FileChange) map[string][]FileChange {
 }
 
 // treeEntry represents a file entry in a Git tree.
+// SHA is a pointer: non-nil for create/update, nil for delete (GitHub removes the file).
 type treeEntry struct {
-	Path string `json:"path"`
-	Mode string `json:"mode"`
-	Type string `json:"type"`
-	SHA  string `json:"sha"`
+	Path string  `json:"path"`
+	Mode string  `json:"mode"`
+	Type string  `json:"type"`
+	SHA  *string `json:"sha"` // nil = delete file from tree
 }
 
 // applyToRepo creates a single commit with all file changes using Git Data API.
@@ -423,18 +489,29 @@ func (p *Processor) applyViaGitDataAPI(repo, branch, headSHA string, changes []F
 }
 
 // createBlobs creates a Git blob for each file change and returns tree entries.
+// FileDelete entries get a nil SHA which tells the Git Data API to remove the file.
 func (p *Processor) createBlobs(repo string, changes []FileChange) ([]treeEntry, error) {
 	var entries []treeEntry
 	for _, c := range changes {
+		if c.Type == FileDelete {
+			entries = append(entries, treeEntry{
+				Path: c.Path,
+				Mode: "100644",
+				Type: "blob",
+				SHA:  nil, // nil SHA = delete from tree
+			})
+			continue
+		}
 		blobSHA, err := p.createBlob(repo, c.Desired)
 		if err != nil {
 			return nil, fmt.Errorf("create blob for %s: %w", c.Path, err)
 		}
+		sha := blobSHA
 		entries = append(entries, treeEntry{
 			Path: c.Path,
 			Mode: "100644",
 			Type: "blob",
-			SHA:  blobSHA,
+			SHA:  &sha,
 		})
 	}
 	return entries, nil
@@ -691,6 +768,8 @@ func PrintPlan(p ui.Printer, changes []FileChange) {
 				p.FileCreate(c.Path)
 			case FileUpdate:
 				p.FileUpdate(c.Path)
+			case FileDelete:
+				p.FileDelete(c.Path)
 			case FileDrift:
 				p.FileDrift(c.Path, c.OnDrift)
 			case FileSkip:
@@ -726,14 +805,16 @@ func HasChanges(changes []FileChange) bool {
 	return false
 }
 
-// CountChanges returns create, update, drift counts.
-func CountChanges(changes []FileChange) (creates, updates, drifts int) {
+// CountChanges returns create, update, delete, drift counts.
+func CountChanges(changes []FileChange) (creates, updates, deletes, drifts int) {
 	for _, c := range changes {
 		switch c.Type {
 		case FileCreate:
 			creates++
 		case FileUpdate:
 			updates++
+		case FileDelete:
+			deletes++
 		case FileDrift:
 			drifts++
 		}

--- a/internal/fileset/fileset_test.go
+++ b/internal/fileset/fileset_test.go
@@ -410,7 +410,7 @@ func TestCountChanges(t *testing.T) {
 		{Type: FileSkip},
 	}
 
-	creates, updates, drifts := CountChanges(changes)
+	creates, updates, _, drifts := CountChanges(changes)
 
 	if creates != 2 {
 		t.Errorf("creates: got %d, want 2", creates)
@@ -590,5 +590,171 @@ func TestPrintSummary_AllSuccess(t *testing.T) {
 	}
 	if strings.Contains(output, "skipped") {
 		t.Errorf("should not contain 'skipped', got:\n%s", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mirror mode tests
+// ---------------------------------------------------------------------------
+
+// dirContentsJSON builds a GitHub Contents API JSON response for a directory listing.
+func dirContentsJSON(files []struct{ Path, Type string }) []byte {
+	type item struct {
+		Path string `json:"path"`
+		Type string `json:"type"`
+	}
+	var items []item
+	for _, f := range files {
+		items = append(items, item{Path: f.Path, Type: f.Type})
+	}
+	b, _ := json.Marshal(items)
+	return b
+}
+
+func TestPlan_MirrorDetectsOrphans(t *testing.T) {
+	// file1.yml is declared in YAML, file2.yml is NOT → file2.yml should be FileDelete
+	dirFiles := []struct{ Path, Type string }{
+		{Path: "config/file1.yml", Type: "file"},
+		{Path: "config/file2.yml", Type: "file"},
+	}
+
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			// file1.yml exists in repo with same content → NoOp
+			contentsKey("owner/repo", "config/file1.yml"): contentsJSON("content1", "sha1"),
+			// directory listing for mirror orphan detection
+			contentsKey("owner/repo", "config"): dirContentsJSON(dirFiles),
+		},
+		Errors: map[string]error{},
+	}
+	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
+
+	fileSets := []*manifest.FileSet{
+		{
+			Metadata: manifest.FileSetMetadata{Owner: "owner"},
+			Spec: manifest.FileSetSpec{
+				Repositories: []manifest.FileSetRepository{{Name: "repo"}},
+				Files: []manifest.FileEntry{
+					{
+						Path:     "config/file1.yml",
+						Content:  "content1",
+						SyncMode: manifest.SyncModeMirror,
+						DirScope: "config",
+					},
+				},
+			},
+		},
+	}
+
+	changes, err := p.Plan(fileSets, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expect 2 changes: NoOp for file1.yml, Delete for file2.yml
+	if len(changes) != 2 {
+		t.Fatalf("expected 2 changes, got %d: %+v", len(changes), changes)
+	}
+
+	var foundDelete bool
+	for _, c := range changes {
+		if c.Path == "config/file2.yml" && c.Type == FileDelete {
+			foundDelete = true
+		}
+	}
+	if !foundDelete {
+		t.Errorf("expected FileDelete for config/file2.yml, changes: %+v", changes)
+	}
+}
+
+func TestPlan_PatchIgnoresOrphans(t *testing.T) {
+	// Same setup but with patch mode — no deletes should be generated
+	dirFiles := []struct{ Path, Type string }{
+		{Path: "config/file1.yml", Type: "file"},
+		{Path: "config/file2.yml", Type: "file"},
+	}
+
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			contentsKey("owner/repo", "config/file1.yml"): contentsJSON("content1", "sha1"),
+			// directory listing should NOT be called for patch mode, but include it to be safe
+			contentsKey("owner/repo", "config"): dirContentsJSON(dirFiles),
+		},
+		Errors: map[string]error{},
+	}
+	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
+
+	fileSets := []*manifest.FileSet{
+		{
+			Metadata: manifest.FileSetMetadata{Owner: "owner"},
+			Spec: manifest.FileSetSpec{
+				Repositories: []manifest.FileSetRepository{{Name: "repo"}},
+				Files: []manifest.FileEntry{
+					{
+						Path:     "config/file1.yml",
+						Content:  "content1",
+						SyncMode: manifest.SyncModePatch,
+						DirScope: "config",
+					},
+				},
+				OnDrift: "warn",
+			},
+		},
+	}
+
+	changes, err := p.Plan(fileSets, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, c := range changes {
+		if c.Type == FileDelete {
+			t.Errorf("patch mode should not generate FileDelete, got delete for %s", c.Path)
+		}
+	}
+}
+
+func TestCountChanges_WithDeletes(t *testing.T) {
+	changes := []FileChange{
+		{Type: FileCreate},
+		{Type: FileUpdate},
+		{Type: FileDelete},
+		{Type: FileDelete},
+		{Type: FileDrift},
+		{Type: FileNoOp},
+	}
+
+	creates, updates, deletes, drifts := CountChanges(changes)
+
+	if creates != 1 {
+		t.Errorf("creates: got %d, want 1", creates)
+	}
+	if updates != 1 {
+		t.Errorf("updates: got %d, want 1", updates)
+	}
+	if deletes != 2 {
+		t.Errorf("deletes: got %d, want 2", deletes)
+	}
+	if drifts != 1 {
+		t.Errorf("drifts: got %d, want 1", drifts)
+	}
+}
+
+func TestHasChanges_FileDelete(t *testing.T) {
+	changes := []FileChange{
+		{Type: FileNoOp},
+		{Type: FileDelete},
+	}
+	if !HasChanges(changes) {
+		t.Error("expected HasChanges=true when FileDelete is present")
+	}
+}
+
+func TestHasChanges_OnlyDeletes(t *testing.T) {
+	changes := []FileChange{
+		{Type: FileDelete},
+	}
+	if !HasChanges(changes) {
+		t.Error("expected HasChanges=true when only FileDelete changes exist")
 	}
 }

--- a/internal/fileset/resolve.go
+++ b/internal/fileset/resolve.go
@@ -16,9 +16,15 @@ func ResolveFiles(fs *manifest.FileSet, target manifest.FileSetRepository) []man
 	result := make([]manifest.FileEntry, 0, len(fs.Spec.Files))
 	for _, f := range fs.Spec.Files {
 		if override, ok := overrideMap[f.Path]; ok {
-			// Inherit vars from original if override doesn't define its own
+			// Inherit metadata from original if override doesn't define its own
 			if override.Vars == nil && f.Vars != nil {
 				override.Vars = f.Vars
+			}
+			if override.DirScope == "" {
+				override.DirScope = f.DirScope
+			}
+			if override.SyncMode == "" {
+				override.SyncMode = f.SyncMode
 			}
 			result = append(result, override)
 		} else {

--- a/internal/fileset/resolve_test.go
+++ b/internal/fileset/resolve_test.go
@@ -62,3 +62,61 @@ func TestResolveFiles_WithOverrides(t *testing.T) {
 		t.Errorf("result[2].Content = %q, want %q", result[2].Content, "original-c")
 	}
 }
+
+func TestResolveFiles_InheritsDirScopeAndSyncMode(t *testing.T) {
+	fs := &manifest.FileSet{
+		Spec: manifest.FileSetSpec{
+			Files: []manifest.FileEntry{
+				{
+					Path:     "config/a.yml",
+					Content:  "original-a",
+					DirScope: "config",
+					SyncMode: manifest.SyncModeMirror,
+					Vars:     map[string]string{"env": "prod"},
+				},
+				{
+					Path:     "config/b.yml",
+					Content:  "original-b",
+					DirScope: "config",
+					SyncMode: manifest.SyncModeMirror,
+				},
+			},
+		},
+	}
+	target := manifest.FileSetRepository{
+		Name: "repo",
+		Overrides: []manifest.FileEntry{
+			// Override content but don't set DirScope or SyncMode
+			{Path: "config/a.yml", Content: "overridden-a"},
+		},
+	}
+
+	result := ResolveFiles(fs, target)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(result))
+	}
+
+	// Check the overridden entry inherits DirScope and SyncMode
+	if result[0].Content != "overridden-a" {
+		t.Errorf("result[0].Content = %q, want %q", result[0].Content, "overridden-a")
+	}
+	if result[0].DirScope != "config" {
+		t.Errorf("result[0].DirScope = %q, want %q (should inherit from original)", result[0].DirScope, "config")
+	}
+	if result[0].SyncMode != manifest.SyncModeMirror {
+		t.Errorf("result[0].SyncMode = %q, want %q (should inherit from original)", result[0].SyncMode, manifest.SyncModeMirror)
+	}
+	// Vars should also be inherited
+	if result[0].Vars == nil || result[0].Vars["env"] != "prod" {
+		t.Errorf("result[0].Vars should inherit from original, got %v", result[0].Vars)
+	}
+
+	// Non-overridden entry should retain its fields
+	if result[1].DirScope != "config" {
+		t.Errorf("result[1].DirScope = %q, want %q", result[1].DirScope, "config")
+	}
+	if result[1].SyncMode != manifest.SyncModeMirror {
+		t.Errorf("result[1].SyncMode = %q, want %q", result[1].SyncMode, manifest.SyncModeMirror)
+	}
+}

--- a/internal/manifest/source.go
+++ b/internal/manifest/source.go
@@ -36,9 +36,14 @@ func (r *SourceResolver) ResolveFiles(files []FileEntry, yamlDir string) ([]File
 			if err != nil {
 				return nil, fmt.Errorf("resolve %s: %w", entry.Source, err)
 			}
-			// Preserve Vars from the original entry
+			// Preserve metadata from the original entry
+			isDir := len(entries) > 1 || strings.HasSuffix(entry.Source, "/")
 			for i := range entries {
 				entries[i].Vars = entry.Vars
+				entries[i].SyncMode = entry.SyncMode
+				if isDir {
+					entries[i].DirScope = entry.Path
+				}
 			}
 			resolved = append(resolved, entries...)
 		} else {
@@ -46,9 +51,14 @@ func (r *SourceResolver) ResolveFiles(files []FileEntry, yamlDir string) ([]File
 			if err != nil {
 				return nil, fmt.Errorf("resolve %s: %w", entry.Source, err)
 			}
-			// Preserve Vars from the original entry
+			// Preserve metadata from the original entry
+			isDir := len(entries) > 1 || strings.HasSuffix(entry.Source, "/")
 			for i := range entries {
 				entries[i].Vars = entry.Vars
+				entries[i].SyncMode = entry.SyncMode
+				if isDir {
+					entries[i].DirScope = entry.Path
+				}
 			}
 			resolved = append(resolved, entries...)
 		}

--- a/internal/manifest/source_test.go
+++ b/internal/manifest/source_test.go
@@ -445,3 +445,45 @@ func TestResolveFiles(t *testing.T) {
 		}
 	})
 }
+
+func TestResolveFiles_DirScope_LocalDirectory(t *testing.T) {
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "configs")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "a.yml"), []byte("aaa"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "b.yml"), []byte("bbb"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &SourceResolver{}
+
+	files := []FileEntry{
+		{
+			Path:     ".github/workflows",
+			Source:   "configs",
+			SyncMode: SyncModeMirror,
+		},
+	}
+	result, err := r.ResolveFiles(files, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) < 2 {
+		t.Fatalf("expected at least 2 entries, got %d", len(result))
+	}
+
+	// All expanded entries should have DirScope set to the destination path
+	for i, entry := range result {
+		if entry.DirScope != ".github/workflows" {
+			t.Errorf("result[%d].DirScope = %q, want %q", i, entry.DirScope, ".github/workflows")
+		}
+		if entry.SyncMode != SyncModeMirror {
+			t.Errorf("result[%d].SyncMode = %q, want %q", i, entry.SyncMode, SyncModeMirror)
+		}
+	}
+}

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -24,6 +24,10 @@ const (
 	CommitStrategyPush        = "push"
 	CommitStrategyPullRequest = "pull_request"
 
+	// SyncMode values for FileEntry directory sync behavior.
+	SyncModePatch  = "patch"  // default: add/update only
+	SyncModeMirror = "mirror" // add/update + delete orphans
+
 	// Resource type identifiers used in plan changes.
 	ResourceRepository       = "Repository"
 	ResourceBranchProtection = "BranchProtection"
@@ -297,10 +301,12 @@ func (fs *FileSet) RepoFullName(repoName string) string {
 }
 
 type FileEntry struct {
-	Path    string            `yaml:"path"`
-	Content string            `yaml:"content,omitempty"`
-	Source  string            `yaml:"source,omitempty"` // local file path
-	Vars    map[string]string `yaml:"vars,omitempty"`   // template variables
+	Path     string            `yaml:"path"`
+	Content  string            `yaml:"content,omitempty"`
+	Source   string            `yaml:"source,omitempty"`    // local file path
+	Vars     map[string]string `yaml:"vars,omitempty"`      // template variables
+	SyncMode string            `yaml:"sync_mode,omitempty"` // patch (default), mirror
+	DirScope string            `yaml:"-"`                   // internal: directory path for mirror mode
 }
 
 // ParseResult holds all parsed resources from a path.

--- a/internal/manifest/validation.go
+++ b/internal/manifest/validation.go
@@ -150,6 +150,9 @@ func (f *File) Validate() error {
 	if len(f.Spec.Files) == 0 {
 		return fmt.Errorf("File %q: spec.files is required", f.Metadata.FullName())
 	}
+	if err := validateDriftMirrorConflict(f.Spec.OnDrift, f.Spec.Files); err != nil {
+		return fmt.Errorf("File %q: %w", f.Metadata.FullName(), err)
+	}
 	if f.Spec.OnDrift != "" {
 		if err := validateOneOf("on_drift", f.Spec.OnDrift,
 			OnDriftWarn, OnDriftOverwrite, OnDriftSkip); err != nil {
@@ -169,6 +172,11 @@ func (f *File) Validate() error {
 		if fe.Content != "" && fe.Source != "" {
 			return fmt.Errorf("File %q: files[%d] (%s) cannot have both content and source", f.Metadata.FullName(), i, fe.Path)
 		}
+		if fe.SyncMode != "" {
+			if err := validateOneOf("sync_mode", fe.SyncMode, SyncModePatch, SyncModeMirror); err != nil {
+				return fmt.Errorf("File %q: files[%d] (%s): %w", f.Metadata.FullName(), i, fe.Path, err)
+			}
+		}
 	}
 	return nil
 }
@@ -183,6 +191,9 @@ func (fs *FileSet) Validate() error {
 	}
 	if len(fs.Spec.Files) == 0 {
 		return fmt.Errorf("FileSet %q: spec.files is required", fs.Metadata.Owner)
+	}
+	if err := validateDriftMirrorConflict(fs.Spec.OnDrift, fs.Spec.Files); err != nil {
+		return fmt.Errorf("FileSet %q: %w", fs.Metadata.Owner, err)
 	}
 	if fs.Spec.OnDrift == "" {
 		fs.Spec.OnDrift = OnDriftWarn
@@ -205,6 +216,11 @@ func (fs *FileSet) Validate() error {
 		if f.Content != "" && f.Source != "" {
 			return fmt.Errorf("FileSet %q: files[%d] (%s) cannot have both content and source", fs.Metadata.Owner, i, f.Path)
 		}
+		if f.SyncMode != "" {
+			if err := validateOneOf("sync_mode", f.SyncMode, SyncModePatch, SyncModeMirror); err != nil {
+				return fmt.Errorf("FileSet %q: files[%d] (%s): %w", fs.Metadata.Owner, i, f.Path, err)
+			}
+		}
 	}
 	repoNames := make(map[string]bool)
 	for _, r := range fs.Spec.Repositories {
@@ -215,6 +231,21 @@ func (fs *FileSet) Validate() error {
 			return fmt.Errorf("FileSet %q: duplicate repository %q", fs.Metadata.Owner, r.Name)
 		}
 		repoNames[r.Name] = true
+	}
+	return nil
+}
+
+// validateDriftMirrorConflict returns an error if on_drift is explicitly set
+// while any file entry uses sync_mode: mirror. Mirror always overwrites,
+// so an explicit on_drift setting would be contradictory.
+func validateDriftMirrorConflict(onDrift string, files []FileEntry) error {
+	if onDrift == "" {
+		return nil // not explicitly set — no conflict
+	}
+	for _, f := range files {
+		if f.SyncMode == SyncModeMirror {
+			return fmt.Errorf("on_drift cannot be set when sync_mode \"mirror\" is used (mirror always overwrites)")
+		}
 	}
 	return nil
 }

--- a/internal/manifest/validation_test.go
+++ b/internal/manifest/validation_test.go
@@ -565,3 +565,111 @@ func TestValidateOneOf(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func TestValidateDriftMirrorConflict(t *testing.T) {
+	tests := []struct {
+		name    string
+		onDrift string
+		files   []FileEntry
+		wantErr bool
+	}{
+		{
+			name:    "no conflict: on_drift empty",
+			onDrift: "",
+			files:   []FileEntry{{SyncMode: SyncModeMirror}},
+			wantErr: false,
+		},
+		{
+			name:    "no conflict: no mirror files",
+			onDrift: "warn",
+			files:   []FileEntry{{SyncMode: ""}, {SyncMode: SyncModePatch}},
+			wantErr: false,
+		},
+		{
+			name:    "conflict: on_drift warn + mirror",
+			onDrift: "warn",
+			files:   []FileEntry{{SyncMode: SyncModeMirror}},
+			wantErr: true,
+		},
+		{
+			name:    "conflict: on_drift skip + mirror",
+			onDrift: "skip",
+			files:   []FileEntry{{SyncMode: SyncModeMirror}},
+			wantErr: true,
+		},
+		{
+			name:    "conflict: on_drift overwrite + mirror",
+			onDrift: "overwrite",
+			files:   []FileEntry{{SyncMode: SyncModeMirror}},
+			wantErr: true,
+		},
+		{
+			name:    "conflict: mirror among other files",
+			onDrift: "warn",
+			files:   []FileEntry{{SyncMode: ""}, {SyncMode: SyncModeMirror}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDriftMirrorConflict(tt.onDrift, tt.files)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateFileSet_InvalidSyncMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		syncMode string
+		wantErr  string
+	}{
+		{
+			name:     "invalid sync_mode on FileSet",
+			syncMode: "full",
+			wantErr:  "invalid sync_mode",
+		},
+		{
+			name:     "valid sync_mode patch",
+			syncMode: SyncModePatch,
+		},
+		{
+			name:     "valid sync_mode mirror",
+			syncMode: SyncModeMirror,
+		},
+		{
+			name:     "empty sync_mode is valid (defaults to patch)",
+			syncMode: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := &FileSet{
+				Metadata: FileSetMetadata{Owner: "org"},
+				Spec: FileSetSpec{
+					Repositories: []FileSetRepository{{Name: "repo"}},
+					Files:        []FileEntry{{Path: "LICENSE", Content: "MIT", SyncMode: tt.syncMode}},
+				},
+			}
+			err := fs.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/ui/printer.go
+++ b/internal/ui/printer.go
@@ -31,6 +31,7 @@ type Printer interface {
 	SubItemDelete(field string, value any)
 	FileCreate(path string)
 	FileUpdate(path string)
+	FileDelete(path string)
 	FileDrift(path, onDrift string)
 	FileSkip(path string)
 	Success(name, detail string)
@@ -163,6 +164,11 @@ func (p *StandardPrinter) FileCreate(path string) {
 func (p *StandardPrinter) FileUpdate(path string) {
 	fmt.Fprintf(p.out, "          %s %-*s  %s\n",
 		Yellow.Render("~"), p.subItemWidth(), path, Yellow.Render("(content changed)"))
+}
+
+func (p *StandardPrinter) FileDelete(path string) {
+	fmt.Fprintf(p.out, "          %s %-*s  %s\n",
+		Red.Render("-"), p.subItemWidth(), path, Red.Render("(deleted)"))
 }
 
 func (p *StandardPrinter) FileDrift(path, onDrift string) {


### PR DESCRIPTION
## Summary
Add `sync_mode` field to file entries: `patch` (default, add/update only) or `mirror` (add/update + delete orphans). Mirror makes the target directory an exact replica of the source by deleting files not declared in the manifest.

## Background
When using directory sources (e.g., `.github/workflows/`), gh-infra only added and updated files — extra files in the target repo that weren't in the source were left behind. For workflows and other strictly-managed directories, users need full synchronization where files not in the source are removed.

## Changes
**Core implementation:**
- `manifest/types.go` — Add `SyncMode` and `DirScope` fields to `FileEntry`, add `SyncModePatch`/`SyncModeMirror` constants
- `manifest/source.go` — Set `DirScope` and `SyncMode` during directory expansion (local and GitHub sources)
- `fileset/resolve.go` — Inherit `DirScope`/`SyncMode` through overrides
- `fileset/fileset.go` — Add `FileDelete` change type, orphan detection in Plan (compares repo contents against all planned paths), delete via Git tree entries with `SHA: nil`, `fetchDirectoryContents` helper, mirror forces overwrite behavior
- `manifest/validation.go` — `sync_mode` validation, `validateDriftMirrorConflict` (explicit `on_drift` + mirror = error)
- `ui/printer.go` — `FileDelete` method
- `cmd/output.go`, `cmd/plan.go`, `cmd/apply.go` — FileDelete display and counting

**Tests (11 new):**
- Mirror orphan detection, patch ignoring orphans, CountChanges with deletes, HasChanges with FileDelete, DirScope/SyncMode inheritance in overrides, DirScope set during directory expansion, invalid sync_mode validation, drift/mirror conflict validation

**Documentation:**
- `file/sync-mode.mdx` (new) — Full reference with FileTree examples
- `file/drift.md` — Mirror interaction section
- `file/index.md` — sync_mode in spec table
- `fileset/index.md` — Sync Mode in shared features list
- `file/sources.md` — Mirror mention in directory source sections