### PR TITLE
Enable patch mode for inline-backed files in import

### DIFF
--- a/.agents/skills/import-into/references/write-modes.md
+++ b/.agents/skills/import-into/references/write-modes.md
@@ -9,13 +9,16 @@ Use when the local source of truth should move to match GitHub.
 
 ## `patch`
 
-Use when the drift is repository-specific and should not immediately rewrite a shared source.
+Use when the drift is repository-specific and should not immediately rewrite the source.
+
+Available for all file types (source-backed and inline-backed).
 
 This is the safest default for:
 
 - shared local source files
 - cases where the repo differs slightly from a common template
 - existing `patches:`-based entries
+- inline content where you want to preserve the original `content:` block and store the drift separately
 
 ## `skip`
 

--- a/docs/src/content/docs/commands/import.md
+++ b/docs/src/content/docs/commands/import.md
@@ -110,7 +110,7 @@ The default action depends on the file shape:
 
 | File shape | Default | Allowed |
 |-----------|---------|---------|
-| Inline content | `write` | `write`, `skip` |
+| Inline content | `write` | `write`, `patch`, `skip` |
 | Local source (single-use) | `write` | `write`, `patch`, `skip` |
 | Local source shared by multiple repos | `patch` | `write`, `patch`, `skip` |
 | Existing `patches:` entry | `patch` | `write`, `patch`, `skip` |

--- a/docs/src/content/docs/internals/import-into.md
+++ b/docs/src/content/docs/internals/import-into.md
@@ -54,6 +54,7 @@ File import planning works with four concrete write-back modes:
   - update an inline `content: |` block inside the manifest
 - `WritePatch`
   - store the drift as a patch under `patches:`
+  - available for both source-backed and inline-backed entries
 - `WriteSkip`
   - do not write anything
 

--- a/internal/importer/files.go
+++ b/internal/importer/files.go
@@ -109,8 +109,11 @@ func planImportEntry(ctx context.Context, runner gh.Runner, fullName string, fil
 		return change
 	}
 
+	// Patch mode is primarily designed for source-backed files (shared templates)
+	// and files with existing patches. inlineBacked is included for consistency
+	// so that the diff viewer offers write/patch/skip for all file types.
 	patchSupported := false
-	if len(file.Patches) > 0 || sourceBacked {
+	if len(file.Patches) > 0 || sourceBacked || inlineBacked {
 		patchSupported = configurePatchTarget(&change, file, doc, repoIdx, repo, repoCount)
 	}
 	if len(file.Patches) > 0 && !patchSupported {
@@ -132,7 +135,9 @@ func planImportEntry(ctx context.Context, runner gh.Runner, fullName string, fil
 		}
 	} else if patchSupported {
 		availableModes = []WriteMode{WriteInline, WritePatch}
-		suggestedMode = WritePatch
+		if patchPreferred {
+			suggestedMode = WritePatch
+		}
 	}
 	setWriteMetadata(&change, suggestedMode, availableModes...)
 


### PR DESCRIPTION
## Summary

Allow inline-backed files to use write/patch/skip action cycling in the diff viewer during `import --into`, and fix the suggested mode so patch is only pre-selected when the file already has patches.

## Background

Previously, `patchSupported` was only set for source-backed files or files with existing patches. Inline-backed files (those with `content:` in the YAML) were limited to write-only, meaning the diff viewer couldn't offer the patch option. Additionally, `suggestedMode` was unconditionally set to `WritePatch` when patch was supported, even for files without existing patches — this made the default action confusing.

## Changes

- Include `inlineBacked` in the `patchSupported` condition so all file types get write/patch/skip in the diff viewer
- Only set `suggestedMode = WritePatch` when `patchPreferred` is true (i.e., the file already has patches), keeping "write" as the default for files without prior patches
- Add comment explaining why inline-backed files are included