### PR TITLE
Add security section for Dependabot/Advanced Security settings

### DIFF
--- a/.agents/skills/repository-manifest/SKILL.md
+++ b/.agents/skills/repository-manifest/SKILL.md
@@ -37,6 +37,7 @@ Read these references as needed:
 - Actions settings and validation traps: [references/actions.md](./references/actions.md)
 - Rulesets and branch protection: [references/protection.md](./references/protection.md)
 - Secrets and variables: [references/secrets-variables.md](./references/secrets-variables.md)
+- Security (Dependabot, vulnerability alerts): [references/security.md](./references/security.md)
 
 ## RepositorySet
 

--- a/.agents/skills/repository-manifest/references/general.md
+++ b/.agents/skills/repository-manifest/references/general.md
@@ -50,6 +50,15 @@ spec:
 
 Use this to lock releases after publishing.
 
+## Vulnerability Alerts
+
+```yaml
+spec:
+  vulnerability_alerts: true
+```
+
+Enable Dependabot vulnerability alerts. Required when integrating with tools like Renovate's `osvVulnerabilityAlerts`. Uses PUT/DELETE on `/repos/{owner}/{repo}/vulnerability-alerts`; GitHub reports state via HTTP status (204 = enabled, 404 = disabled).
+
 ## Lifecycle
 
 - Missing repository in GitHub: `plan` shows create, `apply` creates it

--- a/.agents/skills/repository-manifest/references/general.md
+++ b/.agents/skills/repository-manifest/references/general.md
@@ -50,15 +50,6 @@ spec:
 
 Use this to lock releases after publishing.
 
-## Vulnerability Alerts
-
-```yaml
-spec:
-  vulnerability_alerts: true
-```
-
-Enable Dependabot vulnerability alerts. Required when integrating with tools like Renovate's `osvVulnerabilityAlerts`. Uses PUT/DELETE on `/repos/{owner}/{repo}/vulnerability-alerts`; GitHub reports state via HTTP status (204 = enabled, 404 = disabled).
-
 ## Lifecycle
 
 - Missing repository in GitHub: `plan` shows create, `apply` creates it

--- a/.agents/skills/repository-manifest/references/security.md
+++ b/.agents/skills/repository-manifest/references/security.md
@@ -1,0 +1,15 @@
+# Security
+
+Fields under this section correspond to GitHub's **Advanced Security** settings page.
+
+All Advanced Security fields live under the `security` map.
+
+## Vulnerability Alerts
+
+```yaml
+spec:
+  security:
+    vulnerability_alerts: true
+```
+
+Enable Dependabot vulnerability alerts. Required when integrating with tools like Renovate's `osvVulnerabilityAlerts`. Uses PUT/DELETE on `/repos/{owner}/{repo}/vulnerability-alerts`; GitHub reports state via HTTP status (204 = enabled, 404 = disabled).

--- a/.agents/skills/repository-manifest/references/security.md
+++ b/.agents/skills/repository-manifest/references/security.md
@@ -4,12 +4,25 @@ Fields under this section correspond to GitHub's **Advanced Security** settings 
 
 All Advanced Security fields live under the `security` map.
 
-## Vulnerability Alerts
-
 ```yaml
 spec:
   security:
     vulnerability_alerts: true
+    automated_security_fixes: true
+    private_vulnerability_reporting: true
 ```
 
-Enable Dependabot vulnerability alerts. Required when integrating with tools like Renovate's `osvVulnerabilityAlerts`. Uses PUT/DELETE on `/repos/{owner}/{repo}/vulnerability-alerts`; GitHub reports state via HTTP status (204 = enabled, 404 = disabled).
+| Field | Endpoint | Notes |
+|---|---|---|
+| `vulnerability_alerts` | `vulnerability-alerts` | 204 = enabled / 404 = disabled |
+| `automated_security_fixes` | `automated-security-fixes` | Requires `vulnerability_alerts: true` (server-side check) |
+| `private_vulnerability_reporting` | `private-vulnerability-reporting` | |
+
+All three use PUT to enable, DELETE to disable on `/repos/{owner}/{repo}/<endpoint>`.
+
+Validation traps:
+- `automated_security_fixes` requires `vulnerability_alerts` to be effectively true. Checked at `plan` (NOT `validate` — the check needs current GitHub state). Effective state = manifest value if set, else current remote value (omission = unmanaged).
+- `vulnerability_alerts: false` + `automated_security_fixes: true` → plan fails with explicit error.
+- `automated_security_fixes: true` alone (alerts omitted) → plan succeeds only if remote alerts already true; otherwise fails with same error.
+- Apply order: when both are set true in one manifest, `vulnerability_alerts` is sent before `automated_security_fixes` (guaranteed by `diffSecurity` child order and `applyAllSettings` for new repos).
+- `private_vulnerability_reporting` is independent — no dependency.

--- a/.claude/rules/skill-sync.md
+++ b/.claude/rules/skill-sync.md
@@ -20,6 +20,7 @@ When either side changes, check whether the other side needs updating.
 | `resources/repository/actions.md` | `repository-manifest` | `references/actions.md` |
 | `resources/repository/rulesets.md`, `resources/repository/branch-protection.md` | `repository-manifest` | `references/protection.md` |
 | `resources/repository/secrets-variables.md` | `repository-manifest` | `references/secrets-variables.md` |
+| `resources/repository/security.md` | `repository-manifest` | `references/security.md` |
 | `resources/repository-set/defaults.md`, `resources/repository-set/index.md` | `repository-manifest` | `references/repository-set.md` |
 | `resources/file/sources.md`, `resources/file/templating.md` | `file-manifest` | `references/sources-and-templating.md` |
 | `resources/file/delivery.md`, `resources/file/index.md` | `file-manifest` | `references/reconcile-and-delivery.md` |

--- a/docs/src/content/docs/resources/repository/general.md
+++ b/docs/src/content/docs/resources/repository/general.md
@@ -102,3 +102,18 @@ spec:
 | `release_immutability` | bool | `true` to lock releases after publishing. Once enabled, release assets and metadata cannot be edited or deleted |
 
 This setting uses a dedicated GitHub API endpoint (`/repos/{owner}/{repo}/immutable-releases`) rather than the standard repository settings endpoint.
+
+## Vulnerability Alerts
+
+Enable or disable Dependabot vulnerability alerts for the repository:
+
+```yaml
+spec:
+  vulnerability_alerts: true
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `vulnerability_alerts` | bool | `true` to enable Dependabot vulnerability alerts. Required for features like Renovate's `osvVulnerabilityAlerts` that integrate with Dependabot |
+
+This setting uses a dedicated GitHub API endpoint (`/repos/{owner}/{repo}/vulnerability-alerts`) rather than the standard repository settings endpoint. The API signals state via HTTP status: `204 No Content` when enabled, `404 Not Found` when disabled.

--- a/docs/src/content/docs/resources/repository/general.md
+++ b/docs/src/content/docs/resources/repository/general.md
@@ -100,5 +100,3 @@ spec:
 | Field | Type | Description |
 |-------|------|-------------|
 | `release_immutability` | bool | `true` to lock releases after publishing. Once enabled, release assets and metadata cannot be edited or deleted |
-
-This setting uses a dedicated GitHub API endpoint (`/repos/{owner}/{repo}/immutable-releases`) rather than the standard repository settings endpoint.

--- a/docs/src/content/docs/resources/repository/general.md
+++ b/docs/src/content/docs/resources/repository/general.md
@@ -102,18 +102,3 @@ spec:
 | `release_immutability` | bool | `true` to lock releases after publishing. Once enabled, release assets and metadata cannot be edited or deleted |
 
 This setting uses a dedicated GitHub API endpoint (`/repos/{owner}/{repo}/immutable-releases`) rather than the standard repository settings endpoint.
-
-## Vulnerability Alerts
-
-Enable or disable Dependabot vulnerability alerts for the repository:
-
-```yaml
-spec:
-  vulnerability_alerts: true
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `vulnerability_alerts` | bool | `true` to enable Dependabot vulnerability alerts. Required for features like Renovate's `osvVulnerabilityAlerts` that integrate with Dependabot |
-
-This setting uses a dedicated GitHub API endpoint (`/repos/{owner}/{repo}/vulnerability-alerts`) rather than the standard repository settings endpoint. The API signals state via HTTP status: `204 No Content` when enabled, `404 Not Found` when disabled.

--- a/docs/src/content/docs/resources/repository/security.md
+++ b/docs/src/content/docs/resources/repository/security.md
@@ -1,0 +1,29 @@
+---
+title: Security
+sidebar:
+  order: 8
+---
+
+Security settings correspond to the **Advanced Security** section of the GitHub repository settings UI. They are grouped under the `security` key on the repository spec:
+
+```yaml
+spec:
+  security:
+    vulnerability_alerts: true
+```
+
+## Vulnerability Alerts
+
+Enable or disable Dependabot vulnerability alerts for the repository:
+
+```yaml
+spec:
+  security:
+    vulnerability_alerts: true
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `security.vulnerability_alerts` | bool | `true` to enable Dependabot vulnerability alerts. Required for features like Renovate's `osvVulnerabilityAlerts` that integrate with Dependabot |
+
+This setting uses a dedicated GitHub API endpoint (`/repos/{owner}/{repo}/vulnerability-alerts`) rather than the standard repository settings endpoint. The API signals state via HTTP status: `204 No Content` when enabled, `404 Not Found` when disabled.

--- a/docs/src/content/docs/resources/repository/security.md
+++ b/docs/src/content/docs/resources/repository/security.md
@@ -10,11 +10,31 @@ Security settings correspond to the **Advanced Security** section of the GitHub 
 spec:
   security:
     vulnerability_alerts: true
+    automated_security_fixes: true
+    private_vulnerability_reporting: true
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `vulnerability_alerts` | bool | Enable Dependabot vulnerability alerts |
+| `automated_security_fixes` | bool | Enable Dependabot security updates (auto-PRs that fix vulnerabilities). Requires `vulnerability_alerts: true` on GitHub side |
+| `private_vulnerability_reporting` | bool | Allow security researchers to privately report vulnerabilities |
+
+Each field is optional and uses a dedicated GitHub REST API endpoint (PUT to enable, DELETE to disable).
+
+### Field dependencies
+
+`automated_security_fixes` requires `vulnerability_alerts` to be effectively enabled (per GitHub's API). gh-infra evaluates this at `plan` time using both the manifest and the current GitHub state, and rejects the plan if the dependency cannot be satisfied:
+
+- If `vulnerability_alerts: true` is set in the same manifest, the plan succeeds and `apply` enables alerts before fixes (ordering is guaranteed).
+- If `vulnerability_alerts` is omitted from the manifest, gh-infra falls back to the repository's current GitHub state (omission means "leave as-is"). The plan succeeds only when alerts are already enabled on GitHub.
+- If `vulnerability_alerts: false` is set explicitly, the plan fails with a clear error.
+
+`private_vulnerability_reporting` has no dependency on the other fields and can be toggled independently.
 
 ## Vulnerability Alerts
 
-Enable or disable Dependabot vulnerability alerts for the repository:
+Enable or disable Dependabot vulnerability alerts:
 
 ```yaml
 spec:
@@ -22,8 +42,28 @@ spec:
     vulnerability_alerts: true
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `security.vulnerability_alerts` | bool | `true` to enable Dependabot vulnerability alerts. Required for features like Renovate's `osvVulnerabilityAlerts` that integrate with Dependabot |
+Endpoint: `/repos/{owner}/{repo}/vulnerability-alerts`. Required for features like Renovate's `osvVulnerabilityAlerts` that integrate with Dependabot. The API signals state via HTTP status: `204 No Content` when enabled, `404 Not Found` when disabled.
 
