### PR TITLE
Add interactive diff viewer with on_drift toggle to apply flow

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -139,7 +139,8 @@ func runApply(path, filterRepo string, autoApprove, forceSecrets, failOnUnknown 
 
 	// Confirm
 	if !autoApprove {
-		confirmed, err := p.Confirm("Do you want to apply these changes?")
+		diffEntries := buildDiffEntries(fileChanges)
+		confirmed, err := p.ConfirmWithDiff("Do you want to apply these changes?", diffEntries)
 		if err != nil {
 			return err
 		}
@@ -147,6 +148,8 @@ func runApply(path, filterRepo string, autoApprove, forceSecrets, failOnUnknown 
 			p.Message("Apply cancelled.")
 			return nil
 		}
+		// Apply on_drift overrides from the diff viewer back to fileChanges
+		applyOnDriftOverrides(fileChanges, diffEntries)
 	}
 
 	totalSucceeded := 0
@@ -243,6 +246,64 @@ func runApply(path, filterRepo string, autoApprove, forceSecrets, failOnUnknown 
 	}
 
 	return nil
+}
+
+// applyOnDriftOverrides writes on_drift changes made in the diff viewer back
+// to fileChanges, adjusting Type so that apply handles them correctly.
+func applyOnDriftOverrides(changes []fileset.FileChange, entries []ui.DiffEntry) {
+	overrides := make(map[string]string, len(entries))
+	for _, e := range entries {
+		if e.OnDrift != "" {
+			overrides[e.Path] = e.OnDrift
+		}
+	}
+	for i := range changes {
+		newDrift, ok := overrides[changes[i].Path]
+		if !ok || newDrift == changes[i].OnDrift {
+			continue
+		}
+		changes[i].OnDrift = newDrift
+		// Re-derive Type from the new on_drift value for drifted files
+		if !changes[i].Drifted {
+			continue
+		}
+		switch newDrift {
+		case "overwrite":
+			changes[i].Type = fileset.FileUpdate
+		case "warn":
+			changes[i].Type = fileset.FileDrift
+		case "skip":
+			changes[i].Type = fileset.FileSkip
+		}
+	}
+}
+
+func buildDiffEntries(changes []fileset.FileChange) []ui.DiffEntry {
+	var entries []ui.DiffEntry
+	for _, c := range changes {
+		var icon string
+		switch c.Type {
+		case fileset.FileCreate:
+			icon = ui.IconAdd
+		case fileset.FileUpdate:
+			icon = ui.IconChange
+		case fileset.FileDelete:
+			icon = ui.IconRemove
+		case fileset.FileDrift:
+			icon = ui.IconWarning
+		default:
+			continue
+		}
+		entries = append(entries, ui.DiffEntry{
+			Path:            c.Path,
+			Icon:            icon,
+			Current:         c.Current,
+			Desired:         c.Desired,
+			OnDrift:         c.OnDrift,
+			OriginalOnDrift: c.OnDrift,
+		})
+	}
+	return entries
 }
 
 func uniqueStrings(s []string) []string {

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/babarot/gh-infra/internal/fileset"
+	"github.com/babarot/gh-infra/internal/ui"
+)
+
+func TestBuildDiffEntries(t *testing.T) {
+	changes := []fileset.FileChange{
+		{Path: "a.txt", Type: fileset.FileCreate, Desired: "new\n", OnDrift: "overwrite"},
+		{Path: "b.txt", Type: fileset.FileUpdate, Current: "old\n", Desired: "new\n", OnDrift: "warn"},
+		{Path: "c.txt", Type: fileset.FileNoOp},
+		{Path: "d.txt", Type: fileset.FileSkip},
+		{Path: "e.txt", Type: fileset.FileDelete, Current: "bye\n", OnDrift: "overwrite"},
+		{Path: "f.txt", Type: fileset.FileDrift, Current: "x\n", Desired: "y\n", OnDrift: "warn"},
+	}
+
+	entries := buildDiffEntries(changes)
+
+	// Should filter out NoOp and Skip
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+
+	// Check icons
+	if entries[0].Icon != ui.IconAdd {
+		t.Errorf("a.txt icon = %q, want %q", entries[0].Icon, ui.IconAdd)
+	}
+	if entries[1].Icon != ui.IconChange {
+		t.Errorf("b.txt icon = %q, want %q", entries[1].Icon, ui.IconChange)
+	}
+	if entries[2].Icon != ui.IconRemove {
+		t.Errorf("e.txt icon = %q, want %q", entries[2].Icon, ui.IconRemove)
+	}
+	if entries[3].Icon != ui.IconWarning {
+		t.Errorf("f.txt icon = %q, want %q", entries[3].Icon, ui.IconWarning)
+	}
+
+	// Check OnDrift passthrough
+	if entries[0].OnDrift != "overwrite" {
+		t.Errorf("a.txt OnDrift = %q, want overwrite", entries[0].OnDrift)
+	}
+
+	// Check Current/Desired passthrough
+	if entries[1].Current != "old\n" || entries[1].Desired != "new\n" {
+		t.Errorf("b.txt Current/Desired mismatch")
+	}
+}
+
+func TestApplyOnDriftOverrides_NoChange(t *testing.T) {
+	changes := []fileset.FileChange{
+		{Path: "a.txt", Type: fileset.FileDrift, OnDrift: "warn", Drifted: true},
+	}
+	entries := []ui.DiffEntry{
+		{Path: "a.txt", OnDrift: "warn"}, // no change
+	}
+
+	applyOnDriftOverrides(changes, entries)
+
+	if changes[0].Type != fileset.FileDrift {
+		t.Errorf("expected FileDrift (unchanged), got %s", changes[0].Type)
+	}
+}
+
+func TestApplyOnDriftOverrides_WarnToOverwrite(t *testing.T) {
+	changes := []fileset.FileChange{
+		{Path: "a.txt", Type: fileset.FileDrift, OnDrift: "warn", Drifted: true},
+	}
+	entries := []ui.DiffEntry{
+		{Path: "a.txt", OnDrift: "overwrite"},
+	}
+
+	applyOnDriftOverrides(changes, entries)
+
+	if changes[0].OnDrift != "overwrite" {
+		t.Errorf("OnDrift = %q, want overwrite", changes[0].OnDrift)
+	}
+	if changes[0].Type != fileset.FileUpdate {
+		t.Errorf("Type = %s, want FileUpdate", changes[0].Type)
+	}
+}
+
+func TestApplyOnDriftOverrides_WarnToSkip(t *testing.T) {
+	changes := []fileset.FileChange{
+		{Path: "a.txt", Type: fileset.FileDrift, OnDrift: "warn", Drifted: true},
+	}
+	entries := []ui.DiffEntry{
+		{Path: "a.txt", OnDrift: "skip"},
+	}
+
+	applyOnDriftOverrides(changes, entries)
+
+	if changes[0].Type != fileset.FileSkip {
+		t.Errorf("Type = %s, want FileSkip", changes[0].Type)
+	}
+}
+
+func TestApplyOnDriftOverrides_OverwriteToWarn(t *testing.T) {
+	changes := []fileset.FileChange{
+		{Path: "a.txt", Type: fileset.FileUpdate, OnDrift: "overwrite", Drifted: true},
+	}
+	entries := []ui.DiffEntry{
+		{Path: "a.txt", OnDrift: "warn"},
+	}
+
+	applyOnDriftOverrides(changes, entries)
+
+	if changes[0].Type != fileset.FileDrift {
+		t.Errorf("Type = %s, want FileDrift", changes[0].Type)
+	}
+}
+
+func TestApplyOnDriftOverrides_NonDriftedIgnored(t *testing.T) {
+	changes := []fileset.FileChange{
+		{Path: "a.txt", Type: fileset.FileCreate, OnDrift: "overwrite", Drifted: false},
+	}
+	entries := []ui.DiffEntry{
+		{Path: "a.txt", OnDrift: "skip"},
+	}
+
+	applyOnDriftOverrides(changes, entries)
+
+	// OnDrift updated but Type should NOT change (not drifted)
+	if changes[0].OnDrift != "skip" {
+		t.Errorf("OnDrift = %q, want skip", changes[0].OnDrift)
+	}
+	if changes[0].Type != fileset.FileCreate {
+		t.Errorf("Type = %s, want FileCreate (non-drifted should keep type)", changes[0].Type)
+	}
+}

