### PR TITLE
feat: add allow_auto_merge to merge_strategy

### DIFF
--- a/.agents/skills/repository-manifest/references/general.md
+++ b/.agents/skills/repository-manifest/references/general.md
@@ -34,6 +34,7 @@ spec:
     allow_merge_commit: false
     allow_squash_merge: true
     allow_rebase_merge: false
+    allow_auto_merge: true
     auto_delete_head_branches: true
     merge_commit_title: MERGE_MESSAGE
     merge_commit_message: PR_TITLE

--- a/.claude/rules/mock-gh-sync.md
+++ b/.claude/rules/mock-gh-sync.md
@@ -1,0 +1,29 @@
+---
+paths:
+  - "internal/repository/state.go"
+  - "internal/repository/state_types.go"
+  - "internal/manifest/repository_types.go"
+---
+
+# Keep mock-gh and VHS setup scripts in sync with API changes
+
+When adding, removing, or renaming fields fetched from the GitHub API (GraphQL via `gh repo view --json` or REST via `gh api`), you **must** update the following files to match:
+
+1. **`docs/tapes/mock-gh`** — the generic mock script. Update the default JSON fallbacks for both `view.json` (GraphQL fields) and `commit-settings.json` (REST API fields), plus any field-matching patterns.
+2. **`docs/tapes/setup*.sh`** — every setup script that generates `view.json` or `commit-settings.json`. Each heredoc must include the new/changed field.
+3. **`internal/repository/state_test.go`** — mock response map keys contain the full `--json` / `--jq` field list; these must match the production query exactly.
+
+## Important: GraphQL vs REST API fields
+
+Not all GitHub repository fields are available via GraphQL (`gh repo view --json`). Some fields (e.g. `allow_auto_merge`, commit message settings) are only available via the REST API (`gh api repos/{owner}/{repo}`). Before adding a new field:
+
+1. Check `gh repo view --json` available fields by running `gh repo view --json` with no value
+2. If the field is not in GraphQL, fetch it via the REST API path (`fetchCommitMessageSettings` or a new fetcher)
+3. Place mock data in the correct mock response (`view.json` for GraphQL, `commit-settings.json` for REST)
+
+## Checklist
+
+- [ ] `mock-gh` default JSON fallbacks include the field in the correct response (GraphQL or REST)
+- [ ] Every `setup*.sh` heredoc for the relevant mock file includes the field
+- [ ] `state_test.go` mock keys match the updated query strings
+- [ ] `state_test.go` mock JSON responses include the field with a sensible value

--- a/docs/src/content/docs/resources/repository/general.md
+++ b/docs/src/content/docs/resources/repository/general.md
@@ -70,6 +70,7 @@ spec:
     allow_merge_commit: false
     allow_squash_merge: true
     allow_rebase_merge: false
+    allow_auto_merge: true
     auto_delete_head_branches: true
     merge_commit_title: MERGE_MESSAGE            # MERGE_MESSAGE | PR_TITLE
     merge_commit_message: PR_TITLE               # PR_TITLE | PR_BODY | BLANK
@@ -82,6 +83,7 @@ spec:
 | `allow_merge_commit` | bool | Allow merge commits |
 | `allow_squash_merge` | bool | Allow squash merging |
 | `allow_rebase_merge` | bool | Allow rebase merging |
+| `allow_auto_merge` | bool | Allow auto-merge on pull requests |
 | `auto_delete_head_branches` | bool | Automatically delete head branches after merge |
 | `merge_commit_title` | string | Title format for merge commits |
 | `merge_commit_message` | string | Message format for merge commits |

--- a/docs/tapes/mock-gh
+++ b/docs/tapes/mock-gh
@@ -128,7 +128,8 @@ if [[ "$args" == *"--jq"*"squash_merge_commit_title"* ]]; then
   "squash_merge_commit_title": "COMMIT_OR_PR_TITLE",
   "squash_merge_commit_message": "COMMIT_MESSAGES",
   "merge_commit_title": "MERGE_MESSAGE",
