### PR TITLE
Replace global DefaultResolver with explicit SourceResolver injection

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,15 +1,12 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
-	"github.com/babarot/gh-infra/internal/gh"
 	"github.com/babarot/gh-infra/internal/logger"
-	"github.com/babarot/gh-infra/internal/manifest"
 	"github.com/babarot/gh-infra/internal/ui"
 )
 
@@ -38,12 +35,6 @@ func NewRootCmd(version, revision string) *cobra.Command {
 			// --verbose is a shorthand for debug level
 			if verbose && level == "" {
 				logger.Init("debug")
-			}
-
-			// Wire up gh runner for GitHub source resolution
-			runner := gh.NewRunner(false)
-			manifest.DefaultResolver.RunGH = func(ctx context.Context, args ...string) ([]byte, error) {
-				return runner.Run(ctx, args...)
 			}
 		},
 	}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/babarot/gh-infra/internal/gh"
 	"github.com/babarot/gh-infra/internal/manifest"
 	"github.com/babarot/gh-infra/internal/ui"
 )
@@ -33,9 +35,17 @@ func runValidate(args []string, failOnUnknown bool) error {
 
 	p := ui.NewStandardPrinter()
 
+	runner := gh.NewRunner(false)
+	sourceResolver := manifest.NewSourceResolver(func(ctx context.Context, args ...string) ([]byte, error) {
+		return runner.Run(ctx, args...)
+	})
+
 	parsed := &manifest.ParseResult{}
 	for _, path := range paths {
-		result, err := manifest.ParseAll(path, manifest.ParseOptions{FailOnUnknown: failOnUnknown})
+		result, err := manifest.ParseAll(path, manifest.ParseOptions{
+			FailOnUnknown: failOnUnknown,
+			Resolver:      sourceResolver,
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/infra/import_into.go
+++ b/internal/infra/import_into.go
@@ -145,8 +145,13 @@ func (d *ImportDiff) Write() error {
 func ImportInto(args []string, into string) (*ImportDiff, error) {
 	printer := ui.NewStandardPrinter()
 
+	runner := gh.NewRunner(false)
+	sourceResolver := manifest.NewSourceResolver(func(ctx context.Context, args ...string) ([]byte, error) {
+		return runner.Run(ctx, args...)
+	})
+
 	// Parse manifests and match targets.
-	parsed, err := manifest.ParseAll(into)
+	parsed, err := manifest.ParseAll(into, manifest.ParseOptions{Resolver: sourceResolver})
 	if err != nil {
 		return nil, err
 	}
@@ -170,8 +175,6 @@ func ImportInto(args []string, into string) (*ImportDiff, error) {
 		printer.Message("\nNo matching resources found in manifests")
 		return &ImportDiff{Matched: false, printer: printer}, nil
 	}
-
-	runner := gh.NewRunner(false)
 
 	// Build spinner tasks.
 	var tasks []ui.RefreshTask

--- a/internal/infra/plan.go
+++ b/internal/infra/plan.go
@@ -56,9 +56,17 @@ func Plan(opts PlanOptions) (*PlanResult, error) {
 		return nil, err
 	}
 
+	runner := gh.NewRunner(false)
+	sourceResolver := manifest.NewSourceResolver(func(ctx context.Context, args ...string) ([]byte, error) {
+		return runner.Run(ctx, args...)
+	})
+
 	parsed := &manifest.ParseResult{}
 	for _, path := range paths {
-		result, err := manifest.ParseAll(path, manifest.ParseOptions{FailOnUnknown: opts.FailOnUnknown})
+		result, err := manifest.ParseAll(path, manifest.ParseOptions{
+			FailOnUnknown: opts.FailOnUnknown,
+			Resolver:      sourceResolver,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -78,8 +86,6 @@ func Plan(opts PlanOptions) (*PlanResult, error) {
 	if !opts.DryRun {
 		manifest.ResolveSecrets(parsed.Repositories)
 	}
-
-	runner := gh.NewRunner(false)
 
 	var resolverOwner string
 	if len(parsed.Repositories) > 0 {

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -24,7 +24,8 @@ func ParsePath(path string) ([]*Repository, error) {
 
 // ParseOptions controls parsing behavior.
 type ParseOptions struct {
-	FailOnUnknown bool // Error on files with unknown Kind (default: skip)
+	FailOnUnknown bool            // Error on files with unknown Kind (default: skip)
+	Resolver      *SourceResolver // Source resolver for File/FileSet entries (required when parsing File/FileSet kinds)
 }
 
 // ParseAll parses a file or directory and returns all resources (Repository + FileSet).
@@ -153,7 +154,10 @@ func parseDocument(data []byte, path string, docNum int, opt ParseOptions) (*Par
 		result.Repositories = repos
 		result.RepositoryDocs = docs
 	case KindFile:
-		fs, warnings, err := parseFile(data, path)
+		if opt.Resolver == nil {
+			return nil, fmt.Errorf("%s: ParseOptions.Resolver is required for File kind", path)
+		}
+		fs, warnings, err := parseFile(data, path, opt.Resolver)
 		if err != nil {
 			return nil, err
 		}
@@ -161,7 +165,10 @@ func parseDocument(data []byte, path string, docNum int, opt ParseOptions) (*Par
 		result.FileDocs = []*FileDocument{{Resource: fs, SourcePath: path, DocIndex: docIndex, Files: fs.Spec.Files}}
 		result.Warnings = append(result.Warnings, warnings...)
 	case KindFileSet:
-		fs, warnings, err := parseFileSet(data, path)
+		if opt.Resolver == nil {
+			return nil, fmt.Errorf("%s: ParseOptions.Resolver is required for FileSet kind", path)
+		}
+		fs, warnings, err := parseFileSet(data, path, opt.Resolver)
 		if err != nil {
 			return nil, err
 		}
@@ -225,7 +232,7 @@ func parseRepositorySet(data []byte, path string, docIndex int) ([]*Repository, 
 	return repos, docs, nil
 }
 
-func parseFile(data []byte, path string) (*FileSet, []string, error) {
+func parseFile(data []byte, path string, resolver *SourceResolver) (*FileSet, []string, error) {
 	var f File
 	if err := yaml.NewDecoder(bytes.NewReader(data), yaml.DisallowUnknownField()).Decode(&f); err != nil {
 		return nil, nil, fmt.Errorf("parse File in %s: %w", path, err)
@@ -256,7 +263,6 @@ func parseFile(data []byte, path string) (*FileSet, []string, error) {
 	}
 
 	// Resolve source references (local files, directories, GitHub URLs)
-	resolver := DefaultResolver
 	resolved, err := resolver.ResolveFiles(context.Background(), fs.Spec.Files, filepath.Dir(path))
 	if err != nil {
 		return nil, nil, fmt.Errorf("%s: %w", path, err)
@@ -272,7 +278,7 @@ func parseFile(data []byte, path string) (*FileSet, []string, error) {
 	return fs, warnings, nil
 }
 
-func parseFileSet(data []byte, path string) (*FileSet, []string, error) {
+func parseFileSet(data []byte, path string, resolver *SourceResolver) (*FileSet, []string, error) {
 	var fs FileSet
 	if err := yaml.NewDecoder(bytes.NewReader(data), yaml.DisallowUnknownField()).Decode(&fs); err != nil {
 		return nil, nil, fmt.Errorf("parse FileSet in %s: %w", path, err)
@@ -283,7 +289,6 @@ func parseFileSet(data []byte, path string) (*FileSet, []string, error) {
 	}
 
 	// Resolve source references (local files, directories, GitHub URLs)
-	resolver := DefaultResolver
 	resolved, err := resolver.ResolveFiles(context.Background(), fs.Spec.Files, filepath.Dir(path))
 	if err != nil {
 		return nil, nil, fmt.Errorf("%s: %w", path, err)

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -6,6 +6,12 @@ import (
 	"testing"
 )
 
+// fileOpts returns ParseOptions with a no-op SourceResolver for tests that
+// parse File/FileSet kinds (which require a non-nil Resolver).
+func fileOpts() ParseOptions {
+	return ParseOptions{Resolver: &SourceResolver{}}
+}
+
 func TestParsePath_SingleRepository(t *testing.T) {
 	dir := t.TempDir()
 	content := `
@@ -524,7 +530,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	result, err := ParseAll(path)
+	result, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("ParseAll returned error: %v", err)
 	}
@@ -583,7 +589,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	result, err := ParseAll(path)
+	result, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("ParseAll returned error: %v", err)
 	}
@@ -616,7 +622,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	_, err := ParseAll(path)
+	_, err := ParseAll(path, fileOpts())
 	if err == nil {
 		t.Fatal("expected error for missing owner, got nil")
 	}
@@ -642,7 +648,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	_, err := ParseAll(path)
+	_, err := ParseAll(path, fileOpts())
 	if err == nil {
 		t.Fatal("expected error for missing targets, got nil")
 	}
@@ -667,7 +673,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	_, err := ParseAll(path)
+	_, err := ParseAll(path, fileOpts())
 	if err == nil {
 		t.Fatal("expected error for missing files, got nil")
 	}
@@ -697,7 +703,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	_, err := ParseAll(path)
+	_, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("on_drift is deprecated but should still parse: %v", err)
 	}
@@ -734,7 +740,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	result, err := ParseAll(dir)
+	result, err := ParseAll(dir, fileOpts())
 	if err != nil {
 		t.Fatalf("ParseAll returned error: %v", err)
 	}
@@ -774,7 +780,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	result, err := ParseAll(path)
+	result, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("ParseAll returned error: %v", err)
 	}
@@ -818,7 +824,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	_, err := ParseAll(path)
+	_, err := ParseAll(path, fileOpts())
 	if err == nil {
 		t.Fatal("expected error for missing owner, got nil")
 	}
@@ -844,7 +850,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	_, err := ParseAll(path)
+	_, err := ParseAll(path, fileOpts())
 	if err == nil {
 		t.Fatal("expected error for missing name, got nil")
 	}
@@ -877,7 +883,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	result, err := ParseAll(path)
+	result, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("ParseAll returned error: %v", err)
 	}
@@ -915,7 +921,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	_, err := ParseAll(path)
+	_, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("on_drift is deprecated but should still parse: %v", err)
 	}
@@ -944,7 +950,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	_, err := ParseAll(path)
+	_, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("on_drift is deprecated but should still parse: %v", err)
 	}
@@ -1045,7 +1051,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	result, err := ParseAll(path)
+	result, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("ParseAll returned error: %v", err)
 	}
@@ -1088,7 +1094,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	result, err := ParseAll(path)
+	result, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("ParseAll returned error: %v", err)
 	}
@@ -1118,7 +1124,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	result, err := ParseAll(path)
+	result, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("ParseAll returned error: %v", err)
 	}
@@ -1155,7 +1161,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	result, err := ParseAll(path)
+	result, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("ParseAll returned error: %v", err)
 	}
@@ -1202,7 +1208,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	result, err := ParseAll(path)
+	result, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("ParseAll error: %v", err)
 	}
@@ -1248,7 +1254,7 @@ repositories:
 		t.Fatal(err)
 	}
 
-	result, err := ParseAll(path)
+	result, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("ParseAll error: %v", err)
 	}
@@ -1297,7 +1303,7 @@ repositories:
 		t.Fatal(err)
 	}
 
-	result, err := ParseAll(path)
+	result, err := ParseAll(path, fileOpts())
 	if err != nil {
 		t.Fatalf("ParseAll error: %v", err)
 	}

--- a/internal/manifest/paths_test.go
+++ b/internal/manifest/paths_test.go
@@ -96,7 +96,7 @@ spec:
 
 	merged := &ParseResult{}
 	for _, p := range paths {
-		result, err := ParseAll(p)
+		result, err := ParseAll(p, ParseOptions{Resolver: &SourceResolver{}})
 		if err != nil {
 			t.Fatalf("ParseAll(%s): %v", p, err)
 		}

--- a/internal/manifest/source.go
+++ b/internal/manifest/source.go
@@ -12,15 +12,16 @@ import (
 
 const githubScheme = "github://"
 
-// DefaultResolver is the package-level resolver used by the parser.
-// Set RunGH before parsing to enable GitHub source support.
-var DefaultResolver = &SourceResolver{}
-
 // SourceResolver resolves file sources (local files, directories, GitHub URLs).
 type SourceResolver struct {
 	// RunGH executes a gh CLI command and returns stdout.
 	// Set by the caller to avoid importing the gh package.
 	RunGH func(ctx context.Context, args ...string) ([]byte, error)
+}
+
+// NewSourceResolver creates a SourceResolver that delegates gh CLI calls to the given function.
+func NewSourceResolver(runGH func(ctx context.Context, args ...string) ([]byte, error)) *SourceResolver {
+	return &SourceResolver{RunGH: runGH}
 }
 
 // ResolveFiles expands source references in FileSet entries.


### PR DESCRIPTION
## Summary

Remove the package-level `DefaultResolver` global from `internal/manifest` and pass `SourceResolver` explicitly via `ParseOptions` at each call site.

## Background

The `manifest.DefaultResolver` was a mutable package-level variable that `cmd/root.go` wired up in `PersistentPreRun` by setting its `RunGH` field. This created implicit init-order coupling: callers had to ensure the global was configured before calling `ParseAll`. It also made testing harder and violated the principle that `manifest` (Layer 2) should be a pure data-model layer without hidden mutable state.

## Changes

- Remove `DefaultResolver` global from `internal/manifest/source.go`
- Add `NewSourceResolver` constructor function
- Add `Resolver *SourceResolver` field to `ParseOptions`
- `parseFile` and `parseFileSet` now receive the resolver as a parameter instead of capturing the global
- Return a clear error when `Resolver` is nil but a File/FileSet kind is encountered
- Remove the `PersistentPreRun` wiring from `cmd/root.go`
- Each call site (`plan.go`, `validate.go`, `import_into.go`) creates its own resolver locally
- Update all tests to pass `fileOpts()` helper with a no-op `SourceResolver`