### PR TITLE
fix: handle null topics as empty array via jq

### DIFF
--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -425,7 +425,7 @@ func (p *Processor) toggleFeature(ctx context.Context, repo, flag string, enable
 
 func (p *Processor) applyTopics(ctx context.Context, fullName string, repo *manifest.Repository) error {
 	// Get current topics
-	out, err := p.runner.Run(ctx, "repo", "view", fullName, "--json", "repositoryTopics", "--jq", ".repositoryTopics[].name")
+	out, err := p.runner.Run(ctx, "repo", "view", fullName, "--json", "repositoryTopics", "--jq", ".repositoryTopics // [] | .[].name")
 	if err != nil {
 		return wrapError(err, fullName, "topics")
 	}

--- a/internal/repository/apply_test.go
+++ b/internal/repository/apply_test.go
@@ -109,7 +109,7 @@ func TestApplyVisibility(t *testing.T) {
 func TestApplyTopics(t *testing.T) {
 	mock := &gh.MockRunner{
 		Responses: map[string][]byte{
-			"repo view myorg/myrepo --json repositoryTopics --jq .repositoryTopics[].name": []byte("old-topic\nkeep-topic\n"),
+			"repo view myorg/myrepo --json repositoryTopics --jq .repositoryTopics // [] | .[].name": []byte("old-topic\nkeep-topic\n"),
 		},
 	}
 	proc := NewProcessor(mock, nil, nil)


### PR DESCRIPTION
## Summary

If you try to add topics to a repository that currently has no topics, the following error occurs.

```text
✗ owner/repo  update owner/repo topics: cannot iterate over: null
```

## Background

The following command attempts to retrieve the name using the `--jq` option even when `repositoryTopics` is null, resulting in the `cannot iterate over: null` error.

```sh
gh repo view owner/repo --json repositoryTopics --jq ".repositoryTopics[].name"
```

## Changes

I made the following change to fall back to an empty array when `--jq` is passed a null value. I believe this now behaves as expected.

```sh
gh repo view owner/repo --json repositoryTopics --jq ".repositoryTopics // [] | .[].name"
```

jq reference: https://jqlang.org/manual/#alternative-operator