-  "merge_commit_message": "PR_TITLE"
+  "merge_commit_message": "PR_TITLE",
+  "allow_auto_merge": false
 }'
   exit 0
 fi

--- a/internal/importer/repository.go
+++ b/internal/importer/repository.go
@@ -354,6 +354,15 @@ var repositoryFieldDescriptors = []repositoryFieldDescriptor{
 		},
 	},
 	{
+		diffField: "merge_strategy.allow_auto_merge",
+		parentKey: "merge_strategy",
+		key:       "allow_auto_merge",
+		kind:      fieldBool,
+		boolVal: func(spec manifest.RepositorySpec) *bool {
+			return boolPtrFromMergeStrategy(spec.MergeStrategy, "allow_auto_merge")
+		},
+	},
+	{
 		diffField: "merge_strategy.auto_delete_head_branches",
 		parentKey: "merge_strategy",
 		key:       "auto_delete_head_branches",
@@ -665,6 +674,8 @@ func boolPtrFromMergeStrategy(m *manifest.MergeStrategy, field string) *bool {
 		return m.AllowSquashMerge
 	case "allow_rebase_merge":
 		return m.AllowRebaseMerge
+	case "allow_auto_merge":
+		return m.AllowAutoMerge
 	case "auto_delete_head_branches":
 		return m.AutoDeleteHeadBranches
 	default:
@@ -842,6 +853,7 @@ func compareMergeStrategy(local, imported *manifest.MergeStrategy) []FieldDiff {
 	diffs = appendBoolPtrDiff(diffs, "merge_strategy.allow_merge_commit", l.AllowMergeCommit, i.AllowMergeCommit)
 	diffs = appendBoolPtrDiff(diffs, "merge_strategy.allow_squash_merge", l.AllowSquashMerge, i.AllowSquashMerge)
 	diffs = appendBoolPtrDiff(diffs, "merge_strategy.allow_rebase_merge", l.AllowRebaseMerge, i.AllowRebaseMerge)
+	diffs = appendBoolPtrDiff(diffs, "merge_strategy.allow_auto_merge", l.AllowAutoMerge, i.AllowAutoMerge)
 	diffs = appendBoolPtrDiff(diffs, "merge_strategy.auto_delete_head_branches", l.AutoDeleteHeadBranches, i.AutoDeleteHeadBranches)
 	diffs = appendPtrDiff(diffs, "merge_strategy.squash_merge_commit_title", l.SquashMergeCommitTitle, i.SquashMergeCommitTitle)
 	diffs = appendPtrDiff(diffs, "merge_strategy.squash_merge_commit_message", l.SquashMergeCommitMessage, i.SquashMergeCommitMessage)
@@ -1208,6 +1220,10 @@ func minimalMergeStrategy(defaults, imported *manifest.MergeStrategy) *manifest.
 	}
 	if !boolPtrEqual(d.AllowRebaseMerge, i.AllowRebaseMerge) {
 		m.AllowRebaseMerge = i.AllowRebaseMerge
+		any = true
+	}
+	if !boolPtrEqual(d.AllowAutoMerge, i.AllowAutoMerge) {
+		m.AllowAutoMerge = i.AllowAutoMerge
 		any = true
 	}
 	if !boolPtrEqual(d.AutoDeleteHeadBranches, i.AutoDeleteHeadBranches) {

--- a/internal/manifest/repository_types.go
+++ b/internal/manifest/repository_types.go
@@ -108,6 +108,7 @@ type MergeStrategy struct {
 	AllowMergeCommit         *bool   `yaml:"allow_merge_commit,omitempty"`
 	AllowSquashMerge         *bool   `yaml:"allow_squash_merge,omitempty"`
 	AllowRebaseMerge         *bool   `yaml:"allow_rebase_merge,omitempty"`
+	AllowAutoMerge           *bool   `yaml:"allow_auto_merge,omitempty"`
 	AutoDeleteHeadBranches   *bool   `yaml:"auto_delete_head_branches,omitempty"`
 	SquashMergeCommitTitle   *string `yaml:"squash_merge_commit_title,omitempty"   validate:"omitempty,oneof=PR_TITLE COMMIT_OR_PR_TITLE"`
 	SquashMergeCommitMessage *string `yaml:"squash_merge_commit_message,omitempty" validate:"omitempty,oneof=COMMIT_MESSAGES PR_BODY BLANK"`

--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -264,6 +264,9 @@ func (p *Processor) applyRepoPatch(ctx context.Context, fullName string, repo *m
 		if ms.AllowRebaseMerge != nil {
 			payload["allow_rebase_merge"] = *ms.AllowRebaseMerge
 		}
+		if ms.AllowAutoMerge != nil {
+			payload["allow_auto_merge"] = *ms.AllowAutoMerge
+		}
 		if ms.AutoDeleteHeadBranches != nil {
 			payload["delete_branch_on_merge"] = *ms.AutoDeleteHeadBranches
 		}

--- a/internal/repository/apply_test.go
+++ b/internal/repository/apply_test.go
@@ -955,6 +955,7 @@ func TestApplyRepoPatch_BatchesSettings(t *testing.T) {
 		AllowMergeCommit:         manifest.Ptr(true),
 		AllowSquashMerge:         manifest.Ptr(true),
 		AllowRebaseMerge:         manifest.Ptr(false),
+		AllowAutoMerge:           manifest.Ptr(true),
 		AutoDeleteHeadBranches:   manifest.Ptr(true),
 		SquashMergeCommitTitle:   manifest.Ptr("COMMIT_OR_PR_TITLE"),
 		SquashMergeCommitMessage: manifest.Ptr("COMMIT_MESSAGES"),
@@ -1009,6 +1010,9 @@ func TestApplyRepoPatch_BatchesSettings(t *testing.T) {
 	}
 	if payload["allow_rebase_merge"] != false {
 		t.Errorf("allow_rebase_merge = %v, want false", payload["allow_rebase_merge"])
+	}
+	if payload["allow_auto_merge"] != true {
+		t.Errorf("allow_auto_merge = %v, want true", payload["allow_auto_merge"])
 	}
 	if payload["delete_branch_on_merge"] != true {
 		t.Errorf("delete_branch_on_merge = %v, want true", payload["delete_branch_on_merge"])

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -198,6 +198,7 @@ func diffMergeStrategy(name string, desired *manifest.Repository, current *Curre
 		appendChildChanged(cc, "allow_merge_commit", ms.AllowMergeCommit, current.MergeStrategy.AllowMergeCommit)
 		appendChildChanged(cc, "allow_squash_merge", ms.AllowSquashMerge, current.MergeStrategy.AllowSquashMerge)
 		appendChildChanged(cc, "allow_rebase_merge", ms.AllowRebaseMerge, current.MergeStrategy.AllowRebaseMerge)
+		appendChildChanged(cc, "allow_auto_merge", ms.AllowAutoMerge, current.MergeStrategy.AllowAutoMerge)
 		appendChildChanged(cc, "auto_delete_head_branches", ms.AutoDeleteHeadBranches, current.MergeStrategy.AutoDeleteHeadBranches)
 		appendChildChanged(cc, "merge_commit_title", ms.MergeCommitTitle, current.MergeStrategy.MergeCommitTitle)
 		appendChildChanged(cc, "merge_commit_message", ms.MergeCommitMessage, current.MergeStrategy.MergeCommitMessage)

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -286,6 +286,14 @@ func TestDiff_MergeStrategy_BoolFlags(t *testing.T) {
 			wantField: "allow_rebase_merge",
 		},
 		{
+			name: "allow_auto_merge enabled",
+			setup: func(ms *manifest.MergeStrategy, c *CurrentState) {
+				ms.AllowAutoMerge = manifest.Ptr(true)
+				c.MergeStrategy.AllowAutoMerge = false
+			},
+			wantField: "allow_auto_merge",
+		},
+		{
 			name: "auto_delete_head_branches enabled",
 			setup: func(ms *manifest.MergeStrategy, c *CurrentState) {
 				ms.AutoDeleteHeadBranches = manifest.Ptr(true)

--- a/internal/repository/export.go
+++ b/internal/repository/export.go
@@ -38,6 +38,7 @@ func ToManifest(ctx context.Context, r *CurrentState, resolver *manifest.Resolve
 				AllowMergeCommit:         manifest.Ptr(r.MergeStrategy.AllowMergeCommit),
 				AllowSquashMerge:         manifest.Ptr(r.MergeStrategy.AllowSquashMerge),
 				AllowRebaseMerge:         manifest.Ptr(r.MergeStrategy.AllowRebaseMerge),
+				AllowAutoMerge:           manifest.Ptr(r.MergeStrategy.AllowAutoMerge),
 				AutoDeleteHeadBranches:   manifest.Ptr(r.MergeStrategy.AutoDeleteHeadBranches),
 				MergeCommitTitle:         manifest.Ptr(r.MergeStrategy.MergeCommitTitle),
 				MergeCommitMessage:       manifest.Ptr(r.MergeStrategy.MergeCommitMessage),

--- a/internal/repository/state.go
+++ b/internal/repository/state.go
@@ -206,6 +206,7 @@ func (p *Processor) FetchRepository(ctx context.Context, owner, name string, onS
 	repo.MergeStrategy.MergeCommitMessage = commitMsgSettings.MergeCommitMessage
 	repo.MergeStrategy.SquashMergeCommitTitle = commitMsgSettings.SquashMergeCommitTitle
 	repo.MergeStrategy.SquashMergeCommitMessage = commitMsgSettings.SquashMergeCommitMessage
+	repo.MergeStrategy.AllowAutoMerge = commitMsgSettings.AllowAutoMerge
 	repo.Security = CurrentSecurity{
 		VulnerabilityAlerts:           vulnerabilityAlerts,
 		AutomatedSecurityFixes:        automatedSecurityFixes,
@@ -287,12 +288,13 @@ type commitMessageSettings struct {
 	MergeCommitMessage       string
 	SquashMergeCommitTitle   string
 	SquashMergeCommitMessage string
+	AllowAutoMerge           bool
 }
 
 func (p *Processor) fetchCommitMessageSettings(ctx context.Context, owner, name string) (commitMessageSettings, error) {
 	out, err := p.runner.Run(ctx,
 		"api", fmt.Sprintf("repos/%s/%s", owner, name),
-		"--jq", "{squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message}",
+		"--jq", "{squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}",
 	)
 	if err != nil {
 		return commitMessageSettings{}, err
@@ -303,6 +305,7 @@ func (p *Processor) fetchCommitMessageSettings(ctx context.Context, owner, name 
 		SquashMergeCommitMessage *string `json:"squash_merge_commit_message"`
 		MergeCommitTitle         *string `json:"merge_commit_title"`
 		MergeCommitMessage       *string `json:"merge_commit_message"`
+		AllowAutoMerge           bool    `json:"allow_auto_merge"`
 	}
 	if err := json.Unmarshal(out, &raw); err != nil {
 		return commitMessageSettings{}, err
@@ -320,6 +323,7 @@ func (p *Processor) fetchCommitMessageSettings(ctx context.Context, owner, name 
 		MergeCommitMessage:       deref(raw.MergeCommitMessage, "PR_TITLE"),
 		SquashMergeCommitTitle:   deref(raw.SquashMergeCommitTitle, "COMMIT_OR_PR_TITLE"),
 		SquashMergeCommitMessage: deref(raw.SquashMergeCommitMessage, "COMMIT_MESSAGES"),
+		AllowAutoMerge:           raw.AllowAutoMerge,
 	}, nil
 }
 

--- a/internal/repository/state_test.go
+++ b/internal/repository/state_test.go
@@ -42,11 +42,12 @@ func TestFetchRepository(t *testing.T) {
 				"deleteBranchOnMerge": true,
 				"defaultBranchRef": {"name": "main"}
 			}`),
-			"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message}": []byte(`{
+			"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}": []byte(`{
 				"squash_merge_commit_title": "PR_TITLE",
 				"squash_merge_commit_message": "COMMIT_MESSAGES",
 				"merge_commit_title": "MERGE_MESSAGE",
-				"merge_commit_message": "PR_BODY"
+				"merge_commit_message": "PR_BODY",
+				"allow_auto_merge": false
 			}`),
 			"api repos/myorg/myrepo/immutable-releases":                                       []byte(`{"enabled": false}`),
 			"api repos/myorg/myrepo/vulnerability-alerts":                                     []byte(``),
@@ -305,7 +306,7 @@ func TestFetchVariables(t *testing.T) {
 func TestFetchCommitMessageSettings_NullValues(t *testing.T) {
 	mock := &gh.MockRunner{
 		Responses: map[string][]byte{
-			"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message}": []byte(`{
+			"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}": []byte(`{
 				"squash_merge_commit_title": null,
 				"squash_merge_commit_message": null,
 				"merge_commit_title": null,
@@ -360,7 +361,7 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 			"deleteBranchOnMerge": true,
 			"defaultBranchRef": {"name": "main"}
 		}`),
-		"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message}": []byte(`{
+		"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}": []byte(`{
 			"squash_merge_commit_title": "PR_TITLE",
 			"squash_merge_commit_message": "COMMIT_MESSAGES",
 			"merge_commit_title": "MERGE_MESSAGE",
@@ -375,12 +376,12 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 	t.Run("commit message settings 404 is ignored", func(t *testing.T) {
 		responses := make(map[string][]byte)
 		maps.Copy(responses, baseResponses)
-		delete(responses, "api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message}")
+		delete(responses, "api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}")
 
 		mock := &gh.MockRunner{
 			Responses: responses,
 			Errors: map[string]error{
-				"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message}": fmt.Errorf("%w: api error", gh.ErrNotFound),
+				"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}": fmt.Errorf("%w: api error", gh.ErrNotFound),
 			},
 		}
 		p := NewProcessor(mock, nil)
@@ -417,12 +418,12 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 	t.Run("commit message settings 500 propagates error", func(t *testing.T) {
 		responses := make(map[string][]byte)
 		maps.Copy(responses, baseResponses)
-		delete(responses, "api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message}")
+		delete(responses, "api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}")
 
 		mock := &gh.MockRunner{
 			Responses: responses,
 			Errors: map[string]error{
-				"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message}": fmt.Errorf("internal server error"),
+				"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}": fmt.Errorf("internal server error"),
 			},
 		}
 		p := NewProcessor(mock, nil)

--- a/internal/repository/state_types.go
+++ b/internal/repository/state_types.go
@@ -53,6 +53,7 @@ type CurrentMergeStrategy struct {
 	AllowMergeCommit         bool
 	AllowSquashMerge         bool
 	AllowRebaseMerge         bool
+	AllowAutoMerge           bool
 	AutoDeleteHeadBranches   bool
 	MergeCommitTitle         string
 	MergeCommitMessage       string


### PR DESCRIPTION
## Summary

Add `allow_auto_merge` field to `merge_strategy` so repositories can declaratively enable/disable GitHub's auto-merge feature. Closes #124.

## Background

GitHub's REST API supports `allow_auto_merge` (boolean), which lets pull requests auto-merge once all required checks and reviews pass. gh-infra's `merge_strategy` already manages the other merge-related booleans but was missing this one, forcing users to configure it manually.

Note: `allow_auto_merge` is not available via GitHub's GraphQL API (`gh repo view --json`), so it is fetched via the REST API alongside commit message settings.

## Changes

- Add `AllowAutoMerge` field to `MergeStrategy` manifest struct and `CurrentMergeStrategy` runtime struct
- Fetch `allow_auto_merge` via REST API (`gh api repos/{owner}/{repo}`) in `fetchCommitMessageSettings`
- Wire through diff, apply (both create-patch and update-batch), export, and import paths
- Update mock-gh default `commit-settings.json` fallback to include `allow_auto_merge`
- Update docs (`general.md`) and agent skill references with the new field
- Add `.claude/rules/mock-gh-sync.md` to prevent future sync misses when API fields change
- Add test coverage for the new field in diff, apply, and state tests