### PR TITLE
Add sync_mode: create_only for seed files

### DIFF
--- a/docs/src/content/docs/resources/file/drift.md
+++ b/docs/src/content/docs/resources/file/drift.md
@@ -72,6 +72,21 @@ This override applies only to the current run — the YAML manifest is not modif
 
 See [apply command](../../commands/apply/#interactive-diff-viewer) for full keybindings.
 
+## Interaction with `sync_mode: create_only`
+
+`on_drift` does not apply to `create_only` files. Since `create_only` skips the file entirely once it exists, there is no content comparison and therefore no drift. Setting both on the same file is a validation error:
+
+```yaml
+# ✗ Error: on_drift cannot be set on a file with sync_mode "create_only"
+files:
+  - path: VERSION
+    content: "0.1.0"
+    sync_mode: create_only
+    on_drift: warn        # ← validation error
+```
+
+See [Sync Mode](../sync-mode/#create_only) for details.
+
 ## Interaction with `sync_mode: mirror`
 
 `on_drift` and `sync_mode: mirror` cannot be used on the **same file**. Mirror means "make the directory exactly match the source" — content drift is always resolved by overwriting, so a per-file `on_drift` would be contradictory:

--- a/docs/src/content/docs/resources/file/index.md
+++ b/docs/src/content/docs/resources/file/index.md
@@ -61,7 +61,7 @@ The combination of `owner` and `name` identifies the target repository (`babarot
 | Field | Default | Description |
 |---|---|---|
 | `files` | *(required)* | List of files to manage — see [File Sources](./sources/) |
-| `files[].sync_mode` | `patch` | Per-entry sync mode: `patch` (add/update) or `mirror` (add/update/delete) — see [Sync Mode](./sync-mode/) |
+| `files[].sync_mode` | `patch` | Per-entry sync mode: `patch` (add/update), `mirror` (add/update/delete), or `create_only` (create if missing, never update) — see [Sync Mode](./sync-mode/) |
 | `files[].on_drift` | spec-level | Per-entry drift override — see [Drift Handling](./drift/) |
 | `on_drift` | `warn` | Default drift handling: `warn`, `overwrite`, or `skip` — see [Drift Handling](./drift/) |
 | `commit_strategy` | `push` | Commit method: `push` or `pull_request` — see [Commit Strategy](./commit-strategy/) |

--- a/docs/src/content/docs/resources/file/sync-mode.mdx
+++ b/docs/src/content/docs/resources/file/sync-mode.mdx
@@ -68,7 +68,37 @@ files:
     # README.md is never affected by the mirror above
 ```
 
-## When to use mirror
+## `create_only`
+
+Creates the file if it does not exist, but **never updates or deletes** it. Once the file is present in the target repository, gh-infra ignores it completely — no drift detection, no warnings, no overwrites.
+
+```yaml
+files:
+  - path: VERSION
+    content: "0.1.0"
+    sync_mode: create_only
+```
+
+This is useful for seed files that should be initialized once but then managed independently by the repository:
+
+- `VERSION` — set an initial version, let the repo bump it
+- `README.md` — provide a starter template, let the team customize it
+- `.env.example` — seed the file, let developers edit it
+
+### `create_only` and `on_drift`
+
+`sync_mode: create_only` and `on_drift` cannot be used on the **same file**. Since `create_only` never compares content, drift is not a concept that applies:
+
+```yaml
+# ✗ Error: on_drift cannot be set on a file with sync_mode "create_only"
+files:
+  - path: VERSION
+    content: "0.1.0"
+    sync_mode: create_only
+    on_drift: warn        # ← validation error
+```
+
+## When to use each mode
 
 | Scenario | Recommended |
 |----------|-------------|
@@ -76,3 +106,5 @@ files:
 | Shared config files where repos may add extras | `patch` |
 | Security policies (CODEOWNERS, SECURITY.md) | `patch` |
 | Template directories that should be fully controlled | `mirror` |
+| Seed files that repos manage independently after creation | `create_only` |
+| VERSION, README.md starters, .env.example | `create_only` |

--- a/internal/fileset/fileset.go
+++ b/internal/fileset/fileset.go
@@ -153,6 +153,12 @@ func (p *Processor) Plan(fileSets []*manifest.FileSet, filterRepo string, tracke
 				}
 				file.Content = rendered
 			}
+			// create_only: create if missing, skip entirely if exists
+			if file.SyncMode == manifest.SyncModeCreateOnly {
+				change := p.planCreateOnly(u.fileSetName, fullName, file)
+				out = append(out, change)
+				continue
+			}
 			// Resolve drift handling: mirror > file-level > spec-level
 			drift := u.onDrift
 			if file.OnDrift != "" {
@@ -206,6 +212,26 @@ func (p *Processor) Plan(fileSets []*manifest.FileSet, filterRepo string, tracke
 		changes = append(changes, r.changes...)
 	}
 	return changes, nil
+}
+
+// planCreateOnly handles sync_mode: create_only — create if missing, NoOp if exists.
+func (p *Processor) planCreateOnly(fileSetName, repo string, file manifest.FileEntry) FileChange {
+	current, err := p.fetchFileContent(repo, file.Path)
+	if err != nil || !current.Exists {
+		return FileChange{
+			FileSet: fileSetName,
+			Target:  repo,
+			Path:    file.Path,
+			Type:    FileCreate,
+			Desired: file.Content,
+		}
+	}
+	return FileChange{
+		FileSet: fileSetName,
+		Target:  repo,
+		Path:    file.Path,
+		Type:    FileNoOp,
+	}
 }
 
 func (p *Processor) planFile(fileSetName, repo string, file manifest.FileEntry, onDrift string) FileChange {

--- a/internal/fileset/fileset_test.go
+++ b/internal/fileset/fileset_test.go
@@ -183,6 +183,50 @@ func TestPlan_DriftSkip(t *testing.T) {
 	}
 }
 
+func TestPlan_CreateOnly_FileNotExists(t *testing.T) {
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{},
+		Errors: map[string]error{
+			contentsKey("owner/repo", "VERSION"): gh.ErrNotFound,
+		},
+	}
+	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
+	fileSets := makeFileSet("owner", "repo", "warn", []manifest.FileEntry{
+		{Path: "VERSION", Content: "0.1.0", SyncMode: manifest.SyncModeCreateOnly},
+	})
+
+	changes, _ := p.Plan(fileSets, "", nil)
+
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(changes))
+	}
+	if changes[0].Type != FileCreate {
+		t.Errorf("expected FileCreate, got %s", changes[0].Type)
+	}
+}
+
+func TestPlan_CreateOnly_FileExists(t *testing.T) {
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			contentsKey("owner/repo", "VERSION"): contentsJSON("0.2.0", "sha1"),
+		},
+		Errors: map[string]error{},
+	}
+	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
+	fileSets := makeFileSet("owner", "repo", "warn", []manifest.FileEntry{
+		{Path: "VERSION", Content: "0.1.0", SyncMode: manifest.SyncModeCreateOnly},
+	})
+
+	changes, _ := p.Plan(fileSets, "", nil)
+
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(changes))
+	}
+	if changes[0].Type != FileNoOp {
+		t.Errorf("expected FileNoOp (file exists, create_only ignores), got %s", changes[0].Type)
+	}
+}
+
 func TestPlan_FileLevelOnDrift(t *testing.T) {
 	mock := &gh.MockRunner{
 		Responses: map[string][]byte{

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -24,9 +24,10 @@ const (
 	CommitStrategyPush        = "push"
 	CommitStrategyPullRequest = "pull_request"
 
-	// SyncMode values for FileEntry directory sync behavior.
-	SyncModePatch  = "patch"  // default: add/update only
-	SyncModeMirror = "mirror" // add/update + delete orphans
+	// SyncMode values for FileEntry sync behavior.
+	SyncModePatch      = "patch"       // default: add/update only
+	SyncModeMirror     = "mirror"      // add/update + delete orphans
+	SyncModeCreateOnly = "create_only" // create if missing, never update
 
 	// Resource type identifiers used in plan changes.
 	ResourceRepository       = "Repository"

--- a/internal/manifest/validation.go
+++ b/internal/manifest/validation.go
@@ -173,7 +173,7 @@ func (f *File) Validate() error {
 			return fmt.Errorf("File %q: files[%d] (%s) cannot have both content and source", f.Metadata.FullName(), i, fe.Path)
 		}
 		if fe.SyncMode != "" {
-			if err := validateOneOf("sync_mode", fe.SyncMode, SyncModePatch, SyncModeMirror); err != nil {
+			if err := validateOneOf("sync_mode", fe.SyncMode, SyncModePatch, SyncModeMirror, SyncModeCreateOnly); err != nil {
 				return fmt.Errorf("File %q: files[%d] (%s): %w", f.Metadata.FullName(), i, fe.Path, err)
 			}
 		}
@@ -217,7 +217,7 @@ func (fs *FileSet) Validate() error {
 			return fmt.Errorf("FileSet %q: files[%d] (%s) cannot have both content and source", fs.Metadata.Owner, i, f.Path)
 		}
 		if f.SyncMode != "" {
-			if err := validateOneOf("sync_mode", f.SyncMode, SyncModePatch, SyncModeMirror); err != nil {
+			if err := validateOneOf("sync_mode", f.SyncMode, SyncModePatch, SyncModeMirror, SyncModeCreateOnly); err != nil {
 				return fmt.Errorf("FileSet %q: files[%d] (%s): %w", fs.Metadata.Owner, i, f.Path, err)
 			}
 		}
@@ -250,6 +250,9 @@ func validateFileEntryDrift(files []FileEntry, prefix string) error {
 			}
 			if f.SyncMode == SyncModeMirror {
 				return fmt.Errorf("%sfiles[%d] (%s): on_drift cannot be set on a file with sync_mode \"mirror\" (mirror always overwrites)", prefix, i, f.Path)
+			}
+			if f.SyncMode == SyncModeCreateOnly {
+				return fmt.Errorf("%sfiles[%d] (%s): on_drift cannot be set on a file with sync_mode \"create_only\" (create_only never updates)", prefix, i, f.Path)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Add a new `sync_mode: create_only` option that creates files if they don't exist but never updates them afterward. Once the file is present in the target repository, gh-infra ignores it entirely — no drift detection, no warnings, no overwrites.

## Background

Some files need to be seeded once but then managed independently by the repository. For example, a `VERSION` file should be initialized with `0.1.0` but subsequent version bumps are the repo's responsibility. Previously, the only options were `patch` (which tracks drift) and `mirror` (which enforces exact content). Both would flag or overwrite manual changes, which is undesirable for seed files.

## Changes

- Add `SyncModeCreateOnly = "create_only"` constant in `manifest/types.go`
- Add `create_only` to `sync_mode` validation in `manifest/validation.go`
- Add validation error for `on_drift` + `create_only` combination (drift doesn't apply)
- Add `planCreateOnly()` method in `fileset/fileset.go` that returns `FileCreate` if missing or `FileNoOp` if exists
- Short-circuit before drift resolution in the Plan loop for `create_only` files
- Add tests for both file-exists and file-not-exists scenarios
- Update docs: sync-mode.mdx (new section + comparison table), file/index.md (spec table), drift.md (interaction section)