-This setting uses a dedicated GitHub API endpoint (`/repos/{owner}/{repo}/vulnerability-alerts`) rather than the standard repository settings endpoint. The API signals state via HTTP status: `204 No Content` when enabled, `404 Not Found` when disabled.
+## Automated Security Fixes
+
+Enable or disable Dependabot security updates — automated pull requests that resolve open Dependabot alerts:
+
+```yaml
+spec:
+  security:
+    automated_security_fixes: true
+```
+
+Endpoint: `/repos/{owner}/{repo}/automated-security-fixes`. Requires `vulnerability_alerts` to be effectively enabled — see [Field dependencies](#field-dependencies) above.
+
+## Private Vulnerability Reporting
+
+Allow security researchers to privately report vulnerabilities through GitHub's security advisory workflow:
+
+```yaml
+spec:
+  security:
+    private_vulnerability_reporting: true
+```
+
+Endpoint: `/repos/{owner}/{repo}/private-vulnerability-reporting`.

--- a/docs/src/content/docs/resources/repository/security.md
+++ b/docs/src/content/docs/resources/repository/security.md
@@ -20,8 +20,6 @@ spec:
 | `automated_security_fixes` | bool | Enable Dependabot security updates (auto-PRs that fix vulnerabilities). Requires `vulnerability_alerts: true` on GitHub side |
 | `private_vulnerability_reporting` | bool | Allow security researchers to privately report vulnerabilities |
 
-Each field is optional and uses a dedicated GitHub REST API endpoint (PUT to enable, DELETE to disable).
-
 ### Field dependencies
 
 `automated_security_fixes` requires `vulnerability_alerts` to be effectively enabled (per GitHub's API). gh-infra evaluates this at `plan` time using both the manifest and the current GitHub state, and rejects the plan if the dependency cannot be satisfied:
@@ -42,7 +40,7 @@ spec:
     vulnerability_alerts: true
 ```
 
-Endpoint: `/repos/{owner}/{repo}/vulnerability-alerts`. Required for features like Renovate's `osvVulnerabilityAlerts` that integrate with Dependabot. The API signals state via HTTP status: `204 No Content` when enabled, `404 Not Found` when disabled.
+Required for tools like Renovate's `osvVulnerabilityAlerts` that integrate with Dependabot.
 
 ## Automated Security Fixes
 
@@ -54,7 +52,7 @@ spec:
     automated_security_fixes: true
 ```
 
-Endpoint: `/repos/{owner}/{repo}/automated-security-fixes`. Requires `vulnerability_alerts` to be effectively enabled — see [Field dependencies](#field-dependencies) above.
+Requires `vulnerability_alerts` to be effectively enabled — see [Field dependencies](#field-dependencies) above.
 
 ## Private Vulnerability Reporting
 
@@ -65,5 +63,3 @@ spec:
   security:
     private_vulnerability_reporting: true
 ```
-
-Endpoint: `/repos/{owner}/{repo}/private-vulnerability-reporting`.

--- a/internal/importer/repository.go
+++ b/internal/importer/repository.go
@@ -248,6 +248,22 @@ var repositoryFieldDescriptors = []repositoryFieldDescriptor{
 		},
 	},
 	{
+		diffField: "release_immutability",
+		key:       "release_immutability",
+		kind:      fieldBool,
+		boolVal: func(spec manifest.RepositorySpec) *bool {
+			return spec.ReleaseImmutability
+		},
+	},
+	{
+		diffField: "vulnerability_alerts",
+		key:       "vulnerability_alerts",
+		kind:      fieldBool,
+		boolVal: func(spec manifest.RepositorySpec) *bool {
+			return spec.VulnerabilityAlerts
+		},
+	},
+	{
 		diffField: "topics",
 		key:       "topics",
 		kind:      fieldStringSlice,
@@ -703,6 +719,8 @@ func compareSpecs(local, imported manifest.RepositorySpec) []FieldDiff {
 	diffs = appendPtrDiff(diffs, "homepage", local.Homepage, imported.Homepage)
 	diffs = appendPtrDiff(diffs, "visibility", local.Visibility, imported.Visibility)
 	diffs = appendBoolPtrDiff(diffs, "archived", local.Archived, imported.Archived)
+	diffs = appendBoolPtrDiff(diffs, "release_immutability", local.ReleaseImmutability, imported.ReleaseImmutability)
+	diffs = appendBoolPtrDiff(diffs, "vulnerability_alerts", local.VulnerabilityAlerts, imported.VulnerabilityAlerts)
 
 	// List fields
 	if !stringSliceEqual(local.Topics, imported.Topics) {

--- a/internal/importer/repository.go
+++ b/internal/importer/repository.go
@@ -265,6 +265,24 @@ var repositoryFieldDescriptors = []repositoryFieldDescriptor{
 		},
 	},
 	{
+		diffField: "security.automated_security_fixes",
+		parentKey: "security",
+		key:       "automated_security_fixes",
+		kind:      fieldBool,
+		boolVal: func(spec manifest.RepositorySpec) *bool {
+			return boolPtrFromSecurity(spec.Security, "automated_security_fixes")
+		},
+	},
+	{
+		diffField: "security.private_vulnerability_reporting",
+		parentKey: "security",
+		key:       "private_vulnerability_reporting",
+		kind:      fieldBool,
+		boolVal: func(spec manifest.RepositorySpec) *bool {
+			return boolPtrFromSecurity(spec.Security, "private_vulnerability_reporting")
+		},
+	},
+	{
 		diffField: "topics",
 		key:       "topics",
 		kind:      fieldStringSlice,
@@ -609,6 +627,10 @@ func boolPtrFromSecurity(s *manifest.Security, field string) *bool {
 	switch field {
 	case "vulnerability_alerts":
 		return s.VulnerabilityAlerts
+	case "automated_security_fixes":
+		return s.AutomatedSecurityFixes
+	case "private_vulnerability_reporting":
+		return s.PrivateVulnerabilityReporting
 	default:
 		return nil
 	}
@@ -775,6 +797,8 @@ func compareSecurity(local, imported *manifest.Security) []FieldDiff {
 	l := derefSecurity(local)
 	i := derefSecurity(imported)
 	diffs = appendBoolPtrDiff(diffs, "security.vulnerability_alerts", l.VulnerabilityAlerts, i.VulnerabilityAlerts)
+	diffs = appendBoolPtrDiff(diffs, "security.automated_security_fixes", l.AutomatedSecurityFixes, i.AutomatedSecurityFixes)
+	diffs = appendBoolPtrDiff(diffs, "security.private_vulnerability_reporting", l.PrivateVulnerabilityReporting, i.PrivateVulnerabilityReporting)
 	return diffs
 }
 

--- a/internal/importer/repository.go
+++ b/internal/importer/repository.go
@@ -212,7 +212,7 @@ type repositoryPatchPlan struct {
 	deletes              []string
 }
 
-var repositoryNestedMergeOrder = []string{"features", "merge_strategy", "actions"}
+var repositoryNestedMergeOrder = []string{"features", "merge_strategy", "actions", "security"}
 
 var repositoryFieldDescriptors = []repositoryFieldDescriptor{
 	{
@@ -256,11 +256,12 @@ var repositoryFieldDescriptors = []repositoryFieldDescriptor{
 		},
 	},
 	{
-		diffField: "vulnerability_alerts",
+		diffField: "security.vulnerability_alerts",
+		parentKey: "security",
 		key:       "vulnerability_alerts",
 		kind:      fieldBool,
 		boolVal: func(spec manifest.RepositorySpec) *bool {
-			return spec.VulnerabilityAlerts
+			return boolPtrFromSecurity(spec.Security, "vulnerability_alerts")
 		},
 	},
 	{
@@ -601,6 +602,18 @@ func isPrefixedField(field, prefix string) bool {
 	return len(field) > len(prefix) && field[:len(prefix)] == prefix
 }
 
+func boolPtrFromSecurity(s *manifest.Security, field string) *bool {
+	if s == nil {
+		return nil
+	}
+	switch field {
+	case "vulnerability_alerts":
+		return s.VulnerabilityAlerts
+	default:
+		return nil
+	}
+}
+
 func boolPtrFromFeatures(f *manifest.Features, field string) *bool {
 	if f == nil {
 		return nil
@@ -720,7 +733,6 @@ func compareSpecs(local, imported manifest.RepositorySpec) []FieldDiff {
 	diffs = appendPtrDiff(diffs, "visibility", local.Visibility, imported.Visibility)
 	diffs = appendBoolPtrDiff(diffs, "archived", local.Archived, imported.Archived)
 	diffs = appendBoolPtrDiff(diffs, "release_immutability", local.ReleaseImmutability, imported.ReleaseImmutability)
-	diffs = appendBoolPtrDiff(diffs, "vulnerability_alerts", local.VulnerabilityAlerts, imported.VulnerabilityAlerts)
 
 	// List fields
 	if !stringSliceEqual(local.Topics, imported.Topics) {
@@ -736,6 +748,9 @@ func compareSpecs(local, imported manifest.RepositorySpec) []FieldDiff {
 	// Nested map: actions
 	diffs = append(diffs, compareActions(local.Actions, imported.Actions)...)
 
+	// Nested map: security
+	diffs = append(diffs, compareSecurity(local.Security, imported.Security)...)
+
 	// Branch protection (Phase 2c)
 	diffs = append(diffs, compareBranchProtection(local.BranchProtection, imported.BranchProtection)...)
 
@@ -749,6 +764,25 @@ func compareSpecs(local, imported manifest.RepositorySpec) []FieldDiff {
 	diffs = append(diffs, compareLabels(local.Labels, imported.Labels)...)
 
 	return diffs
+}
+
+// compareSecurity compares Security fields.
+func compareSecurity(local, imported *manifest.Security) []FieldDiff {
+	if local == nil && imported == nil {
+		return nil
+	}
+	var diffs []FieldDiff
+	l := derefSecurity(local)
+	i := derefSecurity(imported)
+	diffs = appendBoolPtrDiff(diffs, "security.vulnerability_alerts", l.VulnerabilityAlerts, i.VulnerabilityAlerts)
+	return diffs
+}
+
+func derefSecurity(s *manifest.Security) manifest.Security {
+	if s == nil {
+		return manifest.Security{}
+	}
+	return *s
 }
 
 // compareFeatures compares Features fields.

--- a/internal/importer/repository_test.go
+++ b/internal/importer/repository_test.go
@@ -214,12 +214,16 @@ spec:
 func TestPlanRepository_SecuritySettingsDiff(t *testing.T) {
 	local := manifest.RepositorySpec{
 		ReleaseImmutability: manifest.Ptr(false),
-		VulnerabilityAlerts: manifest.Ptr(false),
+		Security: &manifest.Security{
+			VulnerabilityAlerts: manifest.Ptr(false),
+		},
 	}
 	imported := manifest.Repository{
 		Spec: manifest.RepositorySpec{
 			ReleaseImmutability: manifest.Ptr(true),
-			VulnerabilityAlerts: manifest.Ptr(true),
+			Security: &manifest.Security{
+				VulnerabilityAlerts: manifest.Ptr(true),
+			},
 		},
 	}
 
@@ -236,7 +240,8 @@ metadata:
   owner: org
 spec:
   release_immutability: false
-  vulnerability_alerts: false
+  security:
+    vulnerability_alerts: false
 `)
 
 	mb := map[string][]byte{"/tmp/test.yaml": yamlData}
@@ -256,8 +261,8 @@ spec:
 	if !found["release_immutability"] {
 		t.Error("expected diff for release_immutability")
 	}
-	if !found["vulnerability_alerts"] {
-		t.Error("expected diff for vulnerability_alerts")
+	if !found["security.vulnerability_alerts"] {
+		t.Error("expected diff for security.vulnerability_alerts")
 	}
 
 	updated := string(mb["/tmp/test.yaml"])

--- a/internal/importer/repository_test.go
+++ b/internal/importer/repository_test.go
@@ -211,6 +211,64 @@ spec:
 	}
 }
 
+func TestPlanRepository_SecuritySettingsDiff(t *testing.T) {
+	local := manifest.RepositorySpec{
+		ReleaseImmutability: manifest.Ptr(false),
+		VulnerabilityAlerts: manifest.Ptr(false),
+	}
+	imported := manifest.Repository{
+		Spec: manifest.RepositorySpec{
+			ReleaseImmutability: manifest.Ptr(true),
+			VulnerabilityAlerts: manifest.Ptr(true),
+		},
+	}
+
+	doc := &manifest.RepositoryDocument{
+		Resource:   &manifest.Repository{Spec: local},
+		SourcePath: "/tmp/test.yaml",
+		DocIndex:   0,
+	}
+
+	yamlData := []byte(`apiVersion: gh-infra/v1
+kind: Repository
+metadata:
+  name: test
+  owner: org
+spec:
+  release_immutability: false
+  vulnerability_alerts: false
+`)
+
+	mb := map[string][]byte{"/tmp/test.yaml": yamlData}
+	rp, err := DiffRepository(DiffInput{
+		Repos:         []*manifest.RepositoryDocument{doc},
+		Imported:      &imported,
+		ManifestBytes: mb,
+	})
+	if err != nil {
+		t.Fatalf("DiffRepository error: %v", err)
+	}
+
+	found := make(map[string]bool)
+	for _, d := range rp.Diffs {
+		found[d.Field] = true
+	}
+	if !found["release_immutability"] {
+		t.Error("expected diff for release_immutability")
+	}
+	if !found["vulnerability_alerts"] {
+		t.Error("expected diff for vulnerability_alerts")
+	}
+
+	updated := string(mb["/tmp/test.yaml"])
+	if !strings.Contains(updated, "release_immutability: true") {
+		t.Errorf("expected manifest to be patched to release_immutability: true, got:\n%s", updated)
+	}
+	if !strings.Contains(updated, "vulnerability_alerts: true") {
+		t.Errorf("expected manifest to be patched to vulnerability_alerts: true, got:\n%s", updated)
+	}
+}
+
 func TestPlanRepository_ManifestBytesUpdated(t *testing.T) {
 	local := manifest.RepositorySpec{
 		Description: manifest.Ptr("old"),

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -376,6 +376,15 @@ func mergeSpecs(defaults *RepositorySetDefaults, override RepositorySpec) Reposi
 	if override.MergeStrategy != nil {
 		result.MergeStrategy = mergeMergeStrategy(result.MergeStrategy, override.MergeStrategy)
 	}
+	if override.ReleaseImmutability != nil {
+		result.ReleaseImmutability = override.ReleaseImmutability
+	}
+	if override.Security != nil {
+		result.Security = mergeSecurity(result.Security, override.Security)
+	}
+	if override.Actions != nil {
+		result.Actions = mergeActions(result.Actions, override.Actions)
+	}
 	if len(override.BranchProtection) > 0 {
 		result.BranchProtection = override.BranchProtection
 	}
@@ -457,6 +466,78 @@ func mergeMergeStrategy(base, override *MergeStrategy) *MergeStrategy {
 	}
 	if override.SquashMergeCommitMessage != nil {
 		result.SquashMergeCommitMessage = override.SquashMergeCommitMessage
+	}
+	return &result
+}
+
+func mergeSecurity(base, override *Security) *Security {
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		return base
+	}
+	result := *base
+	if override.VulnerabilityAlerts != nil {
+		result.VulnerabilityAlerts = override.VulnerabilityAlerts
+	}
+	if override.AutomatedSecurityFixes != nil {
+		result.AutomatedSecurityFixes = override.AutomatedSecurityFixes
+	}
+	if override.PrivateVulnerabilityReporting != nil {
+		result.PrivateVulnerabilityReporting = override.PrivateVulnerabilityReporting
+	}
+	return &result
+}
+
+func mergeActions(base, override *Actions) *Actions {
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		return base
+	}
+	result := *base
+	if override.Enabled != nil {
+		result.Enabled = override.Enabled
+	}
+	if override.AllowedActions != nil {
+		result.AllowedActions = override.AllowedActions
+	}
+	if override.SHAPinningRequired != nil {
+		result.SHAPinningRequired = override.SHAPinningRequired
+	}
+	if override.WorkflowPermissions != nil {
+		result.WorkflowPermissions = override.WorkflowPermissions
+	}
+	if override.CanApprovePullRequests != nil {
+		result.CanApprovePullRequests = override.CanApprovePullRequests
+	}
+	if override.ForkPRApproval != nil {
+		result.ForkPRApproval = override.ForkPRApproval
+	}
+	if override.SelectedActions != nil {
+		result.SelectedActions = mergeSelectedActions(result.SelectedActions, override.SelectedActions)
+	}
+	return &result
+}
+
+func mergeSelectedActions(base, override *SelectedActions) *SelectedActions {
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		return base
+	}
+	result := *base
+	if override.GithubOwnedAllowed != nil {
+		result.GithubOwnedAllowed = override.GithubOwnedAllowed
+	}
+	if override.VerifiedAllowed != nil {
+		result.VerifiedAllowed = override.VerifiedAllowed
+	}
+	if len(override.PatternsAllowed) > 0 {
+		result.PatternsAllowed = override.PatternsAllowed
 	}
 	return &result
 }

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -451,6 +451,182 @@ repositories:
 	}
 }
 