--- a/docs/src/content/docs/commands/apply.md
+++ b/docs/src/content/docs/commands/apply.md
@@ -29,6 +29,44 @@ YAML files that are not gh-infra manifests are silently skipped. Use `--fail-on-
 | `--force-secrets` | Re-set all secrets (even existing ones) |
 | `--fail-on-unknown` | Error on YAML files with unknown Kind (default: silently skip) |
 
+## Interactive Diff Viewer
+
+After the plan is displayed, the confirmation prompt offers three options:
+
+```
+> Do you want to apply these changes? (yes / no / diff)
+```
+
+Press `d` to open a full-screen diff viewer before deciding:
+
+| Key | Action |
+|-----|--------|
+| `↑`/`↓` or `j`/`k` | Select file |
+| `Tab` | Cycle `on_drift` (warn → overwrite → skip) |
+| `Shift+Tab` | Cycle `on_drift` backwards |
+| `d`/`u` | Scroll diff pane |
+| `q`/`Esc` | Return to confirmation |
+
+The diff viewer shows different content depending on the `on_drift` setting:
+
+| `on_drift` | Right pane shows |
+|------------|-----------------|
+| `warn` | Unified diff (current → desired) |
+| `overwrite` | Desired content in green |
+| `skip` | Current content (will be kept as-is) |
+
+Changing `on_drift` with `Tab` in the viewer takes effect for that apply run — the YAML file is not modified. This lets you decide per-file whether to apply, skip, or just warn without editing configuration.
+
+When you return to the confirmation prompt, any overrides are shown as a summary:
+
+```
+  on_drift overrides (this run only):
+    .gitignore: warn → overwrite
+    go.mod: warn → skip
+
+> Do you want to apply these changes? (yes / no / diff)
+```
+
 ## Examples
 
 ```bash

