### PR TITLE
Key-based merge for collection fields in RepositorySet defaults

### DIFF
--- a/docs/src/content/docs/resources/repository-set/defaults.md
+++ b/docs/src/content/docs/resources/repository-set/defaults.md
@@ -44,7 +44,7 @@ repositories:
 
 ### Lists — replaced entirely
 
-Lists like `topics`, `labels`, and `branch_protection` are **not merged** — the per-repo list replaces the default list entirely.
+Lists like `topics` are **not merged** — the per-repo list replaces the default list entirely.
 
 ```yaml
 defaults:
@@ -60,9 +60,85 @@ repositories:
       description: "A CLI tool"     # topics stays [go, cli] (not specified)
 ```
 
+### Collections — merged by key
+
+Collections with a natural key field are merged. Entries with the same key are merged or overridden; new entries are appended. Omitting the collection entirely inherits the full default.
+
+| Collection | Key field | Same-key behavior |
+|---|---|---|
+| `labels` | `name` | Entry replaced |
+| `branch_protection` | `pattern` | Fields merged (unspecified fields inherit default) |
+| `rulesets` | `name` | Entry replaced |
+
+#### Labels
+
+```yaml
+defaults:
+  spec:
+    labels:
+      - name: kind/bug
+        color: d73a4a
+        description: A bug
+      - name: kind/feature
+        color: "425df5"
+
+repositories:
+  - name: my-repo
+    spec:
+      labels:
+        - name: kind/bug
+          color: "FF0000"       # overrides default kind/bug
+        - name: custom
+          color: "00FF00"       # appended
+      # result: kind/bug (FF0000) + kind/feature (425df5) + custom (00FF00)
+```
+
+#### Branch protection
+
+Same-pattern rules are merged at the field level — only specify the fields you want to override.
+
+```yaml
+defaults:
+  spec:
+    branch_protection:
+      - pattern: main
+        required_reviews: 1
+        dismiss_stale_reviews: true
+
+repositories:
+  - name: my-repo
+    spec:
+      branch_protection:
+        - pattern: main
+          required_reviews: 2       # overrides → 2; dismiss_stale_reviews stays true
+        - pattern: release/*
+          required_reviews: 1       # appended
+```
+
+#### Rulesets
+
+Same-name rulesets are replaced entirely.
+
+```yaml
+defaults:
+  spec:
+    rulesets:
+      - name: protect-main
+        target: branch
+        enforcement: active
+
+repositories:
+  - name: my-repo
+    spec:
+      rulesets:
+        - name: protect-main
+          target: branch
+          enforcement: evaluate   # replaces the entire default ruleset entry
+```
+
 ### Maps — merged by key
 
