### PR TITLE
Parallelize per-repo subresource fetches

### DIFF
--- a/docs/src/content/docs/internals/concurrency.md
+++ b/docs/src/content/docs/internals/concurrency.md
@@ -63,7 +63,8 @@ flowchart TB
 **Implementation:** `internal/repository/orchestrate.go` via `parallel.Map`
 
 - `parallel.Map` spawns a fixed pool of 10 worker goroutines that pull jobs from a channel
-- Each worker calls `Fetcher.FetchRepository()`, which internally uses `errgroup` to parallelize sub-fetches (branch protection, rulesets, secrets, variables)
+- Each worker calls `Fetcher.FetchRepository()`, which internally uses `errgroup` to parallelize sub-fetches (branch protection, rulesets, secrets, variables, actions, commit message settings, release immutability, security endpoints)
+- Within `fetchBranchProtection` and `fetchRulesets`, per-branch and per-ruleset detail fetches are themselves parallelized with `parallel.Map` (capped at `DefaultConcurrency`)
 - Spinner display via `ui.RunRefresh` shows per-repo progress (✓/✗)
 - Results are written to a pre-allocated slice by index — no mutex needed for the result array itself
 - Errors are non-fatal: failed repos are skipped and reported after all fetches complete
@@ -236,10 +237,16 @@ During `plan`, each repository triggers the following API calls:
 |----------|-------|-------|
 | `gh repo view` (GraphQL) | 1 | General settings, topics, merge strategy |
 | `GET /repos/{owner}/{repo}` | 1 | Commit message title/body settings |
+| `GET /repos/{owner}/{repo}/immutable-releases` | 1 | Release immutability |
+| `GET /repos/{owner}/{repo}/vulnerability-alerts` | 1 | Dependabot vulnerability alerts |
+| `GET /repos/{owner}/{repo}/automated-security-fixes` | 1 | Dependabot security updates |
+| `GET /repos/{owner}/{repo}/private-vulnerability-reporting` | 1 | Private vulnerability reporting |
 | `GET /repos/{owner}/{repo}/branches` | 1 | List protected branches |
-| `GET /repos/{owner}/{repo}/branches/{branch}/protection` | N | One per protected branch |
+| `GET /repos/{owner}/{repo}/branches/{branch}/protection` | N | One per protected branch (fetched in parallel) |
 | `GET /repos/{owner}/{repo}/rulesets` | 1 | List rulesets (paginated) |
-| `GET /repos/{owner}/{repo}/rulesets/{id}` | M | One per ruleset |
+| `GET /repos/{owner}/{repo}/rulesets/{id}` | M | One per ruleset (fetched in parallel) |
+| `GET /repos/{owner}/{repo}/labels` | 1 | List labels (paginated) |
+| `GET /repos/{owner}/{repo}/milestones` | 1 | List milestones (paginated) |
 | `gh secret list` | 1 | List repository secrets |
 | `gh variable list` | 1 | List repository variables |
 | `GET /repos/{owner}/{repo}/actions/permissions` | 1 | Actions enabled/disabled |
@@ -248,7 +255,7 @@ During `plan`, each repository triggers the following API calls:
 | `GET /repos/{owner}/{repo}/actions/permissions/fork-pr-contributor-approval` | 1 | Fork PR approval setting |
 | `GET /repos/{owner}/{repo}/contents/{path}` | F | One per file (FileSet) |
 
-**Fixed cost per repo:** ~10 calls
+**Fixed cost per repo:** ~16 calls
 **Variable cost:** N (protected branches) + M (rulesets) + F (files)
 
 ### Budget Estimates
@@ -257,10 +264,10 @@ Assuming 1 protected branch, 1 ruleset per repo:
 
 | Files per repo | Calls per repo | Repos for 5,000 budget |
 |----------------|---------------|----------------------|