+func TestRepositorySet_SecurityMerge(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: RepositorySet
+metadata:
+  owner: org
+defaults:
+  spec:
+    visibility: public
+    security:
+      vulnerability_alerts: true
+      automated_security_fixes: true
+      private_vulnerability_reporting: false
+repositories:
+  - name: defaults-only
+  - name: override-one
+    spec:
+      security:
+        private_vulnerability_reporting: true
+  - name: override-disable
+    spec:
+      security:
+        automated_security_fixes: false
+`
+	path := filepath.Join(dir, "security.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath returned error: %v", err)
+	}
+	if len(repos) != 3 {
+		t.Fatalf("expected 3 repos, got %d", len(repos))
+	}
+
+	check := func(t *testing.T, name string, wantVA, wantASF, wantPVR bool) {
+		t.Helper()
+		var s *Security
+		for _, r := range repos {
+			if r.Metadata.Name == name {
+				s = r.Spec.Security
+				break
+			}
+		}
+		if s == nil {
+			t.Fatalf("%s: security is nil", name)
+		}
+		if s.VulnerabilityAlerts == nil || *s.VulnerabilityAlerts != wantVA {
+			t.Errorf("%s: vulnerability_alerts = %v, want %v", name, s.VulnerabilityAlerts, wantVA)
+		}
+		if s.AutomatedSecurityFixes == nil || *s.AutomatedSecurityFixes != wantASF {
+			t.Errorf("%s: automated_security_fixes = %v, want %v", name, s.AutomatedSecurityFixes, wantASF)
+		}
+		if s.PrivateVulnerabilityReporting == nil || *s.PrivateVulnerabilityReporting != wantPVR {
+			t.Errorf("%s: private_vulnerability_reporting = %v, want %v", name, s.PrivateVulnerabilityReporting, wantPVR)
+		}
+	}
+
+	check(t, "defaults-only", true, true, false)
+	check(t, "override-one", true, true, true)
+	check(t, "override-disable", true, false, false)
+}
+
+func TestRepositorySet_ReleaseImmutabilityMerge(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: RepositorySet
+metadata:
+  owner: org
+defaults:
+  spec:
+    visibility: public
+    release_immutability: true
+repositories:
+  - name: from-defaults
+  - name: overridden
+    spec:
+      release_immutability: false
+`
+	path := filepath.Join(dir, "release.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath returned error: %v", err)
+	}
+	for _, r := range repos {
+		switch r.Metadata.Name {
+		case "from-defaults":
+			if r.Spec.ReleaseImmutability == nil || *r.Spec.ReleaseImmutability != true {
+				t.Errorf("from-defaults: release_immutability = %v, want true (from defaults)", r.Spec.ReleaseImmutability)
+			}
+		case "overridden":
+			if r.Spec.ReleaseImmutability == nil || *r.Spec.ReleaseImmutability != false {
+				t.Errorf("overridden: release_immutability = %v, want false (overridden)", r.Spec.ReleaseImmutability)
+			}
+		}
+	}
+}
+
+func TestRepositorySet_ActionsMerge(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: RepositorySet
+metadata:
+  owner: org
+defaults:
+  spec:
+    visibility: public
+    actions:
+      enabled: true
+      allowed_actions: selected
+      sha_pinning_required: false
+      selected_actions:
+        github_owned_allowed: true
+        verified_allowed: false
+repositories:
+  - name: from-defaults
+  - name: overridden
+    spec:
+      actions:
+        sha_pinning_required: true
+        selected_actions:
+          verified_allowed: true
+`
+	path := filepath.Join(dir, "actions.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath returned error: %v", err)
+	}
+	for _, r := range repos {
+		a := r.Spec.Actions
+		if a == nil {
+			t.Fatalf("%s: actions is nil", r.Metadata.Name)
+		}
+		// Common: enabled/allowed_actions inherited
+		if a.Enabled == nil || *a.Enabled != true {
+			t.Errorf("%s: enabled = %v, want true", r.Metadata.Name, a.Enabled)
+		}
+		if a.AllowedActions == nil || *a.AllowedActions != "selected" {
+			t.Errorf("%s: allowed_actions = %v, want selected", r.Metadata.Name, a.AllowedActions)
+		}
+		switch r.Metadata.Name {
+		case "from-defaults":
+			if a.SHAPinningRequired == nil || *a.SHAPinningRequired != false {
+				t.Errorf("from-defaults: sha_pinning_required = %v, want false", a.SHAPinningRequired)
+			}
+			if a.SelectedActions == nil || a.SelectedActions.VerifiedAllowed == nil || *a.SelectedActions.VerifiedAllowed != false {
+				t.Errorf("from-defaults: selected_actions.verified_allowed not inherited")
+			}
+		case "overridden":
+			if a.SHAPinningRequired == nil || *a.SHAPinningRequired != true {
+				t.Errorf("overridden: sha_pinning_required = %v, want true (overridden)", a.SHAPinningRequired)
+			}
+			// github_owned_allowed inherited from defaults
+			if a.SelectedActions == nil || a.SelectedActions.GithubOwnedAllowed == nil || *a.SelectedActions.GithubOwnedAllowed != true {
+				t.Errorf("overridden: selected_actions.github_owned_allowed = %v, want true (inherited)", a.SelectedActions.GithubOwnedAllowed)
+			}
+			if a.SelectedActions.VerifiedAllowed == nil || *a.SelectedActions.VerifiedAllowed != true {
+				t.Errorf("overridden: selected_actions.verified_allowed = %v, want true (overridden)", a.SelectedActions.VerifiedAllowed)
+			}
+		}
+	}
+}
+
 func TestResolveSecrets_ExpandsEnvVars(t *testing.T) {
 	// Set test environment variables
 	t.Setenv("ENV_SECRET_TOKEN", "my-secret-value")

--- a/internal/manifest/repository_types.go
+++ b/internal/manifest/repository_types.go
@@ -92,7 +92,9 @@ type RepositorySpec struct {
 // mirroring the "Advanced Security" section of the GitHub repository
 // settings UI.
 type Security struct {
-	VulnerabilityAlerts *bool `yaml:"vulnerability_alerts,omitempty"`
+	VulnerabilityAlerts           *bool `yaml:"vulnerability_alerts,omitempty"`
+	AutomatedSecurityFixes        *bool `yaml:"automated_security_fixes,omitempty"`
+	PrivateVulnerabilityReporting *bool `yaml:"private_vulnerability_reporting,omitempty"`
 }
 
 type Features struct {

--- a/internal/manifest/repository_types.go
+++ b/internal/manifest/repository_types.go
@@ -80,6 +80,7 @@ type RepositorySpec struct {
 	Features            *Features          `yaml:"features,omitempty"`
 	MergeStrategy       *MergeStrategy     `yaml:"merge_strategy,omitempty"`
 	ReleaseImmutability *bool              `yaml:"release_immutability,omitempty"`
+	VulnerabilityAlerts *bool              `yaml:"vulnerability_alerts,omitempty"`
 	BranchProtection    []BranchProtection `yaml:"branch_protection,omitempty" validate:"unique=pattern"`
 	Rulesets            []Ruleset          `yaml:"rulesets,omitempty"          validate:"unique=name"`
 	Secrets             []Secret           `yaml:"secrets,omitempty"           validate:"unique=name"`

--- a/internal/manifest/repository_types.go
+++ b/internal/manifest/repository_types.go
@@ -80,12 +80,19 @@ type RepositorySpec struct {
 	Features            *Features          `yaml:"features,omitempty"`
 	MergeStrategy       *MergeStrategy     `yaml:"merge_strategy,omitempty"`
 	ReleaseImmutability *bool              `yaml:"release_immutability,omitempty"`
-	VulnerabilityAlerts *bool              `yaml:"vulnerability_alerts,omitempty"`
+	Security            *Security          `yaml:"security,omitempty"`
 	BranchProtection    []BranchProtection `yaml:"branch_protection,omitempty" validate:"unique=pattern"`
 	Rulesets            []Ruleset          `yaml:"rulesets,omitempty"          validate:"unique=name"`
 	Secrets             []Secret           `yaml:"secrets,omitempty"           validate:"unique=name"`
 	Variables           []Variable         `yaml:"variables,omitempty"         validate:"unique=name"`
 	Actions             *Actions           `yaml:"actions,omitempty"`
+}
+
+// Security groups GitHub Advanced Security related repository settings,
+// mirroring the "Advanced Security" section of the GitHub repository
+// settings UI.
+type Security struct {
+	VulnerabilityAlerts *bool `yaml:"vulnerability_alerts,omitempty"`
 }
 
 type Features struct {

--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -195,10 +195,22 @@ func (p *Processor) applyAllSettings(ctx context.Context, repo *manifest.Reposit
 		}
 	}
 
-	// Vulnerability alerts (Dependabot)
-	if s := repo.Spec.Security; s != nil && s.VulnerabilityAlerts != nil {
-		if err := p.applyVulnerabilityAlerts(ctx, owner, name, *s.VulnerabilityAlerts); err != nil {
-			return err
+	// Security (Advanced Security)
+	if s := repo.Spec.Security; s != nil {
+		if s.VulnerabilityAlerts != nil {
+			if err := p.applyVulnerabilityAlerts(ctx, owner, name, *s.VulnerabilityAlerts); err != nil {
+				return err
+			}
+		}
+		if s.AutomatedSecurityFixes != nil {
+			if err := p.applyAutomatedSecurityFixes(ctx, owner, name, *s.AutomatedSecurityFixes); err != nil {
+				return err
+			}
+		}
+		if s.PrivateVulnerabilityReporting != nil {
+			if err := p.applyPrivateVulnerabilityReporting(ctx, owner, name, *s.PrivateVulnerabilityReporting); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -366,6 +378,20 @@ func (p *Processor) applyRepoSetting(ctx context.Context, c Change, repo *manife
 		}
 		return p.applyVulnerabilityAlerts(ctx, owner, name, enabled)
 
+	case "automated_security_fixes":
+		enabled, ok := c.NewValue.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type for %s: %T", c.Field, c.NewValue)
+		}
+		return p.applyAutomatedSecurityFixes(ctx, owner, name, enabled)
+
+	case "private_vulnerability_reporting":
+		enabled, ok := c.NewValue.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type for %s: %T", c.Field, c.NewValue)
+		}
+		return p.applyPrivateVulnerabilityReporting(ctx, owner, name, enabled)
+
 	case "issues":
 		v, ok := c.NewValue.(bool)
 		if !ok {
@@ -497,6 +523,28 @@ func (p *Processor) applyVulnerabilityAlerts(ctx context.Context, owner, name st
 	}
 	_, err := p.runner.Run(ctx, "api", endpoint, "--method", "DELETE")
 	return wrapError(err, fullName, "vulnerability_alerts")
+}
+
+func (p *Processor) applyAutomatedSecurityFixes(ctx context.Context, owner, name string, enable bool) error {
+	endpoint := fmt.Sprintf("repos/%s/%s/automated-security-fixes", owner, name)
+	fullName := owner + "/" + name
+	if enable {
+		_, err := p.runner.Run(ctx, "api", endpoint, "--method", "PUT")
+		return wrapError(err, fullName, "automated_security_fixes")
+	}
+	_, err := p.runner.Run(ctx, "api", endpoint, "--method", "DELETE")
+	return wrapError(err, fullName, "automated_security_fixes")
+}
+
+func (p *Processor) applyPrivateVulnerabilityReporting(ctx context.Context, owner, name string, enable bool) error {
+	endpoint := fmt.Sprintf("repos/%s/%s/private-vulnerability-reporting", owner, name)
+	fullName := owner + "/" + name
+	if enable {
+		_, err := p.runner.Run(ctx, "api", endpoint, "--method", "PUT")
+		return wrapError(err, fullName, "private_vulnerability_reporting")
+	}
+	_, err := p.runner.Run(ctx, "api", endpoint, "--method", "DELETE")
+	return wrapError(err, fullName, "private_vulnerability_reporting")
 }
 
 func (p *Processor) applyBranchProtection(ctx context.Context, c Change, repo *manifest.Repository) error {

--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -196,8 +196,8 @@ func (p *Processor) applyAllSettings(ctx context.Context, repo *manifest.Reposit
 	}
 
 	// Vulnerability alerts (Dependabot)
-	if repo.Spec.VulnerabilityAlerts != nil {
-		if err := p.applyVulnerabilityAlerts(ctx, owner, name, *repo.Spec.VulnerabilityAlerts); err != nil {
+	if s := repo.Spec.Security; s != nil && s.VulnerabilityAlerts != nil {
+		if err := p.applyVulnerabilityAlerts(ctx, owner, name, *s.VulnerabilityAlerts); err != nil {
 			return err
 		}
 	}

--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -195,6 +195,13 @@ func (p *Processor) applyAllSettings(ctx context.Context, repo *manifest.Reposit
 		}
 	}
 
+	// Vulnerability alerts (Dependabot)
+	if repo.Spec.VulnerabilityAlerts != nil {
+		if err := p.applyVulnerabilityAlerts(ctx, owner, name, *repo.Spec.VulnerabilityAlerts); err != nil {
+			return err
+		}
+	}
+
 	// Actions (permissions, workflow defaults, selected actions, fork PR)
 	if a := repo.Spec.Actions; a != nil && a.Enabled != nil {
 		if err := p.applyActionsPermissions(ctx, owner, name, a); err != nil {
@@ -352,6 +359,13 @@ func (p *Processor) applyRepoSetting(ctx context.Context, c Change, repo *manife
 		}
 		return p.applyReleaseImmutability(ctx, owner, name, enabled)
 
+	case "vulnerability_alerts":
+		enabled, ok := c.NewValue.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type for %s: %T", c.Field, c.NewValue)
+		}
+		return p.applyVulnerabilityAlerts(ctx, owner, name, enabled)
+
 	case "issues":
 		v, ok := c.NewValue.(bool)
 		if !ok {
@@ -472,6 +486,17 @@ func (p *Processor) applyReleaseImmutability(ctx context.Context, owner, name st
 	}
 	_, err := p.runner.Run(ctx, "api", endpoint, "--method", "DELETE")
 	return wrapError(err, fullName, "release_immutability")
+}
+
+func (p *Processor) applyVulnerabilityAlerts(ctx context.Context, owner, name string, enable bool) error {
+	endpoint := fmt.Sprintf("repos/%s/%s/vulnerability-alerts", owner, name)
+	fullName := owner + "/" + name
+	if enable {
+		_, err := p.runner.Run(ctx, "api", endpoint, "--method", "PUT")
+		return wrapError(err, fullName, "vulnerability_alerts")
+	}
+	_, err := p.runner.Run(ctx, "api", endpoint, "--method", "DELETE")
+	return wrapError(err, fullName, "vulnerability_alerts")
 }
 
 func (p *Processor) applyBranchProtection(ctx context.Context, c Change, repo *manifest.Repository) error {

--- a/internal/repository/apply_test.go
+++ b/internal/repository/apply_test.go
@@ -185,42 +185,52 @@ func TestApplyFeatureToggle(t *testing.T) {
 	}
 }
 
-func TestApplyVulnerabilityAlerts(t *testing.T) {
+func TestApplySecurityFields(t *testing.T) {
 	tests := []struct {
-		name       string
-		newValue   bool
-		wantMethod string
+		name         string
+		field        string
+		wantEndpoint string
 	}{
-		{"enable", true, "PUT"},
-		{"disable", false, "DELETE"},
+		{"vulnerability_alerts", "vulnerability_alerts", "repos/myorg/myrepo/vulnerability-alerts"},
+		{"automated_security_fixes", "automated_security_fixes", "repos/myorg/myrepo/automated-security-fixes"},
+		{"private_vulnerability_reporting", "private_vulnerability_reporting", "repos/myorg/myrepo/private-vulnerability-reporting"},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mock := &gh.MockRunner{}
-			proc := NewProcessor(mock, nil, nil)
+		for _, sub := range []struct {
+			name       string
+			newValue   bool
+			wantMethod string
+		}{
+			{"enable", true, "PUT"},
+			{"disable", false, "DELETE"},
+		} {
+			t.Run(tt.name+"/"+sub.name, func(t *testing.T) {
+				mock := &gh.MockRunner{}
+				proc := NewProcessor(mock, nil, nil)
 
-			repo := newTestRepo("myorg", "myrepo")
-			changes := []Change{
-				{
-					Type:     ChangeUpdate,
-					Resource: "Repository",
-					Name:     "myorg/myrepo",
-					Field:    "vulnerability_alerts",
-					NewValue: tt.newValue,
-				},
-			}
+				repo := newTestRepo("myorg", "myrepo")
+				changes := []Change{
+					{
+						Type:     ChangeUpdate,
+						Resource: "Repository",
+						Name:     "myorg/myrepo",
+						Field:    tt.field,
+						NewValue: sub.newValue,
+					},
+				}
 
-			results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
-			if results[0].Err != nil {
-				t.Fatalf("unexpected error: %v", results[0].Err)
-			}
-			args := mock.Called[0]
-			expected := []string{"api", "repos/myorg/myrepo/vulnerability-alerts", "--method", tt.wantMethod}
-			if strings.Join(args, " ") != strings.Join(expected, " ") {
-				t.Errorf("args: got %v, want %v", args, expected)
-			}
-		})
+				results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+				if results[0].Err != nil {
+					t.Fatalf("unexpected error: %v", results[0].Err)
+				}
+				args := mock.Called[0]
+				expected := []string{"api", tt.wantEndpoint, "--method", sub.wantMethod}
+				if strings.Join(args, " ") != strings.Join(expected, " ") {
+					t.Errorf("args: got %v, want %v", args, expected)
+				}
+			})
+		}
 	}
 }
 
@@ -228,6 +238,8 @@ func TestApplyRepoSetting_BoolTypeAssertionError(t *testing.T) {
 	boolFields := []string{
 		"release_immutability",
 		"vulnerability_alerts",
+		"automated_security_fixes",
+		"private_vulnerability_reporting",
 		"issues",
 		"projects",
 		"wiki",

--- a/internal/repository/apply_test.go
+++ b/internal/repository/apply_test.go
@@ -185,9 +185,49 @@ func TestApplyFeatureToggle(t *testing.T) {
 	}
 }
 
+func TestApplyVulnerabilityAlerts(t *testing.T) {
+	tests := []struct {
+		name       string
+		newValue   bool
+		wantMethod string
+	}{
+		{"enable", true, "PUT"},
+		{"disable", false, "DELETE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &gh.MockRunner{}
+			proc := NewProcessor(mock, nil, nil)
+
+			repo := newTestRepo("myorg", "myrepo")
+			changes := []Change{
+				{
+					Type:     ChangeUpdate,
+					Resource: "Repository",
+					Name:     "myorg/myrepo",
+					Field:    "vulnerability_alerts",
+					NewValue: tt.newValue,
+				},
+			}
+
+			results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+			if results[0].Err != nil {
+				t.Fatalf("unexpected error: %v", results[0].Err)
+			}
+			args := mock.Called[0]
+			expected := []string{"api", "repos/myorg/myrepo/vulnerability-alerts", "--method", tt.wantMethod}
+			if strings.Join(args, " ") != strings.Join(expected, " ") {
+				t.Errorf("args: got %v, want %v", args, expected)
+			}
+		})
+	}
+}
+
 func TestApplyRepoSetting_BoolTypeAssertionError(t *testing.T) {
 	boolFields := []string{
 		"release_immutability",
+		"vulnerability_alerts",
 		"issues",
 		"projects",
 		"wiki",

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -104,8 +104,20 @@ func Diff(ctx context.Context, desired *manifest.Repository, current *CurrentSta
 	changes = append(changes, diffLabels(name, desired, current, manifest.LabelSyncMode(desired.Spec.LabelSync))...)
 	changes = append(changes, diffMilestones(name, desired, current)...)
 	changes = append(changes, diffActions(name, desired, current)...)
+	changes = append(changes, diffSecurity(name, desired, current)...)
 
 	return changes
+}
+
+func diffSecurity(name string, desired *manifest.Repository, current *CurrentState) []Change {
+	if desired.Spec.Security == nil {
+		return nil
+	}
+	dc := diffContext{resource: manifest.ResourceRepository, name: name}
+	s := desired.Spec.Security
+	return dc.group("security", func(cc *[]Change) {
+		appendChildChanged(cc, "vulnerability_alerts", s.VulnerabilityAlerts, current.VulnerabilityAlerts)
+	})
 }
 
 func diffRepoSettings(name string, desired *manifest.Repository, current *CurrentState) []Change {
@@ -117,7 +129,6 @@ func diffRepoSettings(name string, desired *manifest.Repository, current *Curren
 	appendChanged(dc, &changes, "visibility", desired.Spec.Visibility, current.Visibility)
 	appendChanged(dc, &changes, "archived", desired.Spec.Archived, current.Archived)
 	appendChanged(dc, &changes, "release_immutability", desired.Spec.ReleaseImmutability, current.ReleaseImmutability)
-	appendChanged(dc, &changes, "vulnerability_alerts", desired.Spec.VulnerabilityAlerts, current.VulnerabilityAlerts)
 
 	if len(desired.Spec.Topics) > 0 || len(current.Topics) > 0 {
 		if !stringSliceEqual(desired.Spec.Topics, current.Topics) {

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -117,6 +117,7 @@ func diffRepoSettings(name string, desired *manifest.Repository, current *Curren
 	appendChanged(dc, &changes, "visibility", desired.Spec.Visibility, current.Visibility)
 	appendChanged(dc, &changes, "archived", desired.Spec.Archived, current.Archived)
 	appendChanged(dc, &changes, "release_immutability", desired.Spec.ReleaseImmutability, current.ReleaseImmutability)
+	appendChanged(dc, &changes, "vulnerability_alerts", desired.Spec.VulnerabilityAlerts, current.VulnerabilityAlerts)
 
 	if len(desired.Spec.Topics) > 0 || len(current.Topics) > 0 {
 		if !stringSliceEqual(desired.Spec.Topics, current.Topics) {

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -89,7 +89,7 @@ func ValidateDependencies(desired *manifest.Repository, current *CurrentState) e
 	if s == nil || s.AutomatedSecurityFixes == nil || !*s.AutomatedSecurityFixes {
 		return nil
 	}
-	effectiveAlerts := current.VulnerabilityAlerts
+	effectiveAlerts := current.Security.VulnerabilityAlerts
 	if s.VulnerabilityAlerts != nil {
 		effectiveAlerts = *s.VulnerabilityAlerts
 	}
@@ -142,9 +142,9 @@ func diffSecurity(name string, desired *manifest.Repository, current *CurrentSta
 	dc := diffContext{resource: manifest.ResourceRepository, name: name}
 	s := desired.Spec.Security
 	return dc.group("security", func(cc *[]Change) {
-		appendChildChanged(cc, "vulnerability_alerts", s.VulnerabilityAlerts, current.VulnerabilityAlerts)
-		appendChildChanged(cc, "automated_security_fixes", s.AutomatedSecurityFixes, current.AutomatedSecurityFixes)
-		appendChildChanged(cc, "private_vulnerability_reporting", s.PrivateVulnerabilityReporting, current.PrivateVulnerabilityReporting)
+		appendChildChanged(cc, "vulnerability_alerts", s.VulnerabilityAlerts, current.Security.VulnerabilityAlerts)
+		appendChildChanged(cc, "automated_security_fixes", s.AutomatedSecurityFixes, current.Security.AutomatedSecurityFixes)
+		appendChildChanged(cc, "private_vulnerability_reporting", s.PrivateVulnerabilityReporting, current.Security.PrivateVulnerabilityReporting)
 	})
 }
 

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -73,6 +73,32 @@ func (dc diffContext) group(field string, childFn func(cc *[]Change)) []Change {
 	}}
 }
 
+// ValidateDependencies verifies cross-field dependencies between the desired
+// manifest and the current GitHub state that cannot be checked by the offline
+// validate step (which has no access to remote state).
+//
+// The "effective" state of a field is `desired` when the manifest sets it and
+// `current` otherwise (omission means "leave as-is"). A dependency is violated
+// when the effective state of a dependent field is incompatible.
+//
+// Currently checks:
+//   - security.automated_security_fixes requires security.vulnerability_alerts
+//     to be effectively true. Required by the GitHub API.
+func ValidateDependencies(desired *manifest.Repository, current *CurrentState) error {
+	s := desired.Spec.Security
+	if s == nil || s.AutomatedSecurityFixes == nil || !*s.AutomatedSecurityFixes {
+		return nil
+	}
+	effectiveAlerts := current.VulnerabilityAlerts
+	if s.VulnerabilityAlerts != nil {
+		effectiveAlerts = *s.VulnerabilityAlerts
+	}
+	if !effectiveAlerts {
+		return fmt.Errorf("security.automated_security_fixes: true requires security.vulnerability_alerts to be enabled (current state is disabled and the manifest does not enable it)")
+	}
+	return nil
+}
+
 // Diff compares desired state with current state and returns changes.
 // If the repository does not exist (current.IsNew), a single ChangeCreate is returned.
 func Diff(ctx context.Context, desired *manifest.Repository, current *CurrentState, opts ...DiffOptions) []Change {
@@ -117,6 +143,8 @@ func diffSecurity(name string, desired *manifest.Repository, current *CurrentSta
 	s := desired.Spec.Security
 	return dc.group("security", func(cc *[]Change) {
 		appendChildChanged(cc, "vulnerability_alerts", s.VulnerabilityAlerts, current.VulnerabilityAlerts)
+		appendChildChanged(cc, "automated_security_fixes", s.AutomatedSecurityFixes, current.AutomatedSecurityFixes)
+		appendChildChanged(cc, "private_vulnerability_reporting", s.PrivateVulnerabilityReporting, current.PrivateVulnerabilityReporting)
 	})
 }
 

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -392,7 +392,7 @@ func TestValidateDependencies(t *testing.T) {
 				d.Spec.Security = &manifest.Security{}
 				tt.setupSpec(d.Spec.Security)
 			}
-			c := &CurrentState{VulnerabilityAlerts: tt.currentVA}
+			c := &CurrentState{Security: CurrentSecurity{VulnerabilityAlerts: tt.currentVA}}
 
 			err := ValidateDependencies(d, c)
 			if tt.wantErr {
@@ -428,19 +428,19 @@ func TestDiff_Security(t *testing.T) {
 		{
 			name:      "vulnerability_alerts",
 			setDesire: func(s *manifest.Security) { s.VulnerabilityAlerts = manifest.Ptr(true) },
-			setCur:    func(c *CurrentState) { c.VulnerabilityAlerts = false },
+			setCur:    func(c *CurrentState) { c.Security.VulnerabilityAlerts = false },
 			field:     "vulnerability_alerts",
 		},
 		{
 			name:      "automated_security_fixes",
 			setDesire: func(s *manifest.Security) { s.AutomatedSecurityFixes = manifest.Ptr(true) },
-			setCur:    func(c *CurrentState) { c.AutomatedSecurityFixes = false },
+			setCur:    func(c *CurrentState) { c.Security.AutomatedSecurityFixes = false },
 			field:     "automated_security_fixes",
 		},
 		{
 			name:      "private_vulnerability_reporting",
 			setDesire: func(s *manifest.Security) { s.PrivateVulnerabilityReporting = manifest.Ptr(true) },
-			setCur:    func(c *CurrentState) { c.PrivateVulnerabilityReporting = false },
+			setCur:    func(c *CurrentState) { c.Security.PrivateVulnerabilityReporting = false },
 			field:     "private_vulnerability_reporting",
 		},
 	}

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -132,26 +132,6 @@ func TestDiff_RepoSettings(t *testing.T) {
 			},
 			wantCount: 0,
 		},
-		{
-			name: "vulnerability_alerts enable",
-			setup: func(d *manifest.Repository, c *CurrentState) {
-				d.Spec.VulnerabilityAlerts = manifest.Ptr(true)
-				c.VulnerabilityAlerts = false
-			},
-			wantCount: 1,
-			wantField: "vulnerability_alerts",
-			wantType:  ChangeUpdate,
-			wantOld:   false,
-			wantNew:   true,
-		},
-		{
-			name: "vulnerability_alerts same no change",
-			setup: func(d *manifest.Repository, c *CurrentState) {
-				d.Spec.VulnerabilityAlerts = manifest.Ptr(true)
-				c.VulnerabilityAlerts = true
-			},
-			wantCount: 0,
-		},
 	}
 
 	for _, tt := range tests {
@@ -342,6 +322,54 @@ func TestDiff_MergeStrategy_BoolFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDiff_Security(t *testing.T) {
+	t.Run("nil security is noop", func(t *testing.T) {
+		d := baseDesired()
+		d.Spec.Security = nil
+		c := baseState()
+		if changes := diffSecurity("org/repo", d, c); len(changes) != 0 {
+			t.Errorf("expected no changes when security is nil, got %d", len(changes))
+		}
+	})
+
+	t.Run("vulnerability_alerts enable", func(t *testing.T) {
+		d := baseDesired()
+		d.Spec.Security = &manifest.Security{VulnerabilityAlerts: manifest.Ptr(true)}
+		c := baseState()
+		c.VulnerabilityAlerts = false
+
+		changes := diffSecurity("org/repo", d, c)
+		if len(changes) != 1 {
+			t.Fatalf("expected 1 parent change, got %d", len(changes))
+		}
+		if changes[0].Field != "security" {
+			t.Errorf("expected parent field 'security', got %q", changes[0].Field)
+		}
+		if len(changes[0].Children) != 1 {
+			t.Fatalf("expected 1 child, got %d", len(changes[0].Children))
+		}
+		child := changes[0].Children[0]
+		if child.Field != "vulnerability_alerts" {
+			t.Errorf("expected child field 'vulnerability_alerts', got %q", child.Field)
+		}
+		if child.NewValue != true {
+			t.Errorf("expected NewValue=true, got %v", child.NewValue)
+		}
+	})
+
+	t.Run("vulnerability_alerts no change", func(t *testing.T) {
+		d := baseDesired()
+		d.Spec.Security = &manifest.Security{VulnerabilityAlerts: manifest.Ptr(true)}
+		c := baseState()
+		c.VulnerabilityAlerts = true
+
+		changes := diffSecurity("org/repo", d, c)
+		if len(changes) != 0 {
+			t.Errorf("expected no changes, got %d", len(changes))
+		}
+	})
 }
 
 func TestDiff_Features_BoolNoChange(t *testing.T) {

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -324,6 +324,91 @@ func TestDiff_MergeStrategy_BoolFlags(t *testing.T) {
 	}
 }
 
+func TestValidateDependencies(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupSpec   func(s *manifest.Security)
+		currentVA   bool
+		wantErr     bool
+		wantErrText string
+	}{
+		{
+			name:      "no security: ok",
+			setupSpec: nil,
+			wantErr:   false,
+		},
+		{
+			name:      "fixes nil: ok",
+			setupSpec: func(s *manifest.Security) {},
+			wantErr:   false,
+		},
+		{
+			name:      "fixes false: ok regardless of alerts",
+			setupSpec: func(s *manifest.Security) { s.AutomatedSecurityFixes = manifest.Ptr(false) },
+			wantErr:   false,
+		},
+		{
+			name: "fixes true + alerts true (manifest): ok",
+			setupSpec: func(s *manifest.Security) {
+				s.AutomatedSecurityFixes = manifest.Ptr(true)
+				s.VulnerabilityAlerts = manifest.Ptr(true)
+			},
+			wantErr: false,
+		},
+		{
+			name: "fixes true + alerts false (manifest): error",
+			setupSpec: func(s *manifest.Security) {
+				s.AutomatedSecurityFixes = manifest.Ptr(true)
+				s.VulnerabilityAlerts = manifest.Ptr(false)
+			},
+			wantErr:     true,
+			wantErrText: "automated_security_fixes",
+		},
+		{
+			name: "fixes true + alerts omitted, current=true: ok (effective true)",
+			setupSpec: func(s *manifest.Security) {
+				s.AutomatedSecurityFixes = manifest.Ptr(true)
+			},
+			currentVA: true,
+			wantErr:   false,
+		},
+		{
+			name: "fixes true + alerts omitted, current=false: error",
+			setupSpec: func(s *manifest.Security) {
+				s.AutomatedSecurityFixes = manifest.Ptr(true)
+			},
+			currentVA:   false,
+			wantErr:     true,
+			wantErrText: "automated_security_fixes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &manifest.Repository{
+				Spec: manifest.RepositorySpec{},
+			}
+			if tt.setupSpec != nil {
+				d.Spec.Security = &manifest.Security{}
+				tt.setupSpec(d.Spec.Security)
+			}
+			c := &CurrentState{VulnerabilityAlerts: tt.currentVA}
+
+			err := ValidateDependencies(d, c)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantErrText, err)
+				}
+			} else if err != nil {
+				t.Errorf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestDiff_Security(t *testing.T) {
 	t.Run("nil security is noop", func(t *testing.T) {
 		d := baseDesired()
@@ -334,40 +419,75 @@ func TestDiff_Security(t *testing.T) {
 		}
 	})
 
-	t.Run("vulnerability_alerts enable", func(t *testing.T) {
+	fields := []struct {
+		name      string
+		setDesire func(s *manifest.Security)
+		setCur    func(c *CurrentState)
+		field     string
+	}{
+		{
+			name:      "vulnerability_alerts",
+			setDesire: func(s *manifest.Security) { s.VulnerabilityAlerts = manifest.Ptr(true) },
+			setCur:    func(c *CurrentState) { c.VulnerabilityAlerts = false },
+			field:     "vulnerability_alerts",
+		},
+		{
+			name:      "automated_security_fixes",
+			setDesire: func(s *manifest.Security) { s.AutomatedSecurityFixes = manifest.Ptr(true) },
+			setCur:    func(c *CurrentState) { c.AutomatedSecurityFixes = false },
+			field:     "automated_security_fixes",
+		},
+		{
+			name:      "private_vulnerability_reporting",
+			setDesire: func(s *manifest.Security) { s.PrivateVulnerabilityReporting = manifest.Ptr(true) },
+			setCur:    func(c *CurrentState) { c.PrivateVulnerabilityReporting = false },
+			field:     "private_vulnerability_reporting",
+		},
+	}
+
+	for _, f := range fields {
+		t.Run(f.name+" enable", func(t *testing.T) {
+			d := baseDesired()
+			d.Spec.Security = &manifest.Security{}
+			f.setDesire(d.Spec.Security)
+			c := baseState()
+			f.setCur(c)
+
+			changes := diffSecurity("org/repo", d, c)
+			if len(changes) != 1 {
+				t.Fatalf("expected 1 parent change, got %d", len(changes))
+			}
+			if changes[0].Field != "security" {
+				t.Errorf("expected parent field 'security', got %q", changes[0].Field)
+			}
+			if len(changes[0].Children) != 1 {
+				t.Fatalf("expected 1 child, got %d", len(changes[0].Children))
+			}
+			child := changes[0].Children[0]
+			if child.Field != f.field {
+				t.Errorf("expected child field %q, got %q", f.field, child.Field)
+			}
+			if child.NewValue != true {
+				t.Errorf("expected NewValue=true, got %v", child.NewValue)
+			}
+		})
+	}
+
+	t.Run("multiple fields produce multiple children", func(t *testing.T) {
 		d := baseDesired()
-		d.Spec.Security = &manifest.Security{VulnerabilityAlerts: manifest.Ptr(true)}
+		d.Spec.Security = &manifest.Security{
+			VulnerabilityAlerts:           manifest.Ptr(true),
+			AutomatedSecurityFixes:        manifest.Ptr(true),
+			PrivateVulnerabilityReporting: manifest.Ptr(true),
+		}
 		c := baseState()
-		c.VulnerabilityAlerts = false
 
 		changes := diffSecurity("org/repo", d, c)
 		if len(changes) != 1 {
 			t.Fatalf("expected 1 parent change, got %d", len(changes))
 		}
-		if changes[0].Field != "security" {
-			t.Errorf("expected parent field 'security', got %q", changes[0].Field)
-		}
-		if len(changes[0].Children) != 1 {
-			t.Fatalf("expected 1 child, got %d", len(changes[0].Children))
-		}
-		child := changes[0].Children[0]
-		if child.Field != "vulnerability_alerts" {
-			t.Errorf("expected child field 'vulnerability_alerts', got %q", child.Field)
-		}
-		if child.NewValue != true {
-			t.Errorf("expected NewValue=true, got %v", child.NewValue)
-		}
-	})
-
-	t.Run("vulnerability_alerts no change", func(t *testing.T) {
-		d := baseDesired()
-		d.Spec.Security = &manifest.Security{VulnerabilityAlerts: manifest.Ptr(true)}
-		c := baseState()
-		c.VulnerabilityAlerts = true
-
-		changes := diffSecurity("org/repo", d, c)
-		if len(changes) != 0 {
-			t.Errorf("expected no changes, got %d", len(changes))
+		if got := len(changes[0].Children); got != 3 {
+			t.Errorf("expected 3 children, got %d", got)
 		}
 	})
 }

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -132,6 +132,26 @@ func TestDiff_RepoSettings(t *testing.T) {
 			},
 			wantCount: 0,
 		},
+		{
+			name: "vulnerability_alerts enable",
+			setup: func(d *manifest.Repository, c *CurrentState) {
+				d.Spec.VulnerabilityAlerts = manifest.Ptr(true)
+				c.VulnerabilityAlerts = false
+			},
+			wantCount: 1,
+			wantField: "vulnerability_alerts",
+			wantType:  ChangeUpdate,
+			wantOld:   false,
+			wantNew:   true,
+		},
+		{
+			name: "vulnerability_alerts same no change",
+			setup: func(d *manifest.Repository, c *CurrentState) {
+				d.Spec.VulnerabilityAlerts = manifest.Ptr(true)
+				c.VulnerabilityAlerts = true
+			},
+			wantCount: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/repository/export.go
+++ b/internal/repository/export.go
@@ -23,6 +23,7 @@ func ToManifest(ctx context.Context, r *CurrentState, resolver *manifest.Resolve
 			Archived:            manifest.Ptr(r.Archived),
 			Topics:              r.Topics,
 			ReleaseImmutability: manifest.Ptr(r.ReleaseImmutability),
+			VulnerabilityAlerts: manifest.Ptr(r.VulnerabilityAlerts),
 			Features: &manifest.Features{
 				Issues:      manifest.Ptr(r.Features.Issues),
 				Projects:    manifest.Ptr(r.Features.Projects),

--- a/internal/repository/export.go
+++ b/internal/repository/export.go
@@ -24,9 +24,9 @@ func ToManifest(ctx context.Context, r *CurrentState, resolver *manifest.Resolve
 			Topics:              r.Topics,
 			ReleaseImmutability: manifest.Ptr(r.ReleaseImmutability),
 			Security: &manifest.Security{
-				VulnerabilityAlerts:           manifest.Ptr(r.VulnerabilityAlerts),
-				AutomatedSecurityFixes:        manifest.Ptr(r.AutomatedSecurityFixes),
-				PrivateVulnerabilityReporting: manifest.Ptr(r.PrivateVulnerabilityReporting),
+				VulnerabilityAlerts:           manifest.Ptr(r.Security.VulnerabilityAlerts),
+				AutomatedSecurityFixes:        manifest.Ptr(r.Security.AutomatedSecurityFixes),
+				PrivateVulnerabilityReporting: manifest.Ptr(r.Security.PrivateVulnerabilityReporting),
 			},
 			Features: &manifest.Features{
 				Issues:      manifest.Ptr(r.Features.Issues),

--- a/internal/repository/export.go
+++ b/internal/repository/export.go
@@ -24,7 +24,9 @@ func ToManifest(ctx context.Context, r *CurrentState, resolver *manifest.Resolve
 			Topics:              r.Topics,
 			ReleaseImmutability: manifest.Ptr(r.ReleaseImmutability),
 			Security: &manifest.Security{
-				VulnerabilityAlerts: manifest.Ptr(r.VulnerabilityAlerts),
+				VulnerabilityAlerts:           manifest.Ptr(r.VulnerabilityAlerts),
+				AutomatedSecurityFixes:        manifest.Ptr(r.AutomatedSecurityFixes),
+				PrivateVulnerabilityReporting: manifest.Ptr(r.PrivateVulnerabilityReporting),
 			},
 			Features: &manifest.Features{
 				Issues:      manifest.Ptr(r.Features.Issues),

--- a/internal/repository/export.go
+++ b/internal/repository/export.go
@@ -23,7 +23,9 @@ func ToManifest(ctx context.Context, r *CurrentState, resolver *manifest.Resolve
 			Archived:            manifest.Ptr(r.Archived),
 			Topics:              r.Topics,
 			ReleaseImmutability: manifest.Ptr(r.ReleaseImmutability),
-			VulnerabilityAlerts: manifest.Ptr(r.VulnerabilityAlerts),
+			Security: &manifest.Security{
+				VulnerabilityAlerts: manifest.Ptr(r.VulnerabilityAlerts),
+			},
 			Features: &manifest.Features{
 				Issues:      manifest.Ptr(r.Features.Issues),
 				Projects:    manifest.Ptr(r.Features.Projects),

--- a/internal/repository/plan.go
+++ b/internal/repository/plan.go
@@ -69,6 +69,17 @@ func (p *Processor) Plan(ctx context.Context, repos []*manifest.Repository, opts
 			return repoResult{index: idx, repo: r, err: err}
 		}
 
+		// Cross-field dependencies that need current state to evaluate.
+		// Only relevant for existing repos; for new repos these are validated
+		// implicitly by ordering during create+apply.
+		if !current.IsNew {
+			if err := ValidateDependencies(r, current); err != nil {
+				logger.Error("dependency validation failed", "repo", fullName, "err", err)
+				tracker.Error(fullName, err)
+				return repoResult{index: idx, repo: r, err: err}
+			}
+		}
+
 		changes := Diff(ctx, r, current, diffOpts)
 		logger.Debug("diff done", "repo", fullName, "changes", len(changes))
 		tracker.Done(fullName)

--- a/internal/repository/state.go
+++ b/internal/repository/state.go
@@ -110,6 +110,57 @@ func (p *Processor) FetchRepository(ctx context.Context, owner, name string, onS
 		return err
 	})
 
+	var (
+		vulnerabilityAlerts           bool
+		automatedSecurityFixes        bool
+		privateVulnerabilityReporting bool
+	)
+
+	// Fetch vulnerability alerts (Dependabot) setting via dedicated REST API endpoint.
+	// 404 is the documented "disabled" response and is handled inside the fetcher;
+	// 403 is ignored gracefully (e.g. GHES without support); other errors propagate.
+	g.Go(func() error {
+		status("fetching vulnerability alerts...")
+		v, err := p.fetchVulnerabilityAlerts(ctx, owner, name)
+		if err != nil {
+			if errors.Is(err, gh.ErrForbidden) {
+				return nil
+			}
+			return fmt.Errorf("fetch vulnerability alerts for %s/%s: %w", owner, name, err)
+		}
+		vulnerabilityAlerts = v
+		return nil
+	})
+
+	// Fetch Dependabot security updates (automated security fixes) via dedicated endpoint.
+	// 404 may also indicate the feature is unavailable on the repo; treat as disabled.
+	g.Go(func() error {
+		status("fetching automated security fixes...")
+		v, err := p.fetchAutomatedSecurityFixes(ctx, owner, name)
+		if err != nil {
+			if errors.Is(err, gh.ErrForbidden) {
+				return nil
+			}
+			return fmt.Errorf("fetch automated security fixes for %s/%s: %w", owner, name, err)
+		}
+		automatedSecurityFixes = v
+		return nil
+	})
+
+	// Fetch private vulnerability reporting setting via dedicated endpoint.
+	g.Go(func() error {
+		status("fetching private vulnerability reporting...")
+		v, err := p.fetchPrivateVulnerabilityReporting(ctx, owner, name)
+		if err != nil {
+			if errors.Is(err, gh.ErrForbidden) {
+				return nil
+			}
+			return fmt.Errorf("fetch private vulnerability reporting for %s/%s: %w", owner, name, err)
+		}
+		privateVulnerabilityReporting = v
+		return nil
+	})
+
 	if err := g.Wait(); err != nil {
 		return nil, err
 	}
@@ -121,6 +172,11 @@ func (p *Processor) FetchRepository(ctx context.Context, owner, name string, onS
 	repo.Labels = labels
 	repo.Milestones = milestones
 	repo.Actions = actions
+	repo.Security = CurrentSecurity{
+		VulnerabilityAlerts:           vulnerabilityAlerts,
+		AutomatedSecurityFixes:        automatedSecurityFixes,
+		PrivateVulnerabilityReporting: privateVulnerabilityReporting,
+	}
 
 	return repo, nil
 }
@@ -181,27 +237,6 @@ func (p *Processor) fetchRepoSettings(ctx context.Context, owner, name string) (
 		return nil, fmt.Errorf("fetch release immutability for %s/%s: %w", owner, name, err)
 	}
 
-	// Fetch vulnerability alerts (Dependabot) setting via dedicated REST API endpoint.
-	// 404 is the documented "disabled" response and is handled inside the fetcher;
-	// 403 is ignored gracefully (e.g. GHES without support); other errors propagate.
-	vulnerabilityAlerts, err := p.fetchVulnerabilityAlerts(ctx, owner, name)
-	if err != nil && !errors.Is(err, gh.ErrForbidden) {
-		return nil, fmt.Errorf("fetch vulnerability alerts for %s/%s: %w", owner, name, err)
-	}
-
-	// Fetch Dependabot security updates (automated security fixes) via dedicated endpoint.
-	// 404 may also indicate the feature is unavailable on the repo; treat as disabled.
-	automatedSecurityFixes, err := p.fetchAutomatedSecurityFixes(ctx, owner, name)
-	if err != nil && !errors.Is(err, gh.ErrForbidden) {
-		return nil, fmt.Errorf("fetch automated security fixes for %s/%s: %w", owner, name, err)
-	}
-
-	// Fetch private vulnerability reporting setting via dedicated endpoint.
-	privateVulnerabilityReporting, err := p.fetchPrivateVulnerabilityReporting(ctx, owner, name)
-	if err != nil && !errors.Is(err, gh.ErrForbidden) {
-		return nil, fmt.Errorf("fetch private vulnerability reporting for %s/%s: %w", owner, name, err)
-	}
-
 	return &CurrentState{
 		Owner:               owner,
 		Name:                name,
@@ -209,11 +244,8 @@ func (p *Processor) fetchRepoSettings(ctx context.Context, owner, name string) (
 		Archived:            raw.IsArchived,
 		Homepage:            raw.HomepageURL,
 		Visibility:          strings.ToLower(raw.Visibility),
-		Topics:                        topics,
-		ReleaseImmutability:           releaseImmutability,
-		VulnerabilityAlerts:           vulnerabilityAlerts,
-		AutomatedSecurityFixes:        automatedSecurityFixes,
-		PrivateVulnerabilityReporting: privateVulnerabilityReporting,
+		Topics:              topics,
+		ReleaseImmutability: releaseImmutability,
 		Features: CurrentFeatures{
 			Issues:      raw.HasIssuesEnabled,
 			Projects:    raw.HasProjectsEnabled,

--- a/internal/repository/state.go
+++ b/internal/repository/state.go
@@ -189,6 +189,19 @@ func (p *Processor) fetchRepoSettings(ctx context.Context, owner, name string) (
 		return nil, fmt.Errorf("fetch vulnerability alerts for %s/%s: %w", owner, name, err)
 	}
 
+	// Fetch Dependabot security updates (automated security fixes) via dedicated endpoint.
+	// 404 may also indicate the feature is unavailable on the repo; treat as disabled.
+	automatedSecurityFixes, err := p.fetchAutomatedSecurityFixes(ctx, owner, name)
+	if err != nil && !errors.Is(err, gh.ErrForbidden) {
+		return nil, fmt.Errorf("fetch automated security fixes for %s/%s: %w", owner, name, err)
+	}
+
+	// Fetch private vulnerability reporting setting via dedicated endpoint.
+	privateVulnerabilityReporting, err := p.fetchPrivateVulnerabilityReporting(ctx, owner, name)
+	if err != nil && !errors.Is(err, gh.ErrForbidden) {
+		return nil, fmt.Errorf("fetch private vulnerability reporting for %s/%s: %w", owner, name, err)
+	}
+
 	return &CurrentState{
 		Owner:               owner,
 		Name:                name,
@@ -196,9 +209,11 @@ func (p *Processor) fetchRepoSettings(ctx context.Context, owner, name string) (
 		Archived:            raw.IsArchived,
 		Homepage:            raw.HomepageURL,
 		Visibility:          strings.ToLower(raw.Visibility),
-		Topics:              topics,
-		ReleaseImmutability: releaseImmutability,
-		VulnerabilityAlerts: vulnerabilityAlerts,
+		Topics:                        topics,
+		ReleaseImmutability:           releaseImmutability,
+		VulnerabilityAlerts:           vulnerabilityAlerts,
+		AutomatedSecurityFixes:        automatedSecurityFixes,
+		PrivateVulnerabilityReporting: privateVulnerabilityReporting,
 		Features: CurrentFeatures{
 			Issues:      raw.HasIssuesEnabled,
 			Projects:    raw.HasProjectsEnabled,
@@ -290,6 +305,50 @@ func (p *Processor) fetchVulnerabilityAlerts(ctx context.Context, owner, name st
 		return false, err
 	}
 	return true, nil
+}
+
+// fetchAutomatedSecurityFixes returns whether Dependabot security updates
+// (automated security fixes) are enabled on the repository.
+// The endpoint may return 404 when the feature is unavailable on the repo
+// (e.g. vulnerability alerts disabled); treat that as disabled.
+func (p *Processor) fetchAutomatedSecurityFixes(ctx context.Context, owner, name string) (bool, error) {
+	out, err := p.runner.Run(ctx,
+		"api", fmt.Sprintf("repos/%s/%s/automated-security-fixes", owner, name),
+	)
+	if err != nil {
+		if errors.Is(err, gh.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	var raw struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return false, err
+	}
+	return raw.Enabled, nil
+}
+
+// fetchPrivateVulnerabilityReporting returns whether private vulnerability
+// reporting is enabled on the repository.
+func (p *Processor) fetchPrivateVulnerabilityReporting(ctx context.Context, owner, name string) (bool, error) {
+	out, err := p.runner.Run(ctx,
+		"api", fmt.Sprintf("repos/%s/%s/private-vulnerability-reporting", owner, name),
+	)
+	if err != nil {
+		if errors.Is(err, gh.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	var raw struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return false, err
+	}
+	return raw.Enabled, nil
 }
 
 func (p *Processor) fetchBranchProtection(ctx context.Context, owner, name string) (map[string]*CurrentBranchProtection, error) {

--- a/internal/repository/state.go
+++ b/internal/repository/state.go
@@ -181,6 +181,14 @@ func (p *Processor) fetchRepoSettings(ctx context.Context, owner, name string) (
 		return nil, fmt.Errorf("fetch release immutability for %s/%s: %w", owner, name, err)
 	}
 
+	// Fetch vulnerability alerts (Dependabot) setting via dedicated REST API endpoint.
+	// 404 is the documented "disabled" response and is handled inside the fetcher;
+	// 403 is ignored gracefully (e.g. GHES without support); other errors propagate.
+	vulnerabilityAlerts, err := p.fetchVulnerabilityAlerts(ctx, owner, name)
+	if err != nil && !errors.Is(err, gh.ErrForbidden) {
+		return nil, fmt.Errorf("fetch vulnerability alerts for %s/%s: %w", owner, name, err)
+	}
+
 	return &CurrentState{
 		Owner:               owner,
 		Name:                name,
@@ -190,6 +198,7 @@ func (p *Processor) fetchRepoSettings(ctx context.Context, owner, name string) (
 		Visibility:          strings.ToLower(raw.Visibility),
 		Topics:              topics,
 		ReleaseImmutability: releaseImmutability,
+		VulnerabilityAlerts: vulnerabilityAlerts,
 		Features: CurrentFeatures{
 			Issues:      raw.HasIssuesEnabled,
 			Projects:    raw.HasProjectsEnabled,
@@ -265,6 +274,22 @@ func (p *Processor) fetchReleaseImmutability(ctx context.Context, owner, name st
 		return false, err
 	}
 	return raw.Enabled, nil
+}
+
+// fetchVulnerabilityAlerts returns whether Dependabot vulnerability alerts are
+// enabled on the repository. The GitHub API signals state via HTTP status:
+// 204 No Content when enabled, 404 Not Found when disabled.
+func (p *Processor) fetchVulnerabilityAlerts(ctx context.Context, owner, name string) (bool, error) {
+	_, err := p.runner.Run(ctx,
+		"api", fmt.Sprintf("repos/%s/%s/vulnerability-alerts", owner, name),
+	)
+	if err != nil {
+		if errors.Is(err, gh.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (p *Processor) fetchBranchProtection(ctx context.Context, owner, name string) (map[string]*CurrentBranchProtection, error) {

--- a/internal/repository/state_test.go
+++ b/internal/repository/state_test.go
@@ -50,6 +50,8 @@ func TestFetchRepository(t *testing.T) {
 			}`),
 			"api repos/myorg/myrepo/immutable-releases":                                       []byte(`{"enabled": false}`),
 			"api repos/myorg/myrepo/vulnerability-alerts":                                    []byte(``),
