### PR TITLE
Suppress ANSI color codes in CI and NO_COLOR environments

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -44,6 +44,10 @@ type planCommandOptions struct {
 }
 
 func runPlan(paths []string, opts planCommandOptions) error {
+	if opts.CI {
+		ui.DisableStyles()
+	}
+
 	result, err := infra.Plan(infra.PlanOptions{
 		Paths:         paths,
 		FilterRepo:    opts.FilterRepo,

--- a/internal/ui/style.go
+++ b/internal/ui/style.go
@@ -1,6 +1,10 @@
 package ui
 
-import "charm.land/lipgloss/v2"
+import (
+	"os"
+
+	"charm.land/lipgloss/v2"
+)
 
 var (
 	Green  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
@@ -11,8 +15,13 @@ var (
 	Dim    = lipgloss.NewStyle().Faint(true)
 )
 
+func init() {
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		DisableStyles()
+	}
+}
+
 // DisableStyles resets all styles to plain text (no color, no formatting).
-// Used in tests to make output assertions simple.
 func DisableStyles() {
 	Green = lipgloss.NewStyle()
 	Red = lipgloss.NewStyle()


### PR DESCRIPTION
## Summary

Disable ANSI color escape sequences when `--ci` flag is passed or `NO_COLOR` environment variable is set. Closes #113

## Background

`gh infra plan --ci` still emits ANSI color codes, reducing readability in CI logs and downstream tools that consume the output. The `NO_COLOR` convention (https://no-color.org/) is also not respected.

## Changes

- **`internal/ui/style.go`**: Add `init()` that checks the `NO_COLOR` environment variable and calls `DisableStyles()` to strip all color/formatting
- **`cmd/plan.go`**: Call `ui.DisableStyles()` before executing the plan when `--ci` flag is set, ensuring plain-text output regardless of terminal detection