### PR TITLE
Parallelize repository fetch in import --into

### DIFF
--- a/internal/importer/diff.go
+++ b/internal/importer/diff.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/babarot/gh-infra/internal/gh"
 	"github.com/babarot/gh-infra/internal/manifest"
+	"github.com/babarot/gh-infra/internal/parallel"
 	"github.com/babarot/gh-infra/internal/repository"
 )
 
@@ -19,24 +20,25 @@ type DiffOptions struct {
 	AllFileDocs []*manifest.FileDocument
 }
 
+// fetchResult holds the result of a parallel repository fetch.
+type fetchResult struct {
+	tm       TargetMatches
+	imported *manifest.Repository
+	fatal    error // auth errors, context canceled — abort all
+	skip     bool  // fetch failed non-fatally — skip this target
+}
+
 // Diff builds a change plan for all targets.
-// manifestBytes is shared across targets so patches accumulate correctly.
-// Targets are processed sequentially (same file may be patched by multiple targets).
+//
+// Phase 1 fetches GitHub state for all targets in parallel.
+// Phase 2 computes diffs and patches manifests sequentially, because
+// manifestBytes is a shared write-back cache that accumulates patches
+// across targets referencing the same file.
 func Diff(ctx context.Context, opts DiffOptions) (*Result, error) {
 	tracker := opts.Tracker
 	if tracker == nil {
 		tracker = noopRefreshTracker{}
 	}
-	plan := &Result{
-		ManifestEdits: make(map[string][]byte),
-	}
-
-	// Shared manifest bytes — lazily loaded, patched in-place across targets.
-	manifestBytes := make(map[string][]byte)
-
-	// Build source reference counts across ALL file documents (not just matched ones)
-	// to detect shared templates that should not be overwritten.
-	sourceRefCount := buildSourceRefCount(opts.AllFileDocs)
 
 	// Determine resolver owner from first target.
 	var resolverOwner string
@@ -46,51 +48,73 @@ func Diff(ctx context.Context, opts DiffOptions) (*Result, error) {
 	resolver := manifest.NewResolver(opts.Runner, resolverOwner)
 	proc := repository.NewProcessor(opts.Runner, resolver)
 
-	for _, tm := range opts.Targets {
-		if ctx.Err() != nil {
-			return nil, context.Canceled
-		}
+	// Build source reference counts across ALL file documents (not just matched ones)
+	// to detect shared templates that should not be overwritten.
+	sourceRefCount := buildSourceRefCount(opts.AllFileDocs)
 
+	// ── Phase 1: Fetch all targets in parallel ──────────────────────────
+	fetched := parallel.Map(ctx, opts.Targets, parallel.DefaultConcurrency, func(ctx context.Context, _ int, tm TargetMatches) fetchResult {
 		fullName := tm.Target.FullName()
-
-		// Fetch current GitHub state.
 		onStatus := func(s string) {
 			tracker.UpdateStatus(fullName, s)
 		}
+
 		current, err := proc.FetchRepository(ctx, tm.Target.Owner, tm.Target.Name, onStatus)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
-				return nil, context.Canceled
+				return fetchResult{tm: tm, fatal: context.Canceled}
 			}
-			// Auth errors affect all targets — abort immediately.
 			if errors.Is(err, gh.ErrUnauthorized) || errors.Is(err, gh.ErrForbidden) {
 				tracker.Fail(fullName)
-				return nil, fmt.Errorf("fetch %s: %w", fullName, err)
+				return fetchResult{tm: tm, fatal: fmt.Errorf("fetch %s: %w", fullName, err)}
 			}
-			// Other errors (network, 404, etc.) — skip this target.
-			// Buffer via tracker.Error so the detail is rendered after the
-			// spinner finishes (consistent with plan / apply).
 			tracker.Error(fullName, fmt.Errorf("fetch failed: %w", err))
-			continue
+			return fetchResult{tm: tm, skip: true}
 		}
 		if current.IsNew {
 			tracker.Error(fullName, fmt.Errorf("repository not found on GitHub"))
+			return fetchResult{tm: tm, skip: true}
+		}
+
+		imported := repository.ToManifest(ctx, current, resolver)
+		return fetchResult{tm: tm, imported: imported}
+	})
+
+	// Abort on fatal errors (auth failure, context canceled).
+	for _, f := range fetched {
+		if f.fatal != nil {
+			return nil, f.fatal
+		}
+	}
+	if ctx.Err() != nil {
+		return nil, context.Canceled
+	}
+
+	// ── Phase 2: Diff and patch sequentially ────────────────────────────
+	// manifestBytes is a shared write-back cache; patches from one target
+	// must be visible to the next target referencing the same file.
+	plan := &Result{
+		ManifestEdits: make(map[string][]byte),
+	}
+	manifestBytes := make(map[string][]byte)
+
+	for _, f := range fetched {
+		if f.skip {
 			continue
 		}
 
-		// Convert to manifest.
-		imported := repository.ToManifest(ctx, current, resolver)
+		fullName := f.tm.Target.FullName()
 
 		// Ensure manifest bytes are loaded for all relevant source paths.
-		if err := ensureManifestBytes(manifestBytes, tm.Matches); err != nil {
+		if err := ensureManifestBytes(manifestBytes, f.tm.Matches); err != nil {
 			return nil, err
 		}
 
 		// Plan Repository matches.
-		if len(tm.Matches.Repositories) > 0 {
+		if len(f.tm.Matches.Repositories) > 0 {
 			rp, err := DiffRepository(DiffInput{
-				Repos:         tm.Matches.Repositories,
-				Imported:      imported,
+				Repos:         f.tm.Matches.Repositories,
+				Imported:      f.imported,
 				ManifestBytes: manifestBytes,
 			})
 			if err != nil {
@@ -100,10 +124,10 @@ func Diff(ctx context.Context, opts DiffOptions) (*Result, error) {
 		}
 
 		// Plan RepositorySet matches.
-		if len(tm.Matches.RepositorySets) > 0 {
+		if len(f.tm.Matches.RepositorySets) > 0 {
 			rp, err := DiffRepositorySet(DiffInput{
-				Repos:         tm.Matches.RepositorySets,
-				Imported:      imported,
+				Repos:         f.tm.Matches.RepositorySets,
+				Imported:      f.imported,
 				ManifestBytes: manifestBytes,
 			})
 			if err != nil {
@@ -113,8 +137,8 @@ func Diff(ctx context.Context, opts DiffOptions) (*Result, error) {
 		}
 
 		// Plan FileSet matches.
-		if len(tm.Matches.FileSets) > 0 {
-			fileChanges, err := DiffFiles(ctx, opts.Runner, tm.Matches.FileSets, DiffFilesOptions{
+		if len(f.tm.Matches.FileSets) > 0 {
+			fileChanges, err := DiffFiles(ctx, opts.Runner, f.tm.Matches.FileSets, DiffFilesOptions{
 				FilterRepo:     fullName,
 				SourceRefCount: sourceRefCount,
 				OnStatus: func(status string) {


### PR DESCRIPTION
## Summary

Split the `Diff` function into two phases — parallel API fetch, then sequential diff/patch — to eliminate the main I/O bottleneck in `import --into`.

## Background

The `Diff` function in `import --into` processed all targets sequentially, including `FetchRepository` API calls that take 100–500ms each. With 10 targets, this adds up to 1–5 seconds of serial I/O wait. The `import` command (without `--into`) and `plan`/`apply` already use `parallel.Map` for concurrent fetches, but `import --into` was left behind.

## Changes

- **Phase 1 (parallel)**: Use `parallel.Map` with `DefaultConcurrency` (10) to fetch GitHub state and convert to manifest for all targets concurrently. Fatal errors (auth, context canceled) are collected and checked after all fetches complete.
- **Phase 2 (sequential)**: Diff computation and manifest patching remain sequential because `manifestBytes` is a shared write-back cache where patches from one target must be visible to the next target referencing the same file.
- Introduced `fetchResult` struct to carry per-target results (imported manifest, fatal/skip status) between phases.
- Error handling matches the original: auth errors abort immediately, other fetch failures skip the target gracefully.