### PR TITLE
fix: resolve false-positive merge strategy diffs when GitHub returns null

### DIFF
--- a/internal/repository/state.go
+++ b/internal/repository/state.go
@@ -192,20 +192,27 @@ func (p *Processor) fetchCommitMessageSettings(ctx context.Context, owner, name 
 	}
 
 	var raw struct {
-		SquashMergeCommitTitle   string `json:"squash_merge_commit_title"`
-		SquashMergeCommitMessage string `json:"squash_merge_commit_message"`
-		MergeCommitTitle         string `json:"merge_commit_title"`
-		MergeCommitMessage       string `json:"merge_commit_message"`
+		SquashMergeCommitTitle   *string `json:"squash_merge_commit_title"`
+		SquashMergeCommitMessage *string `json:"squash_merge_commit_message"`
+		MergeCommitTitle         *string `json:"merge_commit_title"`
+		MergeCommitMessage       *string `json:"merge_commit_message"`
 	}
 	if err := json.Unmarshal(out, &raw); err != nil {
 		return commitMessageSettings{}, err
 	}
 
+	deref := func(s *string, def string) string {
+		if s != nil && *s != "" {
+			return *s
+		}
+		return def
+	}
+
 	return commitMessageSettings{
-		MergeCommitTitle:         raw.MergeCommitTitle,
-		MergeCommitMessage:       raw.MergeCommitMessage,
-		SquashMergeCommitTitle:   raw.SquashMergeCommitTitle,
-		SquashMergeCommitMessage: raw.SquashMergeCommitMessage,
+		MergeCommitTitle:         deref(raw.MergeCommitTitle, "MERGE_MESSAGE"),
+		MergeCommitMessage:       deref(raw.MergeCommitMessage, "PR_TITLE"),
+		SquashMergeCommitTitle:   deref(raw.SquashMergeCommitTitle, "COMMIT_OR_PR_TITLE"),
+		SquashMergeCommitMessage: deref(raw.SquashMergeCommitMessage, "COMMIT_MESSAGES"),
 	}, nil
 }
 

--- a/internal/repository/state_test.go
+++ b/internal/repository/state_test.go
@@ -269,6 +269,38 @@ func TestFetchVariables(t *testing.T) {
 	})
 }
 
+func TestFetchCommitMessageSettings_NullValues(t *testing.T) {
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message}": []byte(`{
+				"squash_merge_commit_title": null,
+				"squash_merge_commit_message": null,
+				"merge_commit_title": null,
+				"merge_commit_message": null
+			}`),
+		},
+	}
+
+	p := NewProcessor(mock, nil, nil)
+	settings, err := p.fetchCommitMessageSettings(context.Background(), "myorg", "myrepo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if settings.MergeCommitTitle != "MERGE_MESSAGE" {
+		t.Errorf("MergeCommitTitle = %q, want MERGE_MESSAGE", settings.MergeCommitTitle)
+	}
+	if settings.MergeCommitMessage != "PR_TITLE" {
+		t.Errorf("MergeCommitMessage = %q, want PR_TITLE", settings.MergeCommitMessage)
+	}
+	if settings.SquashMergeCommitTitle != "COMMIT_OR_PR_TITLE" {
+		t.Errorf("SquashMergeCommitTitle = %q, want COMMIT_OR_PR_TITLE", settings.SquashMergeCommitTitle)
+	}
+	if settings.SquashMergeCommitMessage != "COMMIT_MESSAGES" {
+		t.Errorf("SquashMergeCommitMessage = %q, want COMMIT_MESSAGES", settings.SquashMergeCommitMessage)
+	}
+}
+
 func TestCurrentState_FullName(t *testing.T) {
 	s := &CurrentState{Owner: "myorg", Name: "myrepo"}
 	if got := s.FullName(); got != "myorg/myrepo" {


### PR DESCRIPTION
## Summary
- Change `fetchCommitMessageSettings` to unmarshal `merge_commit_title`, `merge_commit_message`, `squash_merge_commit_title`, and `squash_merge_commit_message` into `*string` instead of `string`
- Substitute GitHub's documented default values when the API returns `null` or an empty string
- Add a test case covering the null API response scenario

## Background / Motivation

Running `gh infra plan` repeatedly shows false-positive diffs on every repository:

```
~ merge_commit_title            → MERGE_MESSAGE
~ merge_commit_message          → PR_TITLE
~ squash_merge_commit_title     → COMMIT_OR_PR_TITLE
~ squash_merge_commit_message   → COMMIT_MESSAGES
```

The root cause is in `fetchCommitMessageSettings` (`internal/repository/state.go`): when a repository uses GitHub's default merge commit settings, the API returns `null` for these fields. Go's `json.Unmarshal` converts `null` into an empty string `""` for `string` fields, so the current state appears as `""` while the desired state is e.g. `"MERGE_MESSAGE"`. Running `apply` sends a PATCH request, but GitHub ignores it (or resets to default on the next GET), causing the same diff to reappear on the next `plan`.

The fix unmarshals into `*string` fields, then falls back to GitHub's documented defaults when the pointer is `nil` (or the string is empty):
- `merge_commit_title`: `"MERGE_MESSAGE"`
- `merge_commit_message`: `"PR_TITLE"`
- `squash_merge_commit_title`: `"COMMIT_OR_PR_TITLE"`
- `squash_merge_commit_message`: `"COMMIT_MESSAGES"`

This approach is semantically correct because `CurrentState` should represent the *effective* state of the repository, not the raw API response. A `null` from GitHub means "this field is using the default value", so substituting the documented default is accurate. It also ensures that `export.go` outputs correct values when generating manifests from current state.

## Known limitations

**Hardcoded defaults may become stale if GitHub changes them.**
The four default values are hardcoded in `fetchCommitMessageSettings`. These are long-standing enum values unlikely to change (a change would be a breaking API change), so the practical risk is low — but worth noting.

**Empty string is treated the same as `null`.**
The `deref` helper returns the default when `s == nil || *s == ""`. If GitHub were to return an explicit empty string `""` for these fields, it would also be replaced by the default. In practice this cannot happen because the fields are enums with no empty-string member, but the distinction is lost at the code level.