### PR TITLE
fix: inherit content/source for per-repo overrides

### DIFF
--- a/internal/fileset/resolve.go
+++ b/internal/fileset/resolve.go
@@ -29,6 +29,15 @@ func ResolveFiles(fs *manifest.FileSet, target manifest.FileSetRepository) []man
 			if override.Patches == nil && f.Patches != nil {
 				override.Patches = f.Patches
 			}
+			if override.Content == "" {
+				override.Content = f.Content
+			}
+			if override.Source == "" {
+				override.Source = f.Source
+			}
+			if override.OriginalSource == "" {
+				override.OriginalSource = f.OriginalSource
+			}
 			result = append(result, override)
 		} else {
 			result = append(result, f)

--- a/internal/fileset/resolve_test.go
+++ b/internal/fileset/resolve_test.go
@@ -187,3 +187,43 @@ func TestResolveFiles_OverridePatchesReplacesOriginal(t *testing.T) {
 		t.Errorf("Patches should use override's patches, got %v", result[0].Patches)
 	}
 }
+
+func TestResolveFiles_InheritsContentAndSource(t *testing.T) {
+	fs := &manifest.FileSet{
+		Spec: manifest.FileSetSpec{
+			Files: []manifest.FileEntry{
+				{
+					Path:           ".goreleaser.yaml",
+					Content:        "dummy message",
+					Source:         "github://owner/repo/templates/.goreleaser.yaml",
+					OriginalSource: "templates/.goreleaser.yaml",
+				},
+			},
+		},
+	}
+
+	target := manifest.FileSetRepository{
+		Name: "repo",
+		Overrides: []manifest.FileEntry{
+			{Path: ".goreleaser.yaml", Vars: map[string]string{"Description": "overwrite message"}},
+		},
+	}
+
+	result := ResolveFiles(fs, target)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(result))
+	}
+	if result[0].Content != "dummy message" {
+		t.Errorf("Content = %q, want %q", result[0].Content, "dummy message")
+	}
+	if result[0].Source != "github://owner/repo/templates/.goreleaser.yaml" {
+		t.Errorf("Source = %q, want %q", result[0].Source, "github://owner/repo/templates/.goreleaser.yaml")
+	}
+	if result[0].OriginalSource != "templates/.goreleaser.yaml" {
+		t.Errorf("OriginalSource = %q, want %q", result[0].OriginalSource, "templates/.goreleaser.yaml")
+	}
+	if v := result[0].Vars["Description"]; v != "overwrite message" {
+		t.Errorf("Vars.Description = %q, want %q", v, "overwrite message")
+	}
+}


### PR DESCRIPTION
## Summary

I noticed that configuring variable overrides for each repository caused files to become empty, so I fixed it.
Related section in the documentation: https://babarot.me/gh-infra/resources/fileset/overrides/#vars-inheritance

## Background

If you try to overwrite `Description` by writing the following YAML, changes that would delete the contents of `.goreleaser.yaml` will be detected.

```yaml
apiVersion: gh-infra/v1
kind: FileSet
metadata:
  owner: owner

spec:
  repositories:
    - name: mytool
      overrides:
        - path: .goreleaser.yaml
          vars:
            Description: overwrite message

  files:
    - path: .goreleaser.yaml
      reconcile: patch
      source: ./templates/.goreleaser.yaml
      vars:
        Description: dummy message
```

This is likely because `Content`, `Source`, and `OriginalSource` are not included in the inheritance in `internal/fileset.ResolveFiles`.

## Changes

- In `internal/fileset.ResolveFiles`, I have ensured that `Content`, `Source`, and `OriginalSource` are also inherited if there is no override.
- The Per-repo Overrides settings work as expected.
- The added unit tests run without issues, and existing tests have not been broken.