+			"api repos/myorg/myrepo/automated-security-fixes":                                []byte(`{"enabled": false, "paused": false}`),
+			"api repos/myorg/myrepo/private-vulnerability-reporting":                         []byte(`{"enabled": false}`),
 			"api repos/myorg/myrepo/branches --jq [.[] | select(.protected == true) | .name]": []byte(`[]`),
 			"secret list --repo myorg/myrepo --json name --jq .[].name":                       []byte("SECRET1\nSECRET2"),
 			"variable list --repo myorg/myrepo --json name,value":                             []byte(`[{"name":"VAR1","value":"val1"},{"name":"VAR2","value":"val2"}]`),
@@ -365,6 +367,8 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 			"merge_commit_message": "PR_BODY"
 		}`),
 		"api repos/myorg/myrepo/immutable-releases":                                       []byte(`{"enabled": false}`),
+		"api repos/myorg/myrepo/automated-security-fixes":                                []byte(`{"enabled": false, "paused": false}`),
+		"api repos/myorg/myrepo/private-vulnerability-reporting":                         []byte(`{"enabled": false}`),
 		"api repos/myorg/myrepo/branches --jq [.[] | select(.protected == true) | .name]": []byte(`[]`),
 	}
 
@@ -524,6 +528,85 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "fetch vulnerability alerts") {
 			t.Errorf("expected 'fetch vulnerability alerts' in error, got: %v", err)
+		}
+	})
+
+	t.Run("automated security fixes 404 means disabled", func(t *testing.T) {
+		responses := make(map[string][]byte)
+		maps.Copy(responses, baseResponses)
+		delete(responses, "api repos/myorg/myrepo/automated-security-fixes")
+
+		mock := &gh.MockRunner{
+			Responses: responses,
+			Errors: map[string]error{
+				"api repos/myorg/myrepo/automated-security-fixes": fmt.Errorf("%w: api error", gh.ErrNotFound),
+			},
+		}
+		p := NewProcessor(mock, nil, nil)
+		state, err := p.FetchRepository(context.Background(), "myorg", "myrepo", nil)
+		if err != nil {
+			t.Fatalf("expected no error for 404, got: %v", err)
+		}
+		if state.AutomatedSecurityFixes {
+			t.Error("expected AutomatedSecurityFixes = false for 404")
+		}
+	})
+
+	t.Run("automated security fixes 500 propagates error", func(t *testing.T) {
+		responses := make(map[string][]byte)
+		maps.Copy(responses, baseResponses)
+		delete(responses, "api repos/myorg/myrepo/automated-security-fixes")
+
+		mock := &gh.MockRunner{
+			Responses: responses,
+			Errors: map[string]error{
+				"api repos/myorg/myrepo/automated-security-fixes": fmt.Errorf("internal server error"),
+			},
+		}
+		p := NewProcessor(mock, nil, nil)
+		_, err := p.FetchRepository(context.Background(), "myorg", "myrepo", nil)
+		if err == nil {
+			t.Fatal("expected error for 500, got nil")
+		}
+		if !strings.Contains(err.Error(), "fetch automated security fixes") {
+			t.Errorf("expected 'fetch automated security fixes' in error, got: %v", err)
+		}
+	})
+
+	t.Run("private vulnerability reporting enabled", func(t *testing.T) {
+		responses := make(map[string][]byte)
+		maps.Copy(responses, baseResponses)
+		responses["api repos/myorg/myrepo/private-vulnerability-reporting"] = []byte(`{"enabled": true}`)
+
+		mock := &gh.MockRunner{Responses: responses}
+		p := NewProcessor(mock, nil, nil)
+		state, err := p.FetchRepository(context.Background(), "myorg", "myrepo", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !state.PrivateVulnerabilityReporting {
+			t.Error("expected PrivateVulnerabilityReporting = true")
+		}
+	})
+
+	t.Run("private vulnerability reporting 500 propagates error", func(t *testing.T) {
+		responses := make(map[string][]byte)
+		maps.Copy(responses, baseResponses)
+		delete(responses, "api repos/myorg/myrepo/private-vulnerability-reporting")
+
+		mock := &gh.MockRunner{
+			Responses: responses,
+			Errors: map[string]error{
+				"api repos/myorg/myrepo/private-vulnerability-reporting": fmt.Errorf("internal server error"),
+			},
+		}
+		p := NewProcessor(mock, nil, nil)
+		_, err := p.FetchRepository(context.Background(), "myorg", "myrepo", nil)
+		if err == nil {
+			t.Fatal("expected error for 500, got nil")
+		}
+		if !strings.Contains(err.Error(), "fetch private vulnerability reporting") {
+			t.Errorf("expected 'fetch private vulnerability reporting' in error, got: %v", err)
 		}
 	})
 }

--- a/internal/repository/state_test.go
+++ b/internal/repository/state_test.go
@@ -49,6 +49,7 @@ func TestFetchRepository(t *testing.T) {
 				"merge_commit_message": "PR_BODY"
 			}`),
 			"api repos/myorg/myrepo/immutable-releases":                                       []byte(`{"enabled": false}`),