-Maps like `features` and `merge_strategy` are merged. Only specified keys are overridden; unspecified keys retain the default value.
+Maps like `features`, `merge_strategy`, and `actions` are merged. Only specified keys are overridden; unspecified keys retain the default value.
 
 ```yaml
 defaults:

--- a/internal/importer/repository.go
+++ b/internal/importer/repository.go
@@ -1136,26 +1136,22 @@ func minimalOverride(defaults, imported manifest.RepositorySpec) manifest.Reposi
 	// MergeStrategy: key-level comparison
 	override.MergeStrategy = minimalMergeStrategy(defaults.MergeStrategy, imported.MergeStrategy)
 
-	// Complex fields: override if different from defaults
-	if !reflect.DeepEqual(defaults.BranchProtection, imported.BranchProtection) {
-		override.BranchProtection = imported.BranchProtection
-	}
-	if !reflect.DeepEqual(defaults.Rulesets, imported.Rulesets) {
-		override.Rulesets = imported.Rulesets
-	}
-	if !reflect.DeepEqual(defaults.Actions, imported.Actions) {
-		override.Actions = imported.Actions
-	}
+	// BranchProtection: only include rules that differ from defaults (by pattern, field-level).
+	override.BranchProtection = minimalBranchProtection(defaults.BranchProtection, imported.BranchProtection)
+
+	// Rulesets: only include rulesets that differ from or are absent in defaults.
+	override.Rulesets = minimalRulesets(defaults.Rulesets, imported.Rulesets)
+
+	// Actions: key-level comparison (matches mergeActions behavior).
+	override.Actions = minimalActions(defaults.Actions, imported.Actions)
 
 	// Variables: override if different
 	if !reflect.DeepEqual(defaults.Variables, imported.Variables) {
 		override.Variables = imported.Variables
 	}
 
-	// Labels: override if different
-	if !reflect.DeepEqual(defaults.Labels, imported.Labels) {
-		override.Labels = imported.Labels
-	}
+	// Labels: only include labels that differ from or are absent in defaults.
+	override.Labels = minimalLabels(defaults.Labels, imported.Labels)
 
 	// Secrets: always preserve local override (not from import)
 	// The caller already sets imported.Secrets = local.Secrets,
@@ -1170,6 +1166,150 @@ func minimalOverride(defaults, imported manifest.RepositorySpec) manifest.Reposi
 	}
 
 	return override
+}
+
+// minimalLabels returns only the imported labels that are new or different from defaults.
+func minimalLabels(defaults, imported []manifest.Label) []manifest.Label {
+	if len(imported) == 0 {
+		return nil
+	}
+
+	defaultMap := make(map[string]manifest.Label, len(defaults))
+	for _, l := range defaults {
+		defaultMap[l.Name] = l
+	}
+
+	var result []manifest.Label
+	for _, l := range imported {
+		if dl, ok := defaultMap[l.Name]; !ok || dl != l {
+			result = append(result, l)
+		}
+	}
+	return result
+}
+
+// minimalBranchProtection returns only branch protection rules that are new or
+// have fields different from the default rule with the same pattern.
+func minimalBranchProtection(defaults, imported []manifest.BranchProtection) []manifest.BranchProtection {
+	if len(imported) == 0 {
+		return nil
+	}
+
+	defaultMap := make(map[string]manifest.BranchProtection, len(defaults))
+	for _, bp := range defaults {
+		defaultMap[bp.Pattern] = bp
+	}
+
+	var result []manifest.BranchProtection
+	for _, bp := range imported {
+		dbp, ok := defaultMap[bp.Pattern]
+		if !ok {
+			result = append(result, bp)
+			continue
+		}
+		// Same pattern exists in defaults — emit only differing fields.
+		minimal := manifest.BranchProtection{Pattern: bp.Pattern}
+		any := false
+		if !intPtrEqual(dbp.RequiredReviews, bp.RequiredReviews) {
+			minimal.RequiredReviews = bp.RequiredReviews
+			any = true
+		}
+		if !boolPtrEqual(dbp.DismissStaleReviews, bp.DismissStaleReviews) {
+			minimal.DismissStaleReviews = bp.DismissStaleReviews
+			any = true
+		}
+		if !boolPtrEqual(dbp.RequireCodeOwnerReviews, bp.RequireCodeOwnerReviews) {
+			minimal.RequireCodeOwnerReviews = bp.RequireCodeOwnerReviews
+			any = true
+		}
+		if !reflect.DeepEqual(dbp.RequireStatusChecks, bp.RequireStatusChecks) {
+			minimal.RequireStatusChecks = bp.RequireStatusChecks
+			any = true
+		}
+		if !boolPtrEqual(dbp.EnforceAdmins, bp.EnforceAdmins) {
+			minimal.EnforceAdmins = bp.EnforceAdmins
+			any = true
+		}
+		if !boolPtrEqual(dbp.RestrictPushes, bp.RestrictPushes) {
+			minimal.RestrictPushes = bp.RestrictPushes
+			any = true
+		}
+		if !boolPtrEqual(dbp.AllowForcePushes, bp.AllowForcePushes) {
+			minimal.AllowForcePushes = bp.AllowForcePushes
+			any = true
+		}
+		if !boolPtrEqual(dbp.AllowDeletions, bp.AllowDeletions) {
+			minimal.AllowDeletions = bp.AllowDeletions
+			any = true
+		}
+		if any {
+			result = append(result, minimal)
+		}
+	}
+	return result
+}
+
+// minimalRulesets returns only rulesets that are new or different from defaults.
+func minimalRulesets(defaults, imported []manifest.Ruleset) []manifest.Ruleset {
+	if len(imported) == 0 {
+		return nil
+	}
+
+	defaultMap := make(map[string]manifest.Ruleset, len(defaults))
+	for _, rs := range defaults {
+		defaultMap[rs.Name] = rs
+	}
+
+	var result []manifest.Ruleset
+	for _, rs := range imported {
+		if drs, ok := defaultMap[rs.Name]; !ok || !reflect.DeepEqual(drs, rs) {
+			result = append(result, rs)
+		}
+	}
+	return result
+}
+
+// minimalActions returns only action fields that differ from defaults.
+func minimalActions(defaults, imported *manifest.Actions) *manifest.Actions {
+	if imported == nil {
+		return nil
+	}
+	d := derefActions(defaults)
+	i := *imported
+	var a manifest.Actions
+	any := false
+	if !boolPtrEqual(d.Enabled, i.Enabled) {
+		a.Enabled = i.Enabled
+		any = true
+	}
+	if !ptrEqual(d.AllowedActions, i.AllowedActions) {
+		a.AllowedActions = i.AllowedActions
+		any = true
+	}
+	if !boolPtrEqual(d.SHAPinningRequired, i.SHAPinningRequired) {
+		a.SHAPinningRequired = i.SHAPinningRequired
+		any = true
+	}
+	if !ptrEqual(d.WorkflowPermissions, i.WorkflowPermissions) {
+		a.WorkflowPermissions = i.WorkflowPermissions
+		any = true
+	}
+	if !boolPtrEqual(d.CanApprovePullRequests, i.CanApprovePullRequests) {
+		a.CanApprovePullRequests = i.CanApprovePullRequests
+		any = true
+	}
+	if !reflect.DeepEqual(d.SelectedActions, i.SelectedActions) {
+		a.SelectedActions = i.SelectedActions
+		any = true
+	}
+	if !ptrEqual(d.ForkPRApproval, i.ForkPRApproval) {
+		a.ForkPRApproval = i.ForkPRApproval
+		any = true
+	}
+	if !any {
+		return nil
+	}
+	return &a
 }
 
 func minimalFeatures(defaults, imported *manifest.Features) *manifest.Features {
@@ -1274,6 +1414,17 @@ func ptrEqual(a, b *string) bool {
 
 func boolPtrEqual(a, b *bool) bool {
 	return derefBool(a) == derefBool(b)
+}
+
+func intPtrEqual(a, b *int) bool {
+	return derefInt(a) == derefInt(b)
+}
+
+func derefInt(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
 }
 
 func derefStr(p *string) string {

--- a/internal/importer/repository_test.go
+++ b/internal/importer/repository_test.go
@@ -681,7 +681,7 @@ func TestMinimalOverride_LabelsOnlyDiff(t *testing.T) {
 
 	imported := manifest.RepositorySpec{
 		Labels: []manifest.Label{
-			{Name: "kind/bug", Color: "d73a4a", Description: "A bug"},       // same
+			{Name: "kind/bug", Color: "d73a4a", Description: "A bug"},         // same
 			{Name: "kind/feature", Color: "FF0000", Description: "A feature"}, // color changed
 			{Name: "custom", Color: "00FF00", Description: "Custom label"},    // new
 		},
@@ -729,7 +729,7 @@ func TestMinimalOverride_BranchProtection(t *testing.T) {
 		BranchProtection: []manifest.BranchProtection{
 			{
 				Pattern:         "main",
-				RequiredReviews: manifest.Ptr(2), // changed
+				RequiredReviews: manifest.Ptr(2),    // changed
 				EnforceAdmins:   manifest.Ptr(true), // same
 			},
 			{
@@ -810,7 +810,7 @@ func TestMinimalOverride_Actions(t *testing.T) {
 	imported := manifest.RepositorySpec{
 		Actions: &manifest.Actions{
 			Enabled:             manifest.Ptr(true),   // same
-			AllowedActions:      manifest.Ptr("all"),   // same
+			AllowedActions:      manifest.Ptr("all"),  // same
 			WorkflowPermissions: manifest.Ptr("read"), // new
 		},
 	}

--- a/internal/importer/repository_test.go
+++ b/internal/importer/repository_test.go
@@ -671,6 +671,181 @@ func TestMinimalOverride_TopicsOverride(t *testing.T) {
 	}
 }
 
+func TestMinimalOverride_LabelsOnlyDiff(t *testing.T) {
+	defaults := manifest.RepositorySpec{
+		Labels: []manifest.Label{
+			{Name: "kind/bug", Color: "d73a4a", Description: "A bug"},
+			{Name: "kind/feature", Color: "425df5", Description: "A feature"},
+		},
+	}
+
+	imported := manifest.RepositorySpec{
+		Labels: []manifest.Label{
+			{Name: "kind/bug", Color: "d73a4a", Description: "A bug"},       // same
+			{Name: "kind/feature", Color: "FF0000", Description: "A feature"}, // color changed
+			{Name: "custom", Color: "00FF00", Description: "Custom label"},    // new
+		},
+	}
+
+	override := minimalOverride(defaults, imported)
+
+	if len(override.Labels) != 2 {
+		t.Fatalf("expected 2 labels in override, got %d: %+v", len(override.Labels), override.Labels)
+	}
+	if override.Labels[0].Name != "kind/feature" || override.Labels[0].Color != "FF0000" {
+		t.Errorf("expected kind/feature override, got %+v", override.Labels[0])
+	}
+	if override.Labels[1].Name != "custom" {
+		t.Errorf("expected custom label, got %+v", override.Labels[1])
+	}
+}
+
+func TestMinimalOverride_LabelsAllSame(t *testing.T) {
+	labels := []manifest.Label{
+		{Name: "kind/bug", Color: "d73a4a", Description: "A bug"},
+	}
+	defaults := manifest.RepositorySpec{Labels: labels}
+	imported := manifest.RepositorySpec{Labels: labels}
+
+	override := minimalOverride(defaults, imported)
+
+	if len(override.Labels) != 0 {
+		t.Errorf("expected no label overrides, got %d: %+v", len(override.Labels), override.Labels)
+	}
+}
+
+func TestMinimalOverride_BranchProtection(t *testing.T) {
+	defaults := manifest.RepositorySpec{
+		BranchProtection: []manifest.BranchProtection{
+			{
+				Pattern:         "main",
+				RequiredReviews: manifest.Ptr(1),
+				EnforceAdmins:   manifest.Ptr(true),
+			},
+		},
+	}
+
+	imported := manifest.RepositorySpec{
+		BranchProtection: []manifest.BranchProtection{
+			{
+				Pattern:         "main",
+				RequiredReviews: manifest.Ptr(2), // changed
+				EnforceAdmins:   manifest.Ptr(true), // same
+			},
+			{
+				Pattern:         "release/*",
+				RequiredReviews: manifest.Ptr(1), // new
+			},
+		},
+	}
+
+	override := minimalOverride(defaults, imported)
+
+	if len(override.BranchProtection) != 2 {
+		t.Fatalf("expected 2 bp rules, got %d: %+v", len(override.BranchProtection), override.BranchProtection)
+	}
+	// main: only required_reviews differs
+	mainBP := override.BranchProtection[0]
+	if mainBP.Pattern != "main" {
+		t.Errorf("expected main, got %q", mainBP.Pattern)
+	}
+	if mainBP.RequiredReviews == nil || *mainBP.RequiredReviews != 2 {
+		t.Errorf("main required_reviews should be 2")
+	}
+	if mainBP.EnforceAdmins != nil {
+		t.Errorf("main enforce_admins should be nil (same as defaults)")
+	}
+	// release/* is new, included as-is
+	if override.BranchProtection[1].Pattern != "release/*" {
+		t.Errorf("expected release/*, got %q", override.BranchProtection[1].Pattern)
+	}
+}
+
+func TestMinimalOverride_BranchProtectionAllSame(t *testing.T) {
+	bp := []manifest.BranchProtection{
+		{Pattern: "main", RequiredReviews: manifest.Ptr(1)},
+	}
+	defaults := manifest.RepositorySpec{BranchProtection: bp}
+	imported := manifest.RepositorySpec{BranchProtection: bp}
+
+	override := minimalOverride(defaults, imported)
+
+	if len(override.BranchProtection) != 0 {
+		t.Errorf("expected no bp overrides, got %d", len(override.BranchProtection))
+	}
+}
+
+func TestMinimalOverride_Rulesets(t *testing.T) {
+	defaults := manifest.RepositorySpec{
+		Rulesets: []manifest.Ruleset{
+			{Name: "default-rs", Target: manifest.Ptr("branch"), Enforcement: manifest.Ptr("active")},
+		},
+	}
+
+	imported := manifest.RepositorySpec{
+		Rulesets: []manifest.Ruleset{
+			{Name: "default-rs", Target: manifest.Ptr("branch"), Enforcement: manifest.Ptr("active")}, // same
+			{Name: "custom-rs", Target: manifest.Ptr("tag"), Enforcement: manifest.Ptr("active")},     // new
+		},
+	}
+
+	override := minimalOverride(defaults, imported)
+
+	if len(override.Rulesets) != 1 {
+		t.Fatalf("expected 1 ruleset override, got %d: %+v", len(override.Rulesets), override.Rulesets)
+	}
+	if override.Rulesets[0].Name != "custom-rs" {
+		t.Errorf("expected custom-rs, got %q", override.Rulesets[0].Name)
+	}
+}
+
+func TestMinimalOverride_Actions(t *testing.T) {
+	defaults := manifest.RepositorySpec{
+		Actions: &manifest.Actions{
+			Enabled:        manifest.Ptr(true),
+			AllowedActions: manifest.Ptr("all"),
+		},
+	}
+
+	imported := manifest.RepositorySpec{
+		Actions: &manifest.Actions{
+			Enabled:             manifest.Ptr(true),   // same
+			AllowedActions:      manifest.Ptr("all"),   // same
+			WorkflowPermissions: manifest.Ptr("read"), // new
+		},
+	}
+
+	override := minimalOverride(defaults, imported)
+
+	if override.Actions == nil {
+		t.Fatal("actions should not be nil")
+	}
+	if override.Actions.Enabled != nil {
+		t.Errorf("enabled should be nil (same as defaults)")
+	}
+	if override.Actions.AllowedActions != nil {
+		t.Errorf("allowed_actions should be nil (same as defaults)")
+	}
+	if override.Actions.WorkflowPermissions == nil || *override.Actions.WorkflowPermissions != "read" {
+		t.Errorf("workflow_permissions should be read")
+	}
+}
+
+func TestMinimalOverride_ActionsAllSame(t *testing.T) {
+	actions := &manifest.Actions{
+		Enabled:        manifest.Ptr(true),
+		AllowedActions: manifest.Ptr("all"),
+	}
+	defaults := manifest.RepositorySpec{Actions: actions}
+	imported := manifest.RepositorySpec{Actions: actions}
+
+	override := minimalOverride(defaults, imported)
+
+	if override.Actions != nil {
+		t.Errorf("actions should be nil (same as defaults), got %+v", override.Actions)
+	}
+}
+
 func TestCompareSpecs_NoDiff(t *testing.T) {
 	spec := manifest.RepositorySpec{
 		Description: manifest.Ptr("test"),

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -386,10 +386,10 @@ func mergeSpecs(defaults *RepositorySetDefaults, override RepositorySpec) Reposi
 		result.Actions = mergeActions(result.Actions, override.Actions)
 	}
 	if len(override.BranchProtection) > 0 {
-		result.BranchProtection = override.BranchProtection
+		result.BranchProtection = mergeBranchProtection(result.BranchProtection, override.BranchProtection)
 	}
 	if len(override.Rulesets) > 0 {
-		result.Rulesets = override.Rulesets
+		result.Rulesets = mergeRulesets(result.Rulesets, override.Rulesets)
 	}
 	if len(override.Secrets) > 0 {
 		result.Secrets = override.Secrets
@@ -398,7 +398,7 @@ func mergeSpecs(defaults *RepositorySetDefaults, override RepositorySpec) Reposi
 		result.Variables = override.Variables
 	}
 	if len(override.Labels) > 0 {
-		result.Labels = override.Labels
+		result.Labels = mergeLabels(result.Labels, override.Labels)
 	}
 	if override.LabelSync != nil {
 		result.LabelSync = override.LabelSync
@@ -520,6 +520,119 @@ func mergeActions(base, override *Actions) *Actions {
 		result.SelectedActions = mergeSelectedActions(result.SelectedActions, override.SelectedActions)
 	}
 	return &result
+}
+
+// mergeLabels merges two label slices by name. Override labels take precedence
+// for entries with the same name; new labels are appended.
+func mergeLabels(base, override []Label) []Label {
+	if len(base) == 0 {
+		return override
+	}
+	if len(override) == 0 {
+		return base
+	}
+
+	index := make(map[string]int, len(base))
+	result := make([]Label, len(base))
+	copy(result, base)
+	for i, l := range result {
+		index[l.Name] = i
+	}
+
+	for _, l := range override {
+		if i, ok := index[l.Name]; ok {
+			result[i] = l
+		} else {
+			index[l.Name] = len(result)
+			result = append(result, l)
+		}
+	}
+	return result
+}
+
+// mergeBranchProtection merges two branch protection slices by pattern.
+// Same-pattern entries are merged at the field level; new patterns are appended.
+func mergeBranchProtection(base, override []BranchProtection) []BranchProtection {
+	if len(base) == 0 {
+		return override
+	}
+	if len(override) == 0 {
+		return base
+	}
+
+	index := make(map[string]int, len(base))
+	result := make([]BranchProtection, len(base))
+	copy(result, base)
+	for i, bp := range result {
+		index[bp.Pattern] = i
+	}
+
+	for _, bp := range override {
+		if i, ok := index[bp.Pattern]; ok {
+			result[i] = mergeBranchProtectionEntry(result[i], bp)
+		} else {
+			index[bp.Pattern] = len(result)
+			result = append(result, bp)
+		}
+	}
+	return result
+}
+
+func mergeBranchProtectionEntry(base, override BranchProtection) BranchProtection {
+	result := base
+	if override.RequiredReviews != nil {
+		result.RequiredReviews = override.RequiredReviews
+	}
+	if override.DismissStaleReviews != nil {
+		result.DismissStaleReviews = override.DismissStaleReviews
+	}
+	if override.RequireCodeOwnerReviews != nil {
+		result.RequireCodeOwnerReviews = override.RequireCodeOwnerReviews
+	}
+	if override.RequireStatusChecks != nil {
+		result.RequireStatusChecks = override.RequireStatusChecks
+	}
+	if override.EnforceAdmins != nil {
+		result.EnforceAdmins = override.EnforceAdmins
+	}
+	if override.RestrictPushes != nil {
+		result.RestrictPushes = override.RestrictPushes
+	}
+	if override.AllowForcePushes != nil {
+		result.AllowForcePushes = override.AllowForcePushes
+	}
+	if override.AllowDeletions != nil {
+		result.AllowDeletions = override.AllowDeletions
+	}
+	return result
+}
+
+// mergeRulesets merges two ruleset slices by name. Override rulesets take precedence
+// for entries with the same name; new rulesets are appended.
+func mergeRulesets(base, override []Ruleset) []Ruleset {
+	if len(base) == 0 {
+		return override
+	}
+	if len(override) == 0 {
+		return base
+	}
+
+	index := make(map[string]int, len(base))
+	result := make([]Ruleset, len(base))
+	copy(result, base)
+	for i, rs := range result {
+		index[rs.Name] = i
+	}
+
+	for _, rs := range override {
+		if i, ok := index[rs.Name]; ok {
+			result[i] = rs
+		} else {
+			index[rs.Name] = len(result)
+			result = append(result, rs)
+		}
+	}
+	return result
 }
 
 func mergeSelectedActions(base, override *SelectedActions) *SelectedActions {

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -1558,12 +1558,197 @@ repositories:
 		t.Errorf("inherits-labels: expected 2 labels, got %d", len(repos[0].Spec.Labels))
 	}
 
-	// Second repo overrides with its own labels (full replacement)
-	if len(repos[1].Spec.Labels) != 1 {
-		t.Fatalf("overrides-labels: expected 1 label, got %d", len(repos[1].Spec.Labels))
+	// Second repo merges defaults + its own labels (3 total)
+	if len(repos[1].Spec.Labels) != 3 {
+		t.Fatalf("overrides-labels: expected 3 labels, got %d", len(repos[1].Spec.Labels))
 	}
-	if repos[1].Spec.Labels[0].Name != "custom-label" {
-		t.Errorf("expected custom-label, got %q", repos[1].Spec.Labels[0].Name)
+	labelNames := make(map[string]bool)
+	for _, l := range repos[1].Spec.Labels {
+		labelNames[l.Name] = true
+	}
+	for _, want := range []string{"kind/bug", "kind/feature", "custom-label"} {
+		if !labelNames[want] {
+			t.Errorf("overrides-labels: missing label %q", want)
+		}
+	}
+}
+
+func TestRepositorySet_LabelsMerge_OverrideByName(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: RepositorySet
+metadata:
+  owner: org
+defaults:
+  spec:
+    labels:
+      - name: kind/bug
+        color: d73a4a
+        description: A bug
+      - name: kind/feature
+        color: "425df5"
+        description: A feature
+repositories:
+  - name: repo-a
+    spec:
+      labels:
+        - name: kind/bug
+          color: "FF0000"
+          description: Updated bug description
+        - name: custom
+          color: "00FF00"
+`
+	path := filepath.Join(dir, "labels.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath error: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+
+	labels := repos[0].Spec.Labels
+	if len(labels) != 3 {
+		t.Fatalf("expected 3 labels, got %d", len(labels))
+	}
+
+	// kind/bug should be overridden by repo
+	if labels[0].Name != "kind/bug" || labels[0].Color != "FF0000" {
+		t.Errorf("kind/bug not overridden: got color=%q", labels[0].Color)
+	}
+	// kind/feature should be inherited from defaults
+	if labels[1].Name != "kind/feature" || labels[1].Color != "425df5" {
+		t.Errorf("kind/feature not inherited: got %+v", labels[1])
+	}
+	// custom should be appended
+	if labels[2].Name != "custom" || labels[2].Color != "00FF00" {
+		t.Errorf("custom not appended: got %+v", labels[2])
+	}
+}
+
+func TestRepositorySet_BranchProtectionMerge(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: RepositorySet
+metadata:
+  owner: org
+defaults:
+  spec:
+    branch_protection:
+      - pattern: main
+        required_reviews: 1
+        dismiss_stale_reviews: true
+repositories:
+  - name: inherits-bp
+    spec:
+      description: "inherits default branch protection"
+  - name: overrides-bp
+    spec:
+      branch_protection:
+        - pattern: main
+          required_reviews: 2
+        - pattern: release/*
+          required_reviews: 1
+`
+	path := filepath.Join(dir, "bp.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath error: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+
+	// First repo inherits default branch protection
+	if len(repos[0].Spec.BranchProtection) != 1 {
+		t.Fatalf("inherits-bp: expected 1 rule, got %d", len(repos[0].Spec.BranchProtection))
+	}
+	if *repos[0].Spec.BranchProtection[0].RequiredReviews != 1 {
+		t.Errorf("inherits-bp: expected required_reviews=1, got %d", *repos[0].Spec.BranchProtection[0].RequiredReviews)
+	}
+
+	// Second repo: main rule merged (required_reviews overridden, dismiss_stale_reviews inherited)
+	bp := repos[1].Spec.BranchProtection
+	if len(bp) != 2 {
+		t.Fatalf("overrides-bp: expected 2 rules, got %d", len(bp))
+	}
+	if *bp[0].RequiredReviews != 2 {
+		t.Errorf("overrides-bp main: expected required_reviews=2, got %d", *bp[0].RequiredReviews)
+	}
+	if bp[0].DismissStaleReviews == nil || *bp[0].DismissStaleReviews != true {
+		t.Errorf("overrides-bp main: dismiss_stale_reviews should be inherited as true")
+	}
+	// release/* is new
+	if bp[1].Pattern != "release/*" {
+		t.Errorf("overrides-bp: expected release/*, got %q", bp[1].Pattern)
+	}
+}
+
+func TestRepositorySet_RulesetsMerge(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: RepositorySet
+metadata:
+  owner: org
+defaults:
+  spec:
+    rulesets:
+      - name: default-ruleset
+        target: branch
+        enforcement: active
+repositories:
+  - name: inherits-rs
+    spec:
+      description: "inherits default rulesets"
+  - name: overrides-rs
+    spec:
+      rulesets:
+        - name: default-ruleset
+          target: branch
+          enforcement: evaluate
+        - name: custom-ruleset
+          target: tag
+          enforcement: active
+`
+	path := filepath.Join(dir, "rs.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath error: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+
+	// First repo inherits default rulesets
+	if len(repos[0].Spec.Rulesets) != 1 {
+		t.Fatalf("inherits-rs: expected 1 ruleset, got %d", len(repos[0].Spec.Rulesets))
+	}
+
+	// Second repo: default-ruleset overridden, custom-ruleset appended
+	rs := repos[1].Spec.Rulesets
+	if len(rs) != 2 {
+		t.Fatalf("overrides-rs: expected 2 rulesets, got %d", len(rs))
+	}
+	if rs[0].Name != "default-ruleset" || *rs[0].Enforcement != "evaluate" {
+		t.Errorf("overrides-rs: default-ruleset should have enforcement=evaluate, got %v", rs[0].Enforcement)
+	}
+	if rs[1].Name != "custom-ruleset" {
+		t.Errorf("overrides-rs: expected custom-ruleset, got %q", rs[1].Name)
 	}
 }
 


### PR DESCRIPTION
## Summary

Replace full-replacement merge with key-based merge for labels, branch_protection, rulesets, and actions in RepositorySet defaults, enabling users to define common settings once and only override per-repo differences.

## Background

Collection fields (labels, branch_protection, rulesets) in RepositorySet defaults used `len > 0 → replace` semantics. This meant any per-repo customization required repeating the entire default list, defeating the purpose of shared defaults. Additionally, `import --into` lacked `minimalActions`/`minimalBranchProtection`/`minimalRulesets`, causing it to write back all fields even when they matched defaults.

## Changes

- **`parser.go`**: Add `mergeLabels` (by name), `mergeBranchProtection` (by pattern, field-level), `mergeRulesets` (by name) merge functions in `mergeSpecs`
- **`repository.go`**: Add `minimalLabels`, `minimalBranchProtection`, `minimalRulesets`, `minimalActions` for `import --into` write-back to emit only fields that differ from defaults
- **`parser_test.go`**: Add merge tests for labels, branch_protection, and rulesets
- **`repository_test.go`**: Add `minimalOverride` tests for all four field types
- **`defaults.md`**: Restructure merge behavior docs with a new "Collections — merged by key" section documenting each field's key and same-key behavior