--- a/docs/src/content/docs/resources/file/drift.md
+++ b/docs/src/content/docs/resources/file/drift.md
@@ -60,6 +60,18 @@ Use this when you've intentionally allowed a repo to diverge and don't want nois
 | `overwrite` | Shows diff | Overwrites with declared content |
 | `skip` | No output | No action |
 
+## Runtime Override in Diff Viewer
+
+During `gh infra apply`, you can press `d` at the confirmation prompt to open the interactive diff viewer. Inside the viewer, press `Tab` to cycle the `on_drift` setting for the selected file:
+
+```
+warn → overwrite → skip → warn
+```
+
+This override applies only to the current run — the YAML manifest is not modified. Use this to make one-off decisions without changing your configuration. For example, you might normally use `on_drift: warn` but override a specific file to `overwrite` after reviewing the diff.
+
+See [apply command](../../commands/apply/#interactive-diff-viewer) for full keybindings.
+
 ## Interaction with `sync_mode: mirror`
 
 `on_drift` and `sync_mode: mirror` cannot be used on the **same file**. Mirror means "make the directory exactly match the source" — content drift is always resolved by overwriting, so a per-file `on_drift` would be contradictory:

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.20 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/internal/fileset/resolve_test.go
+++ b/internal/fileset/resolve_test.go
@@ -133,7 +133,7 @@ func TestResolveFiles_InheritsOnDrift(t *testing.T) {
 	target := manifest.FileSetRepository{
 		Name: "repo",
 		Overrides: []manifest.FileEntry{
-			{Path: "a.txt", Content: "overridden-a"}, // no OnDrift → inherit
+			{Path: "a.txt", Content: "overridden-a"},                                // no OnDrift → inherit
 			{Path: "b.txt", Content: "overridden-b", OnDrift: manifest.OnDriftWarn}, // explicit → keep
 		},
 	}

--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -1,0 +1,131 @@
+package ui
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/term"
+)
+
+// RunConfirmWithDiff runs a y/n/d confirmation prompt backed by bubbletea.
+// If diffEntries is empty or stdin is not a TTY, falls back to the huh-based Confirm.
+func RunConfirmWithDiff(title string, diffEntries []DiffEntry) (confirmed bool, err error) {
+	if len(diffEntries) == 0 || !term.IsTerminal(os.Stdin.Fd()) {
+		return false, errFallback
+	}
+
+	m := newConfirmDiffModel(title, diffEntries)
+	prog := tea.NewProgram(&m)
+	result, err := prog.Run()
+	if err != nil {
+		return false, err
+	}
+	cm := result.(*confirmDiffModel)
+	return cm.confirmed, nil
+}
+
+// errFallback signals that ConfirmWithDiff should fall back to the plain Confirm.
+var errFallback = fmt.Errorf("fallback")
+
+// ErrFallback returns true if the error signals a fallback to plain Confirm.
+func ErrFallback(err error) bool { return err == errFallback }
+
+// confirmDiffModel is a bubbletea model for the y/n/d confirmation prompt.
+type confirmDiffModel struct {
+	title       string
+	diffEntries []DiffEntry
+	confirmed   bool
+	showDiff    bool
+}
+
+func newConfirmDiffModel(title string, entries []DiffEntry) confirmDiffModel {
+	return confirmDiffModel{title: title, diffEntries: entries}
+}
+
+func (m *confirmDiffModel) Init() tea.Cmd { return nil }
+
+func (m *confirmDiffModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "y", "Y":
+			m.confirmed = true
+			return m, tea.Quit
+		case "n", "N", "esc", "ctrl+c":
+			m.confirmed = false
+			return m, tea.Quit
+		case "d", "D":
+			m.showDiff = true
+			return m, func() tea.Msg { return showDiffMsg{} }
+		}
+	case showDiffMsg:
+		if m.showDiff {
+			m.showDiff = false
+			return m, tea.Exec(
+				newDiffViewerCmd(m.diffEntries),
+				func(err error) tea.Msg { return diffDoneMsg{err: err} },
+			)
+		}
+	case diffDoneMsg:
+		if msg.err != nil {
+			m.confirmed = false
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+// huhIndigo matches the huh Charm theme's title color (#7571F9).
+var huhIndigo = lipgloss.NewStyle().Foreground(lipgloss.Color("#7571F9")).Bold(true)
+
+func (m *confirmDiffModel) View() tea.View {
+	var b strings.Builder
+
+	// Show on_drift overrides if any
+	overrides := DriftOverrides(m.diffEntries)
+	if len(overrides) > 0 {
+		b.WriteString("\n")
+		b.WriteString(Yellow.Render("  on_drift overrides (this run only):") + "\n")
+		for _, o := range overrides {
+			b.WriteString(fmt.Sprintf("    %s: %s → %s\n",
+				o.Path,
+				Dim.Render(o.From),
+				Bold.Render(o.To),
+			))
+		}
+	}
+
+	b.WriteString(fmt.Sprintf("\n%s %s (%s / %s / %s)\n",
+		huhIndigo.Render(">"),
+		huhIndigo.Render(m.title),
+		Green.Render("(y)")+"es",
+		Red.Render("(n)")+"o",
+		Yellow.Render("(d)")+"iff",
+	))
+	return tea.NewView(b.String())
+}
+
+type showDiffMsg struct{}
+type diffDoneMsg struct{ err error }
+
+// diffViewerExecCmd wraps the diff viewer as a tea.ExecCommand so bubbletea
+// handles terminal state transitions (altscreen, raw mode) cleanly.
+type diffViewerExecCmd struct {
+	entries []DiffEntry
+}
+
+func newDiffViewerCmd(entries []DiffEntry) *diffViewerExecCmd {
+	return &diffViewerExecCmd{entries: entries}
+}
+
+func (c *diffViewerExecCmd) Run() error {
+	return RunDiffViewer(c.entries)
+}
+
+func (c *diffViewerExecCmd) SetStdin(_ io.Reader)  {}
+func (c *diffViewerExecCmd) SetStdout(_ io.Writer) {}
+func (c *diffViewerExecCmd) SetStderr(_ io.Writer) {}

--- a/internal/ui/diffviewer.go
+++ b/internal/ui/diffviewer.go
@@ -1,0 +1,422 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+// DiffEntry holds the raw content for one file change.
+// Diff text is generated at render time based on OnDrift.
+type DiffEntry struct {
+	Path            string // file path
+	Icon            string // "+", "~", "-", "⚠"
+	Current         string // current file content
+	Desired         string // desired file content
+	OnDrift         string // current on_drift setting (warn, overwrite, skip); mutable via Tab
+	OriginalOnDrift string // on_drift value before any viewer changes
+}
+
+// DriftOverride describes a single on_drift change made in the diff viewer.
+type DriftOverride struct {
+	Path string
+	From string
+	To   string
+}
+
+// DriftOverrides returns entries where OnDrift was changed from the original.
+func DriftOverrides(entries []DiffEntry) []DriftOverride {
+	var out []DriftOverride
+	for _, e := range entries {
+		if e.OnDrift != e.OriginalOnDrift {
+			out = append(out, DriftOverride{
+				Path: e.Path,
+				From: e.OriginalOnDrift,
+				To:   e.OnDrift,
+			})
+		}
+	}
+	return out
+}
+
+// GenerateDiff produces a unified diff string between current and desired content.
+func GenerateDiff(current, desired, path string) string {
+	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(current),
+		B:        difflib.SplitLines(desired),
+		FromFile: path + " (current)",
+		ToFile:   path + " (desired)",
+		Context:  3,
+	})
+	return diff
+}
+
+// RunDiffViewer launches an interactive full-screen diff viewer.
+func RunDiffViewer(entries []DiffEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	m := newDiffViewModel(entries)
+	p := tea.NewProgram(&m)
+	_, err := p.Run()
+	return err
+}
+
+// --- bubbletea model ---
+
+type diffViewModel struct {
+	entries   []DiffEntry
+	cursor    int // selected file index
+	scrollY   int // scroll offset in diff pane
+	width     int
+	height    int
+	listWidth int
+}
+
+func newDiffViewModel(entries []DiffEntry) diffViewModel {
+	return diffViewModel{
+		entries:   entries,
+		listWidth: 30,
+	}
+}
+
+func (m *diffViewModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m *diffViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.listWidth = m.calcListWidth()
+		m.clampScroll()
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc":
+			return m, tea.Quit
+
+		// file list navigation
+		case "j", "down":
+			if m.cursor < len(m.entries)-1 {
+				m.cursor++
+				m.scrollY = 0
+			}
+		case "k", "up":
+			if m.cursor > 0 {
+				m.cursor--
+				m.scrollY = 0
+			}
+		case "tab":
+			// Cycle on_drift: warn → overwrite → skip → warn
+			e := &m.entries[m.cursor]
+			if e.OnDrift != "" {
+				switch e.OnDrift {
+				case "warn":
+					e.OnDrift = "overwrite"
+				case "overwrite":
+					e.OnDrift = "skip"
+				case "skip":
+					e.OnDrift = "warn"
+				}
+			}
+		case "shift+tab":
+			// Cycle on_drift backwards: warn → skip → overwrite → warn
+			e := &m.entries[m.cursor]
+			if e.OnDrift != "" {
+				switch e.OnDrift {
+				case "warn":
+					e.OnDrift = "skip"
+				case "skip":
+					e.OnDrift = "overwrite"
+				case "overwrite":
+					e.OnDrift = "warn"
+				}
+			}
+
+		// diff scrolling
+		case "d", "pgdown":
+			m.scrollY += m.diffVisibleLines() / 2
+			m.clampScroll()
+		case "u", "pgup":
+			m.scrollY -= m.diffVisibleLines() / 2
+			m.clampScroll()
+		}
+	}
+	return m, nil
+}
+
+func (m *diffViewModel) View() tea.View {
+	if m.width == 0 || m.height == 0 {
+		return tea.NewView("")
+	}
+
+	diffWidth := m.width - m.listWidth - 3 // 3 for separator
+	if diffWidth < 10 {
+		diffWidth = 10
+	}
+	visibleHeight := m.height - 3 // reserve 3 for padding + help line
+
+	// Left pane: file list
+	var listLines []string
+	for i, e := range m.entries {
+		icon := renderDiffIcon(e.Icon)
+		badge := renderOnDriftShort(e.OnDrift)
+		// layout: " ▸ ~ [O] filename" = 4 (prefix) + badge + 1 (space)
+		labelWidth := m.listWidth - 4
+		if badge != "" {
+			labelWidth -= lipgloss.Width(badge) + 1
+		}
+		label := truncate(e.Path, labelWidth)
+		var line string
+		if i == m.cursor {
+			if badge != "" {
+				line = fmt.Sprintf(" ▸ %s %s %s", icon, badge, Bold.Render(label))
+			} else {
+				line = fmt.Sprintf(" ▸ %s %s", icon, Bold.Render(label))
+			}
+		} else {
+			if badge != "" {
+				line = fmt.Sprintf("   %s %s %s", icon, badge, label)
+			} else {
+				line = fmt.Sprintf("   %s %s", icon, label)
+			}
+		}
+		listLines = append(listLines, line)
+	}
+	// Pad to fill height
+	for len(listLines) < visibleHeight {
+		listLines = append(listLines, "")
+	}
+	if len(listLines) > visibleHeight {
+		listLines = listLines[:visibleHeight]
+	}
+
+	// Right pane: content generated from raw data based on on_drift
+	entry := m.entries[m.cursor]
+	diffLines := m.buildRightPane(entry, diffWidth)
+
+	// Apply scroll
+	start := m.scrollY
+	if start > len(diffLines) {
+		start = len(diffLines)
+	}
+	end := start + visibleHeight
+	if end > len(diffLines) {
+		end = len(diffLines)
+	}
+	visible := diffLines[start:end]
+
+	borderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	var coloredLines []string
+	for _, line := range visible {
+		if line == "\x00divider\x00" {
+			coloredLines = append(coloredLines, borderStyle.Render(strings.Repeat("─", diffWidth)))
+			continue
+		}
+		colored := colorDiffLine(line, diffWidth)
+		coloredLines = append(coloredLines, colored)
+	}
+	for len(coloredLines) < visibleHeight {
+		coloredLines = append(coloredLines, "")
+	}
+
+	// Compose panes
+	sep := lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Render("│")
+	var rows []string
+	for i := 0; i < visibleHeight; i++ {
+		left := padRight(listLines[i], m.listWidth)
+		right := padRight(coloredLines[i], diffWidth)
+		rows = append(rows, left+" "+sep+" "+right)
+	}
+
+	// Help line
+	help := Dim.Render("  ↑↓/jk: select  tab: cycle on_drift  d/u: scroll  q: back")
+
+	v := tea.NewView(strings.Join(rows, "\n") + "\n\n" + help)
+	v.AltScreen = true
+	return v
+}
+
+// calcListWidth computes left pane width based on longest file name.
+// Layout per line: " ▸ ~ [O] filename" = 4 (prefix " ▸ ") + icon(1) + " " + badge(3) + " " + filename
+// So overhead = 4 + 1 + 1 + 3 + 1 = 10, plus 2 for right margin.
+func (m *diffViewModel) calcListWidth() int {
+	const overhead = 12 // " ▸ ~ [O] " + 2 margin
+	maxPath := 0
+	for _, e := range m.entries {
+		if len(e.Path) > maxPath {
+			maxPath = len(e.Path)
+		}
+	}
+	lw := maxPath + overhead
+	// Ensure at least half the terminal is available for the diff pane
+	maxAllowed := m.width / 2
+	if lw > maxAllowed {
+		lw = maxAllowed
+	}
+	if lw < 20 {
+		lw = 20
+	}
+	return lw
+}
+
+func (m *diffViewModel) diffVisibleLines() int {
+	h := m.height - 2
+	if h < 1 {
+		return 1
+	}
+	return h
+}
+
+// buildRightPane generates the lines for the right pane based on on_drift.
+func (m *diffViewModel) buildRightPane(entry DiffEntry, width int) []string {
+	var header []string
+	if entry.OnDrift != "" {
+		header = []string{
+			fmt.Sprintf("on_drift: %s", renderOnDriftFull(entry.OnDrift)),
+			"",
+		}
+	}
+
+	const dividerMarker = "\x00divider\x00" // sentinel, rendered in View
+
+	switch entry.OnDrift {
+	case "skip":
+		body := []string{Dim.Render("Current content (will be kept as-is):"), dividerMarker, ""}
+		if entry.Current != "" {
+			body = append(body, strings.Split(strings.TrimRight(entry.Current, "\n"), "\n")...)
+		} else {
+			body = append(body, Dim.Render("(empty)"))
+		}
+		return append(header, body...)
+
+	case "warn":
+		body := []string{Dim.Render("Drift detected (will warn but skip apply):"), dividerMarker, ""}
+		diff := GenerateDiff(entry.Current, entry.Desired, entry.Path)
+		raw := strings.Split(diff, "\n")
+		if len(raw) > 0 && raw[len(raw)-1] == "" {
+			raw = raw[:len(raw)-1]
+		}
+		return append(header, append(body, raw...)...)
+
+	case "overwrite":
+		body := []string{Dim.Render("Desired content (will overwrite):"), dividerMarker, ""}
+		if entry.Desired != "" {
+			for _, line := range strings.Split(strings.TrimRight(entry.Desired, "\n"), "\n") {
+				body = append(body, Green.Render(line))
+			}
+		} else {
+			body = append(body, Dim.Render("(empty)"))
+		}
+		return append(header, body...)
+
+	default:
+		diff := GenerateDiff(entry.Current, entry.Desired, entry.Path)
+		raw := strings.Split(diff, "\n")
+		if len(raw) > 0 && raw[len(raw)-1] == "" {
+			raw = raw[:len(raw)-1]
+		}
+		return append(header, raw...)
+	}
+}
+
+func (m *diffViewModel) clampScroll() {
+	entry := m.entries[m.cursor]
+	diffWidth := m.width - m.listWidth - 3
+	if diffWidth < 10 {
+		diffWidth = 10
+	}
+	lines := m.buildRightPane(entry, diffWidth)
+	total := len(lines)
+	maxScroll := total - m.diffVisibleLines()
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if m.scrollY > maxScroll {
+		m.scrollY = maxScroll
+	}
+	if m.scrollY < 0 {
+		m.scrollY = 0
+	}
+}
+
+func renderOnDriftShort(onDrift string) string {
+	switch onDrift {
+	case "warn":
+		return Yellow.Render("[W]")
+	case "overwrite":
+		return Green.Render("[O]")
+	case "skip":
+		return Dim.Render("[S]")
+	default:
+		return ""
+	}
+}
+
+func renderOnDriftFull(onDrift string) string {
+	switch onDrift {
+	case "warn":
+		return Yellow.Render("warn")
+	case "overwrite":
+		return Green.Render("overwrite")
+	case "skip":
+		return Dim.Render("skip")
+	default:
+		return onDrift
+	}
+}
+
+func renderDiffIcon(icon string) string {
+	switch icon {
+	case "+":
+		return Green.Render(icon)
+	case "~":
+		return Yellow.Render(icon)
+	case "-":
+		return Red.Render(icon)
+	case "⚠":
+		return Yellow.Render(icon)
+	default:
+		return icon
+	}
+}
+
+func colorDiffLine(line string, maxWidth int) string {
+	display := truncate(line, maxWidth)
+	if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
+		return Green.Render(display)
+	}
+	if strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---") {
+		return Red.Render(display)
+	}
+	if strings.HasPrefix(line, "@@") {
+		return Cyan.Render(display)
+	}
+	if strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++") {
+		return Bold.Render(display)
+	}
+	return display
+}
+
+func truncate(s string, maxWidth int) string {
+	if len(s) <= maxWidth {
+		return s
+	}
+	if maxWidth <= 3 {
+		return s[:maxWidth]
+	}
+	return s[:maxWidth-3] + "..."
+}
+
+func padRight(s string, width int) string {
+	visible := lipgloss.Width(s)
+	if visible >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-visible)
+}