+			"api repos/myorg/myrepo/vulnerability-alerts":                                    []byte(``),
 			"api repos/myorg/myrepo/branches --jq [.[] | select(.protected == true) | .name]": []byte(`[]`),
 			"secret list --repo myorg/myrepo --json name --jq .[].name":                       []byte("SECRET1\nSECRET2"),
 			"variable list --repo myorg/myrepo --json name,value":                             []byte(`[{"name":"VAR1","value":"val1"},{"name":"VAR2","value":"val2"}]`),
@@ -448,6 +449,81 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "fetch release immutability") {
 			t.Errorf("expected 'fetch release immutability' in error, got: %v", err)
+		}
+	})
+
+	t.Run("vulnerability alerts 204 means enabled", func(t *testing.T) {
+		mock := &gh.MockRunner{Responses: baseResponses}
+		p := NewProcessor(mock, nil, nil)
+		state, err := p.FetchRepository(context.Background(), "myorg", "myrepo", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !state.VulnerabilityAlerts {
+			t.Error("expected VulnerabilityAlerts = true for 204 response")
+		}
+	})
+
+	t.Run("vulnerability alerts 404 means disabled", func(t *testing.T) {
+		responses := make(map[string][]byte)
+		maps.Copy(responses, baseResponses)
+		delete(responses, "api repos/myorg/myrepo/vulnerability-alerts")
+
+		mock := &gh.MockRunner{
+			Responses: responses,
+			Errors: map[string]error{
+				"api repos/myorg/myrepo/vulnerability-alerts": fmt.Errorf("%w: api error", gh.ErrNotFound),
+			},
+		}
+		p := NewProcessor(mock, nil, nil)
+		state, err := p.FetchRepository(context.Background(), "myorg", "myrepo", nil)
+		if err != nil {
+			t.Fatalf("expected no error for 404, got: %v", err)
+		}
+		if state.VulnerabilityAlerts {
+			t.Error("expected VulnerabilityAlerts = false for 404")
+		}
+	})
+
+	t.Run("vulnerability alerts 403 is ignored", func(t *testing.T) {
+		responses := make(map[string][]byte)
+		maps.Copy(responses, baseResponses)
+		delete(responses, "api repos/myorg/myrepo/vulnerability-alerts")
+
+		mock := &gh.MockRunner{
+			Responses: responses,
+			Errors: map[string]error{
+				"api repos/myorg/myrepo/vulnerability-alerts": fmt.Errorf("%w: api error", gh.ErrForbidden),
+			},
+		}
+		p := NewProcessor(mock, nil, nil)
+		state, err := p.FetchRepository(context.Background(), "myorg", "myrepo", nil)
+		if err != nil {
+			t.Fatalf("expected no error for 403, got: %v", err)
+		}
+		if state.VulnerabilityAlerts {
+			t.Error("expected VulnerabilityAlerts = false for 403")
+		}
+	})
+
+	t.Run("vulnerability alerts 500 propagates error", func(t *testing.T) {
+		responses := make(map[string][]byte)
+		maps.Copy(responses, baseResponses)
+		delete(responses, "api repos/myorg/myrepo/vulnerability-alerts")
+
+		mock := &gh.MockRunner{
+			Responses: responses,
+			Errors: map[string]error{
+				"api repos/myorg/myrepo/vulnerability-alerts": fmt.Errorf("internal server error"),
+			},
+		}
+		p := NewProcessor(mock, nil, nil)
+		_, err := p.FetchRepository(context.Background(), "myorg", "myrepo", nil)
+		if err == nil {
+			t.Fatal("expected error for 500, got nil")
+		}
+		if !strings.Contains(err.Error(), "fetch vulnerability alerts") {
+			t.Errorf("expected 'fetch vulnerability alerts' in error, got: %v", err)
 		}
 	})
 }

