### PR TITLE
Sort sub-resources for deterministic export output

### DIFF
--- a/internal/repository/export.go
+++ b/internal/repository/export.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"sort"
 
 	"github.com/babarot/gh-infra/internal/manifest"
 )
@@ -121,14 +122,25 @@ func ToManifest(ctx context.Context, r *CurrentState, resolver *manifest.Resolve
 		repo.Spec.Rulesets = append(repo.Spec.Rulesets, mrs)
 	}
 
-	for name, value := range r.Variables {
+	varNames := make([]string, 0, len(r.Variables))
+	for name := range r.Variables {
+		varNames = append(varNames, name)
+	}
+	sort.Strings(varNames)
+	for _, name := range varNames {
 		repo.Spec.Variables = append(repo.Spec.Variables, manifest.Variable{
 			Name:  name,
-			Value: value,
+			Value: r.Variables[name],
 		})
 	}
 
-	for _, label := range r.Labels {
+	labelNames := make([]string, 0, len(r.Labels))
+	for name := range r.Labels {
+		labelNames = append(labelNames, name)
+	}
+	sort.Strings(labelNames)
+	for _, name := range labelNames {
+		label := r.Labels[name]
 		repo.Spec.Labels = append(repo.Spec.Labels, manifest.Label{
 			Name:        label.Name,
 			Description: label.Description,
@@ -136,7 +148,13 @@ func ToManifest(ctx context.Context, r *CurrentState, resolver *manifest.Resolve
 		})
 	}
 
-	for _, ms := range r.Milestones {
+	msNames := make([]string, 0, len(r.Milestones))
+	for title := range r.Milestones {
+		msNames = append(msNames, title)
+	}
+	sort.Strings(msNames)
+	for _, title := range msNames {
+		ms := r.Milestones[title]
 		m := manifest.Milestone{
 			Title:       ms.Title,
 			Description: ms.Description,

--- a/internal/repository/state.go
+++ b/internal/repository/state.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -521,7 +522,9 @@ func (p *Processor) fetchSecrets(ctx context.Context, owner, name string) ([]str
 	if raw == "" {
 		return nil, nil
 	}
-	return strings.Split(raw, "\n"), nil
+	names := strings.Split(raw, "\n")
+	sort.Strings(names)
+	return names, nil
 }
 
 func (p *Processor) fetchVariables(ctx context.Context, owner, name string) (map[string]string, error) {


### PR DESCRIPTION
## Summary

Sort labels, variables, milestones, and secrets by name so that repeated `gh infra import` runs produce stable, diff-free YAML output. Closes #112

## Background

The GitHub API returns sub-resources (labels, variables, milestones, secrets) in non-deterministic order. Since `export.go` iterates over Go maps directly, each export can emit these resources in a different order — producing spurious git diffs even when nothing actually changed. This was reported in #112.

## Changes

- **`export.go`**: Collect map keys into a sorted slice before building the manifest for variables, labels, and milestones
- **`state.go`**: Sort secret names returned by `fetchSecrets` so the slice is stable across fetches