--- a/internal/ui/diffviewer_test.go
+++ b/internal/ui/diffviewer_test.go
@@ -1,0 +1,155 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateDiff_Update(t *testing.T) {
+	current := "line1\nline2\n"
+	desired := "line1\nline2\nline3\n"
+	diff := GenerateDiff(current, desired, "test.txt")
+
+	if !strings.Contains(diff, "+line3") {
+		t.Errorf("expected +line3 in diff, got:\n%s", diff)
+	}
+	if !strings.Contains(diff, "test.txt (current)") {
+		t.Errorf("expected 'test.txt (current)' header in diff")
+	}
+}
+
+func TestGenerateDiff_Create(t *testing.T) {
+	diff := GenerateDiff("", "new content\n", "new.txt")
+	if !strings.Contains(diff, "+new content") {
+		t.Errorf("expected +new content in diff, got:\n%s", diff)
+	}
+}
+
+func TestGenerateDiff_Delete(t *testing.T) {
+	diff := GenerateDiff("old content\n", "", "old.txt")
+	if !strings.Contains(diff, "-old content") {
+		t.Errorf("expected -old content in diff, got:\n%s", diff)
+	}
+}
+
+func TestGenerateDiff_NoDiff(t *testing.T) {
+	diff := GenerateDiff("same\n", "same\n", "file.txt")
+	if diff != "" {
+		t.Errorf("expected empty diff for identical content, got:\n%s", diff)
+	}
+}
+
+func TestBuildRightPane_Skip(t *testing.T) {
+	m := &diffViewModel{entries: []DiffEntry{{
+		Path:    "a.txt",
+		Current: "hello\nworld\n",
+		OnDrift: "skip",
+	}}, width: 100, listWidth: 30}
+
+	lines := m.buildRightPane(m.entries[0], 60)
+
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l, "kept as-is") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'kept as-is' description for skip mode")
+	}
+	// Should show current content, not diff
+	hasHello := false
+	for _, l := range lines {
+		if strings.Contains(l, "hello") {
+			hasHello = true
+		}
+	}
+	if !hasHello {
+		t.Error("expected current content 'hello' in skip mode")
+	}
+}
+
+func TestBuildRightPane_Overwrite(t *testing.T) {
+	m := &diffViewModel{entries: []DiffEntry{{
+		Path:    "a.txt",
+		Current: "old\n",
+		Desired: "new\n",
+		OnDrift: "overwrite",
+	}}, width: 100, listWidth: 30}
+
+	lines := m.buildRightPane(m.entries[0], 60)
+
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l, "will overwrite") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'will overwrite' description for overwrite mode")
+	}
+	// Should show desired content (green), not unified diff
+	hasDiffHeader := false
+	for _, l := range lines {
+		if strings.Contains(l, "---") || strings.Contains(l, "@@") {
+			hasDiffHeader = true
+		}
+	}
+	if hasDiffHeader {
+		t.Error("overwrite mode should show desired content, not unified diff")
+	}
+}
+
+func TestBuildRightPane_Warn(t *testing.T) {
+	m := &diffViewModel{entries: []DiffEntry{{
+		Path:    "a.txt",
+		Current: "old\n",
+		Desired: "new\n",
+		OnDrift: "warn",
+	}}, width: 100, listWidth: 30}
+
+	lines := m.buildRightPane(m.entries[0], 60)
+
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l, "warn but skip") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'warn but skip' description for warn mode")
+	}
+	// Should show unified diff
+	hasDiffMarker := false
+	for _, l := range lines {
+		if strings.Contains(l, "@@") || strings.Contains(l, "---") {
+			hasDiffMarker = true
+		}
+	}
+	if !hasDiffMarker {
+		t.Error("warn mode should show unified diff")
+	}
+}
+
+func TestRenderOnDriftShort(t *testing.T) {
+	DisableStyles()
+	defer func() {
+		// Re-initialize would be complex; just check the values
+	}()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"warn", "[W]"},
+		{"overwrite", "[O]"},
+		{"skip", "[S]"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := renderOnDriftShort(tt.input)
+		if got != tt.want {
+			t.Errorf("renderOnDriftShort(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/ui/drain_bsd.go
+++ b/internal/ui/drain_bsd.go
@@ -26,7 +26,8 @@ import (
 // so they leak into the user's shell prompt.
 //
 // This drain approach is borrowed from a community fork:
-//   https://github.com/saltydk/bubbletea/commit/96c1e05
+//
+//	https://github.com/saltydk/bubbletea/commit/96c1e05
 //
 // Related upstream issues (open as of bubbletea v2.0.2, no official fix yet):
 //   - https://github.com/charmbracelet/bubbletea/issues/1590

--- a/internal/ui/drain_linux.go
+++ b/internal/ui/drain_linux.go
@@ -26,7 +26,8 @@ import (
 // so they leak into the user's shell prompt.
 //
 // This drain approach is borrowed from a community fork:
-//   https://github.com/saltydk/bubbletea/commit/96c1e05
+//
+//	https://github.com/saltydk/bubbletea/commit/96c1e05
 //
 // On Linux, uses a poll loop with 200ms timeout to accommodate SSH round-trip
 // latency where terminal responses may arrive in bursts.

--- a/internal/ui/drain_windows.go
+++ b/internal/ui/drain_windows.go
@@ -26,7 +26,8 @@ import (
 // so they leak into the user's shell prompt.
 //
 // This drain approach is borrowed from a community fork:
-//   https://github.com/saltydk/bubbletea/commit/96c1e05
+//
+//	https://github.com/saltydk/bubbletea/commit/96c1e05
 //
 // Related upstream issues (open as of bubbletea v2.0.2, no official fix yet):
 //   - https://github.com/charmbracelet/bubbletea/issues/1590

--- a/internal/ui/printer.go
+++ b/internal/ui/printer.go
@@ -54,6 +54,7 @@ type Printer interface {
 
 	// interaction
 	Confirm(title string) (bool, error)
+	ConfirmWithDiff(title string, diffEntries []DiffEntry) (bool, error)
 
 	// writers
 	OutWriter() io.Writer
@@ -301,6 +302,14 @@ func (p *StandardPrinter) Confirm(title string) (bool, error) {
 		return false, err
 	}
 	return confirm, nil
+}
+
+func (p *StandardPrinter) ConfirmWithDiff(title string, diffEntries []DiffEntry) (bool, error) {
+	confirmed, err := RunConfirmWithDiff(title, diffEntries)
+	if ErrFallback(err) {
+		return p.Confirm(title)
+	}
+	return confirmed, err
 }
 
 // --- Package-level utilities ---


### PR DESCRIPTION
## Summary

Add a full-screen TUI diff viewer to the `gh infra apply` confirmation flow, allowing users to inspect per-file diffs and toggle `on_drift` settings before applying.

<img width="1610" height="1450" alt="CleanShot 2026-03-25 at 02 00 35@2x" src="https://github.com/user-attachments/assets/a8d6bf5b-c26a-4832-aa43-b8cef0f41f13" />

<img width="2554" height="1940" alt="CleanShot 2026-03-25 at 02 00 24@2x" src="https://github.com/user-attachments/assets/9890f9bd-9b61-492c-80a8-d50dfb139aa5" />


## Background

When running `gh infra apply`, the plan output only shows `(content changed)` for file updates — there is no way to see the actual diff before confirming. Users had to blindly trust the plan or manually check files. Additionally, changing `on_drift` per-file required editing YAML and re-running the command, even for one-off decisions.

## Changes

- **Interactive diff viewer** (`internal/ui/diffviewer.go`): Bubbletea-based split-pane TUI with file list (left) and content pane (right). Supports j/k navigation, d/u scrolling, and full altscreen mode.
- **on_drift toggle**: `Tab`/`Shift+Tab` cycles `on_drift` (warn → overwrite → skip) per-file at runtime. Display adapts per mode: unified diff for warn, desired content (green) for overwrite, current content for skip.
- **Confirmation prompt** (`internal/ui/confirm.go`): Bubbletea model replacing raw terminal handling. Shows `(y)es / (n)o / (d)iff` prompt with override summary when returning from diff viewer.
- **Apply integration** (`cmd/apply.go`): `buildDiffEntries` converts `FileChange` → `DiffEntry`, `applyOnDriftOverrides` writes back toggled settings to `fileChanges` before apply.
- **Tests**: `GenerateDiff`, `buildRightPane` mode variants, `buildDiffEntries` filtering, `applyOnDriftOverrides` for all drift transitions.
- **Docs**: Updated `commands/apply.md` (keybindings, display modes, override summary) and `resources/file/drift.md` (runtime override section).