--- a/internal/repository/state_test.go
+++ b/internal/repository/state_test.go
@@ -49,9 +49,9 @@ func TestFetchRepository(t *testing.T) {
 				"merge_commit_message": "PR_BODY"
 			}`),
 			"api repos/myorg/myrepo/immutable-releases":                                       []byte(`{"enabled": false}`),
-			"api repos/myorg/myrepo/vulnerability-alerts":                                    []byte(``),
-			"api repos/myorg/myrepo/automated-security-fixes":                                []byte(`{"enabled": false, "paused": false}`),
-			"api repos/myorg/myrepo/private-vulnerability-reporting":                         []byte(`{"enabled": false}`),
+			"api repos/myorg/myrepo/vulnerability-alerts":                                     []byte(``),
+			"api repos/myorg/myrepo/automated-security-fixes":                                 []byte(`{"enabled": false, "paused": false}`),
+			"api repos/myorg/myrepo/private-vulnerability-reporting":                          []byte(`{"enabled": false}`),
 			"api repos/myorg/myrepo/branches --jq [.[] | select(.protected == true) | .name]": []byte(`[]`),
 			"secret list --repo myorg/myrepo --json name --jq .[].name":                       []byte("SECRET1\nSECRET2"),
 			"variable list --repo myorg/myrepo --json name,value":                             []byte(`[{"name":"VAR1","value":"val1"},{"name":"VAR2","value":"val2"}]`),
@@ -367,8 +367,8 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 			"merge_commit_message": "PR_BODY"
 		}`),
 		"api repos/myorg/myrepo/immutable-releases":                                       []byte(`{"enabled": false}`),