-| 1 | ~13 | ~384 |
-| 5 | ~17 | ~294 |
-| 10 | ~22 | ~227 |
-| 20 | ~32 | ~156 |
+| 1 | ~19 | ~263 |
+| 5 | ~23 | ~217 |
+| 10 | ~28 | ~178 |
+| 20 | ~38 | ~131 |
 
 :::caution
 These estimates cover the **plan phase only**. An `apply` run executes the plan fetch first, then makes additional API calls to mutate state (create/update settings, Git Data API for file commits, etc.). Budget accordingly.

--- a/internal/gh/mock.go
+++ b/internal/gh/mock.go
@@ -3,22 +3,28 @@ package gh
 import (
 	"context"
 	"strings"
+	"sync"
 )
 
 // MockRunner is a test double for Runner.
 // Called[i] and CalledStdin[i] always correspond to the same call.
 // CalledStdin[i] is nil for Run calls and contains the body for RunWithStdin calls.
+// Concurrent callers are safe: Called/CalledStdin are guarded by mu.
 type MockRunner struct {
 	Responses   map[string][]byte
 	Errors      map[string]error
 	Called      [][]string
 	CalledStdin [][]byte
+
+	mu sync.Mutex
 }
 
 func (m *MockRunner) Run(_ context.Context, args ...string) ([]byte, error) {
 	key := strings.Join(args, " ")
+	m.mu.Lock()
 	m.Called = append(m.Called, args)
 	m.CalledStdin = append(m.CalledStdin, nil)
+	m.mu.Unlock()
 	if err, ok := m.Errors[key]; ok {
 		return nil, err
 	}
@@ -30,8 +36,10 @@ func (m *MockRunner) Run(_ context.Context, args ...string) ([]byte, error) {
 
 func (m *MockRunner) RunWithStdin(_ context.Context, body []byte, args ...string) ([]byte, error) {
 	key := strings.Join(args, " ")
+	m.mu.Lock()
 	m.Called = append(m.Called, args)
 	m.CalledStdin = append(m.CalledStdin, body)
+	m.mu.Unlock()
 	if err, ok := m.Errors[key]; ok {
 		return nil, err
 	}

--- a/internal/repository/state.go
+++ b/internal/repository/state.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/babarot/gh-infra/internal/gh"
 	"github.com/babarot/gh-infra/internal/manifest"
+	"github.com/babarot/gh-infra/internal/parallel"
 )
 
 // Processor handles repository plan and apply operations.
@@ -111,10 +112,42 @@ func (p *Processor) FetchRepository(ctx context.Context, owner, name string, onS
 	})
 
 	var (
+		commitMsgSettings             commitMessageSettings
+		releaseImmutability           bool
 		vulnerabilityAlerts           bool
 		automatedSecurityFixes        bool
 		privateVulnerabilityReporting bool
 	)
+
+	// Fetch commit message settings via REST API (not available in gh repo view --json).
+	// 404/403 are ignored gracefully (e.g. GHES without support); other errors propagate.
+	g.Go(func() error {
+		status("fetching commit message settings...")
+		s, err := p.fetchCommitMessageSettings(ctx, owner, name)
+		if err != nil {
+			if errors.Is(err, gh.ErrNotFound) || errors.Is(err, gh.ErrForbidden) {
+				return nil
+			}
+			return fmt.Errorf("fetch commit message settings for %s/%s: %w", owner, name, err)
+		}
+		commitMsgSettings = s
+		return nil
+	})
+
+	// Fetch release immutability setting via dedicated REST API endpoint.
+	// 404/403 are ignored gracefully (e.g. GHES without support); other errors propagate.
+	g.Go(func() error {
+		status("fetching release immutability...")
+		v, err := p.fetchReleaseImmutability(ctx, owner, name)
+		if err != nil {
+			if errors.Is(err, gh.ErrNotFound) || errors.Is(err, gh.ErrForbidden) {
+				return nil
+			}
+			return fmt.Errorf("fetch release immutability for %s/%s: %w", owner, name, err)
+		}
+		releaseImmutability = v
+		return nil
+	})
 
 	// Fetch vulnerability alerts (Dependabot) setting via dedicated REST API endpoint.
 	// 404 is the documented "disabled" response and is handled inside the fetcher;
@@ -172,6 +205,11 @@ func (p *Processor) FetchRepository(ctx context.Context, owner, name string, onS
 	repo.Labels = labels
 	repo.Milestones = milestones
 	repo.Actions = actions
+	repo.ReleaseImmutability = releaseImmutability
+	repo.MergeStrategy.MergeCommitTitle = commitMsgSettings.MergeCommitTitle
+	repo.MergeStrategy.MergeCommitMessage = commitMsgSettings.MergeCommitMessage
+	repo.MergeStrategy.SquashMergeCommitTitle = commitMsgSettings.SquashMergeCommitTitle
+	repo.MergeStrategy.SquashMergeCommitMessage = commitMsgSettings.SquashMergeCommitMessage
 	repo.Security = CurrentSecurity{
 		VulnerabilityAlerts:           vulnerabilityAlerts,
 		AutomatedSecurityFixes:        automatedSecurityFixes,
@@ -223,29 +261,14 @@ func (p *Processor) fetchRepoSettings(ctx context.Context, owner, name string) (
 		topics = append(topics, t.Name)
 	}
 
-	// Fetch commit message settings via REST API (not available in gh repo view --json)
-	// 404/403 are ignored gracefully (e.g. GHES without support); other errors propagate.
-	commitMsgSettings, err := p.fetchCommitMessageSettings(ctx, owner, name)
-	if err != nil && !errors.Is(err, gh.ErrNotFound) && !errors.Is(err, gh.ErrForbidden) {
-		return nil, fmt.Errorf("fetch commit message settings for %s/%s: %w", owner, name, err)
-	}
-
-	// Fetch release immutability setting via dedicated REST API endpoint
-	// 404/403 are ignored gracefully (e.g. GHES without support); other errors propagate.
-	releaseImmutability, err := p.fetchReleaseImmutability(ctx, owner, name)
-	if err != nil && !errors.Is(err, gh.ErrNotFound) && !errors.Is(err, gh.ErrForbidden) {
-		return nil, fmt.Errorf("fetch release immutability for %s/%s: %w", owner, name, err)
-	}
-
 	return &CurrentState{
-		Owner:               owner,
-		Name:                name,
-		Description:         raw.Description,
-		Archived:            raw.IsArchived,
-		Homepage:            raw.HomepageURL,
-		Visibility:          strings.ToLower(raw.Visibility),
-		Topics:              topics,
-		ReleaseImmutability: releaseImmutability,
+		Owner:       owner,
+		Name:        name,
+		Description: raw.Description,
+		Archived:    raw.IsArchived,
+		Homepage:    raw.HomepageURL,
+		Visibility:  strings.ToLower(raw.Visibility),
+		Topics:      topics,
 		Features: CurrentFeatures{
 			Issues:      raw.HasIssuesEnabled,
 			Projects:    raw.HasProjectsEnabled,
@@ -253,14 +276,12 @@ func (p *Processor) fetchRepoSettings(ctx context.Context, owner, name string) (
 			Discussions: raw.HasDiscussionsEnabled,
 		},
 		MergeStrategy: CurrentMergeStrategy{
-			AllowMergeCommit:         raw.MergeCommitAllowed,
-			AllowSquashMerge:         raw.SquashMergeAllowed,
-			AllowRebaseMerge:         raw.RebaseMergeAllowed,
-			AutoDeleteHeadBranches:   raw.DeleteBranchOnMerge,
-			MergeCommitTitle:         commitMsgSettings.MergeCommitTitle,
-			MergeCommitMessage:       commitMsgSettings.MergeCommitMessage,
-			SquashMergeCommitTitle:   commitMsgSettings.SquashMergeCommitTitle,
-			SquashMergeCommitMessage: commitMsgSettings.SquashMergeCommitMessage,
+			AllowMergeCommit:       raw.MergeCommitAllowed,
+			AllowSquashMerge:       raw.SquashMergeAllowed,
+			AllowRebaseMerge:       raw.RebaseMergeAllowed,
+			AutoDeleteHeadBranches: raw.DeleteBranchOnMerge,
+			// Commit message string fields are populated later via
+			// fetchCommitMessageSettings in the FetchRepository errgroup.
 		},
 	}, nil
 }
@@ -398,14 +419,20 @@ func (p *Processor) fetchBranchProtection(ctx context.Context, owner, name strin
 		return nil, nil // no protected branches or parse error
 	}
 
-	result := make(map[string]*CurrentBranchProtection)
-	for _, branch := range protectedBranches {
+	// Fetch per-branch protection rules in parallel. Individual errors are
+	// swallowed (skip branch) to preserve existing behavior.
+	fetched := parallel.Map(ctx, protectedBranches, parallel.DefaultConcurrency, func(ctx context.Context, _ int, branch string) *CurrentBranchProtection {
 		bp, err := p.fetchBranchProtectionRule(ctx, owner, name, branch)
 		if err != nil {
-			continue // skip branches we can't read
+			return nil
 		}
+		return bp
+	})
+
+	result := make(map[string]*CurrentBranchProtection)
+	for i, bp := range fetched {
 		if bp != nil {
-			result[branch] = bp
+			result[protectedBranches[i]] = bp
 		}
 	}
 	return result, nil
@@ -494,17 +521,30 @@ func (p *Processor) fetchRulesets(ctx context.Context, owner, name string) (map[
 		return make(map[string]*CurrentRuleset), nil
 	}
 
-	result := make(map[string]*CurrentRuleset)
+	// Filter out org/enterprise-level rulesets (not manageable at repo level).
+	ids := make([]int, 0, len(rawList))
 	for _, item := range rawList {
-		// Skip org-level rulesets (not manageable at repo level)
 		if item.SourceType == "Organization" || item.SourceType == "Enterprise" {
 			continue
 		}
-		rs, err := p.fetchRuleset(ctx, owner, name, item.ID)
+		ids = append(ids, item.ID)
+	}
+
+	// Fetch per-ruleset details in parallel. Individual errors are swallowed
+	// (skip ruleset) to preserve existing behavior.
+	fetched := parallel.Map(ctx, ids, parallel.DefaultConcurrency, func(ctx context.Context, _ int, id int) *CurrentRuleset {
+		rs, err := p.fetchRuleset(ctx, owner, name, id)
 		if err != nil {
-			continue // skip inaccessible individual rulesets
+			return nil
 		}
-		result[rs.Name] = rs
+		return rs
+	})
+
+	result := make(map[string]*CurrentRuleset)
+	for _, rs := range fetched {
+		if rs != nil {
+			result[rs.Name] = rs
+		}
 	}
 	return result, nil
 }

--- a/internal/repository/state_test.go
+++ b/internal/repository/state_test.go
@@ -611,6 +611,155 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 	})
 }
 
+func TestFetchBranchProtection_MultipleBranches(t *testing.T) {
+	// 5 protected branches; ensure all are fetched and returned correctly.
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo/branches --jq [.[] | select(.protected == true) | .name]": []byte(`["main","develop","release/1","release/2","release/3"]`),
+			"api repos/myorg/myrepo/branches/main/protection":                                 []byte(`{"required_pull_request_reviews":{"required_approving_review_count":1}}`),
+			"api repos/myorg/myrepo/branches/develop/protection":                              []byte(`{"required_pull_request_reviews":{"required_approving_review_count":2}}`),
+			"api repos/myorg/myrepo/branches/release/1/protection":                            []byte(`{"required_pull_request_reviews":{"required_approving_review_count":3}}`),
+			"api repos/myorg/myrepo/branches/release/2/protection":                            []byte(`{"required_pull_request_reviews":{"required_approving_review_count":4}}`),
+			"api repos/myorg/myrepo/branches/release/3/protection":                            []byte(`{"required_pull_request_reviews":{"required_approving_review_count":5}}`),
+		},
+	}
+
+	p := NewProcessor(mock, nil, nil)
+	got, err := p.fetchBranchProtection(context.Background(), "myorg", "myrepo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]int{
+		"main":      1,
+		"develop":   2,
+		"release/1": 3,
+		"release/2": 4,
+		"release/3": 5,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d branches, want %d: %v", len(got), len(want), got)
+	}
+	for branch, reviews := range want {
+		bp, ok := got[branch]
+		if !ok {
+			t.Errorf("branch %q missing from result", branch)
+			continue
+		}
+		if bp.RequiredReviews != reviews {
+			t.Errorf("branch %q: required_reviews = %d, want %d", branch, bp.RequiredReviews, reviews)
+		}
+	}
+}
+
+func TestFetchBranchProtection_IndividualFailureSkipped(t *testing.T) {
+	// Two branches, one fetch fails. The failure must not abort the whole fetch.
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo/branches --jq [.[] | select(.protected == true) | .name]": []byte(`["main","broken"]`),
+			"api repos/myorg/myrepo/branches/main/protection":                                 []byte(`{"required_pull_request_reviews":{"required_approving_review_count":1}}`),
+		},
+		Errors: map[string]error{
+			"api repos/myorg/myrepo/branches/broken/protection": fmt.Errorf("%w: not configured", gh.ErrNotFound),
+		},
+	}
+
+	p := NewProcessor(mock, nil, nil)
+	got, err := p.fetchBranchProtection(context.Background(), "myorg", "myrepo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d branches, want 1: %v", len(got), got)
+	}
+	if _, ok := got["main"]; !ok {
+		t.Error("expected 'main' to be present")
+	}
+	if _, ok := got["broken"]; ok {
+		t.Error("expected 'broken' to be skipped")
+	}
+}
+
+func TestFetchRulesets_MultipleRulesets(t *testing.T) {
+	// 3 rulesets; ensure all are fetched and returned correctly.
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo/rulesets --paginate": []byte(`[
+				{"id":1,"name":"protect-main","source_type":"Repository"},
+				{"id":2,"name":"protect-release","source_type":"Repository"},
+				{"id":3,"name":"tag-rules","source_type":"Repository"}
+			]`),
+			"api repos/myorg/myrepo/rulesets/1": []byte(`{"id":1,"name":"protect-main","target":"branch","enforcement":"active"}`),
+			"api repos/myorg/myrepo/rulesets/2": []byte(`{"id":2,"name":"protect-release","target":"branch","enforcement":"active"}`),
+			"api repos/myorg/myrepo/rulesets/3": []byte(`{"id":3,"name":"tag-rules","target":"tag","enforcement":"evaluate"}`),
+		},
+	}
+
+	p := NewProcessor(mock, nil, nil)
+	got, err := p.fetchRulesets(context.Background(), "myorg", "myrepo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d rulesets, want 3: %v", len(got), got)
+	}
+	for _, name := range []string{"protect-main", "protect-release", "tag-rules"} {
+		if _, ok := got[name]; !ok {
+			t.Errorf("ruleset %q missing from result", name)
+		}
+	}
+}
+
+func TestFetchRulesets_IndividualFailureSkipped(t *testing.T) {
+	// Two rulesets, one fetch fails. The failure must not abort the whole fetch.
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo/rulesets --paginate": []byte(`[
+				{"id":1,"name":"ok","source_type":"Repository"},
+				{"id":2,"name":"broken","source_type":"Repository"}
+			]`),
+			"api repos/myorg/myrepo/rulesets/1": []byte(`{"id":1,"name":"ok","target":"branch","enforcement":"active"}`),
+		},
+		Errors: map[string]error{
+			"api repos/myorg/myrepo/rulesets/2": fmt.Errorf("%w: denied", gh.ErrForbidden),
+		},
+	}
+
+	p := NewProcessor(mock, nil, nil)
+	got, err := p.fetchRulesets(context.Background(), "myorg", "myrepo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d rulesets, want 1: %v", len(got), got)
+	}
+	if _, ok := got["ok"]; !ok {
+		t.Error("expected 'ok' to be present")
+	}
+}
+
+func TestFetchRulesets_SkipsOrgAndEnterpriseSource(t *testing.T) {
+	// Org/Enterprise-level rulesets should be filtered out before per-ruleset fetch.
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo/rulesets --paginate": []byte(`[
+				{"id":1,"name":"repo-level","source_type":"Repository"},
+				{"id":2,"name":"org-level","source_type":"Organization"},
+				{"id":3,"name":"ent-level","source_type":"Enterprise"}
+			]`),
+			"api repos/myorg/myrepo/rulesets/1": []byte(`{"id":1,"name":"repo-level","target":"branch","enforcement":"active"}`),
+		},
+	}
+
+	p := NewProcessor(mock, nil, nil)
+	got, err := p.fetchRulesets(context.Background(), "myorg", "myrepo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got["repo-level"] == nil {
+		t.Fatalf("expected only 'repo-level', got: %v", got)
+	}
+}
+
 func TestFetchActionsSettings(t *testing.T) {
 	mock := &gh.MockRunner{
 		Responses: map[string][]byte{


### PR DESCRIPTION
## Summary

Reduce the number of sequential API round trips during `plan` by hoisting the remaining per-repo subresource fetches out of `fetchRepoSettings` into the existing `FetchRepository` errgroup, and by fanning out per-branch and per-ruleset detail fetches with `parallel.Map`.

## Background

A previous PR (#118) parallelized the three new Advanced Security fetches, but several other per-repo API calls remained sequential:

1. `fetchCommitMessageSettings` and `fetchReleaseImmutability` were synchronously chained inside `fetchRepoSettings`, blocking the start of the existing errgroup
2. `fetchBranchProtection` fetched each protected branch's rule in a `for` loop, turning N+1 round trips per repo
3. `fetchRulesets` fetched each ruleset's detail in the same serial way, turning M+1 round trips per repo

For a repo with several protected branches or rulesets, this made the wall-clock fetch time dominated by sequential RTT rather than anything intrinsic to the data.

## Changes

**`internal/repository/state.go`** — the main refactor:
- `fetchRepoSettings` now returns only the GraphQL-derived fields (still runs first for the 404 / repo-not-found short circuit). Commit message strings and release immutability are no longer populated here.
- `FetchRepository` issues two new `g.Go` calls for `fetchCommitMessageSettings` and `fetchReleaseImmutability`, alongside the existing ones for branch protection, rulesets, actions, secrets, variables, labels, milestones, and the three security endpoints. After `g.Wait`, the scalar results are merged back into `CurrentState.MergeStrategy` and `CurrentState.ReleaseImmutability`.
- `fetchBranchProtection` replaces its `for _, branch := range protectedBranches` loop with `parallel.Map(..., DefaultConcurrency, ...)`. Individual branch failures still silently skip the branch (existing behavior).
- `fetchRulesets` filters out Organization/Enterprise-sourced rulesets up front, then fans out the per-ruleset detail fetch with `parallel.Map`. Individual ruleset failures still silently skip.

**`internal/gh/mock.go`** — thread safety:
- `MockRunner.Called` / `CalledStdin` append is now guarded by a `sync.Mutex`. The existing tests pass `-race` only after this change; the race was latent but not exercised until the fan-out in this PR triggered concurrent `Run` calls from the same `MockRunner` instance.

**`docs/src/content/docs/internals/concurrency.md`** — keep the documented model in sync:
- API call table extended with `immutable-releases`, `vulnerability-alerts`, `automated-security-fixes`, `private-vulnerability-reporting`, `labels`, `milestones`
- Clarified that per-branch protection and per-ruleset fetches are themselves parallelized (capped at `DefaultConcurrency`)
- Fixed per-repo cost updated from ~10 to ~16, budget estimates recomputed

## Concurrency boundary

Outer (cross-repo) fan-out is `parallel.DefaultConcurrency = 10`. Inner fan-out (branches / rulesets) reuses the same constant, yielding a theoretical peak burst in the low hundreds only for repositories with many protected branches or rulesets — which is rare. The `gh` runner already retries rate-limit and abuse-detection errors with exponential backoff, providing a safety net without introducing a second concurrency pool.