-		"api repos/myorg/myrepo/automated-security-fixes":                                []byte(`{"enabled": false, "paused": false}`),
-		"api repos/myorg/myrepo/private-vulnerability-reporting":                         []byte(`{"enabled": false}`),
+		"api repos/myorg/myrepo/automated-security-fixes":                                 []byte(`{"enabled": false, "paused": false}`),
+		"api repos/myorg/myrepo/private-vulnerability-reporting":                          []byte(`{"enabled": false}`),
 		"api repos/myorg/myrepo/branches --jq [.[] | select(.protected == true) | .name]": []byte(`[]`),
 	}
 
@@ -463,7 +463,7 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !state.VulnerabilityAlerts {
+		if !state.Security.VulnerabilityAlerts {
 			t.Error("expected VulnerabilityAlerts = true for 204 response")
 		}
 	})
@@ -484,7 +484,7 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error for 404, got: %v", err)
 		}
-		if state.VulnerabilityAlerts {
+		if state.Security.VulnerabilityAlerts {
 			t.Error("expected VulnerabilityAlerts = false for 404")
 		}
 	})
@@ -505,7 +505,7 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error for 403, got: %v", err)
 		}
-		if state.VulnerabilityAlerts {
+		if state.Security.VulnerabilityAlerts {
 			t.Error("expected VulnerabilityAlerts = false for 403")
 		}
 	})
@@ -547,7 +547,7 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error for 404, got: %v", err)
 		}
-		if state.AutomatedSecurityFixes {
+		if state.Security.AutomatedSecurityFixes {
 			t.Error("expected AutomatedSecurityFixes = false for 404")
 		}
 	})
@@ -584,7 +584,7 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !state.PrivateVulnerabilityReporting {
+		if !state.Security.PrivateVulnerabilityReporting {
 			t.Error("expected PrivateVulnerabilityReporting = true")
 		}
 	})

--- a/internal/repository/state_types.go
+++ b/internal/repository/state_types.go
@@ -21,6 +21,7 @@ type CurrentState struct {
 	Features            CurrentFeatures
 	MergeStrategy       CurrentMergeStrategy
 	ReleaseImmutability bool
+	VulnerabilityAlerts bool
 
 	BranchProtection map[string]*CurrentBranchProtection // pattern → protection
 	Rulesets         map[string]*CurrentRuleset          // name → ruleset

--- a/internal/repository/state_types.go
+++ b/internal/repository/state_types.go
@@ -20,10 +20,8 @@ type CurrentState struct {
 	Topics              []string
 	Features            CurrentFeatures
 	MergeStrategy       CurrentMergeStrategy
-	ReleaseImmutability           bool
-	VulnerabilityAlerts           bool
-	AutomatedSecurityFixes        bool
-	PrivateVulnerabilityReporting bool
+	ReleaseImmutability bool
+	Security            CurrentSecurity
 
 	BranchProtection map[string]*CurrentBranchProtection // pattern → protection
 	Rulesets         map[string]*CurrentRuleset          // name → ruleset
@@ -36,6 +34,12 @@ type CurrentState struct {
 
 func (r *CurrentState) FullName() string {
 	return r.Owner + "/" + r.Name
+}
+
+type CurrentSecurity struct {
+	VulnerabilityAlerts           bool
+	AutomatedSecurityFixes        bool
+	PrivateVulnerabilityReporting bool
 }
 
 type CurrentFeatures struct {

--- a/internal/repository/state_types.go
+++ b/internal/repository/state_types.go
@@ -20,8 +20,10 @@ type CurrentState struct {
 	Topics              []string
 	Features            CurrentFeatures
 	MergeStrategy       CurrentMergeStrategy
-	ReleaseImmutability bool
-	VulnerabilityAlerts bool
+	ReleaseImmutability           bool
+	VulnerabilityAlerts           bool
+	AutomatedSecurityFixes        bool
+	PrivateVulnerabilityReporting bool
 
 	BranchProtection map[string]*CurrentBranchProtection // pattern → protection
 	Rulesets         map[string]*CurrentRuleset          // name → ruleset


### PR DESCRIPTION
## Summary

Add a new `spec.security` section to the Repository manifest to manage GitHub Advanced Security settings declaratively. Closes #117.

## Background

#117 requested support for managing Dependabot vulnerability alerts through gh-infra, since the existing workflow required calling `gh api repos/{o}/{r}/vulnerability-alerts -X PUT` manually to use features such as Renovate's `osvVulnerabilityAlerts` that integrate with Dependabot.

While scoping the work it became natural to extend coverage to the two adjacent Advanced Security toggles (`automated_security_fixes`, `private_vulnerability_reporting`) since they share the same API shape (dedicated PUT/DELETE endpoints) and belong to the same section of GitHub's repository settings UI.

## Changes

**New spec: `security.*`** — Three optional `*bool` fields nested under a new `security` object:

```yaml
spec:
  security:
    vulnerability_alerts: true              # Dependabot vulnerability alerts
    automated_security_fixes: true          # Dependabot security updates (auto-PRs)
    private_vulnerability_reporting: true   # Private security advisory reporting
```

Each uses a dedicated GitHub REST API endpoint (`PUT` to enable, `DELETE` to disable), following the existing `release_immutability` pattern.

**Dependency validation at plan time** — `automated_security_fixes` requires `vulnerability_alerts` to be effectively enabled. A new `ValidateDependencies` check runs during `plan` using effective state (manifest value if set, otherwise current GitHub state), so the following cases are caught before `apply`:

- `vulnerability_alerts: false` + `automated_security_fixes: true` → rejected
- `automated_security_fixes: true` only, remote alerts disabled → rejected
- `automated_security_fixes: true` + `vulnerability_alerts: true` in same manifest → accepted, ordering is guaranteed (alerts PUT first)

Validation lives at plan (not validate) because it needs remote state to honor gh-infra's "omission = unmanaged" model.

**`import --into` support** — The field descriptors and spec comparator in `internal/importer/repository.go` were extended so that `security.*` is patched back into existing manifests during `import --into`. Also fixes a pre-existing gap where `release_immutability` was missing from the same paths.

**RepositorySet defaults propagation** — `mergeSpecs` now merges `Security`, `Actions`, and `ReleaseImmutability` from `defaults` into per-repo entries. Previously these three were silently dropped during merge (pre-existing bug surfaced while wiring up `security`, fixed together).

**Docs & skill** — New `docs/src/content/docs/resources/repository/security.md` page and matching skill reference. Tone aligned with `actions.md`/`labels.md`/`rulesets.md` (no inline `Endpoint: /...` annotations).
