### PR TITLE
Improve import --into: display fix and optional repo arguments

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -17,11 +17,16 @@ func newImportCmd() *cobra.Command {
 		Use:   "import <owner/repo> [owner/repo ...]",
 		Short: "Export existing repository settings as YAML",
 		Long: "Fetch current GitHub repository settings and output them as gh-infra YAML.\n" +
-			"With --into, pull GitHub state back into existing local manifests.",
-		Args: cobra.MinimumNArgs(1),
+			"With --into, pull GitHub state back into existing local manifests.\n" +
+			"When --into is used without specifying repositories, all repositories\n" +
+			"defined in the manifests are targeted.",
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if intoPath != "" {
 				return runImportInto(args, intoPath)
+			}
+			if len(args) == 0 {
+				return fmt.Errorf("requires at least 1 arg when --into is not used")
 			}
 			return runImport(args)
 		},

--- a/docs/src/content/docs/commands/import.md
+++ b/docs/src/content/docs/commands/import.md
@@ -17,6 +17,8 @@ gh infra import <owner/repo> [owner/repo ...]
 | `<owner/repo>` | `gh infra import babarot/my-project` | Import that repository |
 | Multiple repos | `gh infra import babarot/my-project babarot/my-cli` | Import each repository |
 
+When using `--into`, arguments are optional. If omitted, all repositories defined in the manifests are targeted.
+
 ## Flags
 
 | Flag | Description |
@@ -35,8 +37,11 @@ gh infra import babarot/my-project babarot/my-cli
 # Import and review
 gh infra import babarot/my-project
 
-# Pull GitHub state into existing manifests
+# Pull GitHub state into existing manifests (specific repo)
 gh infra import babarot/my-project --into=repos/my-project.yaml
+
+# Pull GitHub state for all repos defined in manifests
+gh infra import --into=repos/
 ```
 
 The output is a complete `Repository` YAML manifest reflecting the current state of the repository on GitHub.
@@ -46,16 +51,22 @@ The output is a complete `Repository` YAML manifest reflecting the current state
 With `--into`, import works in the reverse direction of `plan`/`apply`: it fetches the current GitHub state and updates your existing local YAML manifests to match.
 
 ```bash
-gh infra import <owner/repo> --into=<path>
+# Import specific repos into manifests
+gh infra import <owner/repo> [owner/repo ...] --into=<path>
+
+# Import all repos defined in manifests
+gh infra import --into=<path>
 ```
 
 The path can be a single YAML file or a directory containing manifests.
 
+When no `owner/repo` arguments are given, all repositories defined in the manifests (from Repository, RepositorySet, and FileSet resources) are targeted automatically.
+
 ### How It Works
 
 1. **Parse** local manifests at the given path
-2. **Match** each `owner/repo` argument to resources in the manifests (Repository, RepositorySet, FileSet)
-3. **Fetch** the current state from GitHub
+2. **Match** targets to resources in the manifests — either from arguments or all repos in manifests when no arguments are given
+3. **Fetch** the current state from GitHub (in parallel)
 4. **Diff** local vs GitHub, field by field
 5. **Display** the plan (repo setting changes + file changes with diff stats)
 6. **Confirm** with interactive diff viewer (for file changes) or simple prompt (repo-only changes)
@@ -64,6 +75,9 @@ The path can be a single YAML file or a directory containing manifests.
 ### Examples
 
 ```bash
+# Pull GitHub state for all repos defined in manifests
+gh infra import --into=repos/
+
 # Pull GitHub state into a specific manifest file
 gh infra import babarot/my-project --into=repos/my-project.yaml
 

--- a/internal/importer/repository.go
+++ b/internal/importer/repository.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/babarot/gh-infra/internal/manifest"
 	"github.com/babarot/gh-infra/internal/yamledit"
@@ -932,15 +933,15 @@ func compareBranchProtection(local, imported []manifest.BranchProtection) []Fiel
 			diffs = append(diffs, FieldDiff{
 				Field: fmt.Sprintf("branch_protection.%s", pattern),
 				Old:   nil,
-				New:   ibp,
+				New:   formatBranchProtectionSummary(ibp),
 			})
 			continue
 		}
 		if !reflect.DeepEqual(lbp, ibp) {
 			diffs = append(diffs, FieldDiff{
 				Field: fmt.Sprintf("branch_protection.%s", pattern),
-				Old:   lbp,
-				New:   ibp,
+				Old:   formatBranchProtectionSummary(lbp),
+				New:   formatBranchProtectionSummary(ibp),
 			})
 		}
 	}
@@ -950,7 +951,7 @@ func compareBranchProtection(local, imported []manifest.BranchProtection) []Fiel
 		if _, exists := importedMap[pattern]; !exists {
 			diffs = append(diffs, FieldDiff{
 				Field: fmt.Sprintf("branch_protection.%s", pattern),
-				Old:   lbp,
+				Old:   formatBranchProtectionSummary(lbp),
 				New:   nil,
 			})
 		}
@@ -982,15 +983,15 @@ func compareRulesets(local, imported []manifest.Ruleset) []FieldDiff {
 			diffs = append(diffs, FieldDiff{
 				Field: fmt.Sprintf("rulesets.%s", name),
 				Old:   nil,
-				New:   irs,
+				New:   formatRulesetSummary(irs),
 			})
 			continue
 		}
 		if !reflect.DeepEqual(lrs, irs) {
 			diffs = append(diffs, FieldDiff{
 				Field: fmt.Sprintf("rulesets.%s", name),
-				Old:   lrs,
-				New:   irs,
+				Old:   formatRulesetSummary(lrs),
+				New:   formatRulesetSummary(irs),
 			})
 		}
 	}
@@ -999,7 +1000,7 @@ func compareRulesets(local, imported []manifest.Ruleset) []FieldDiff {
 		if _, exists := importedMap[name]; !exists {
 			diffs = append(diffs, FieldDiff{
 				Field: fmt.Sprintf("rulesets.%s", name),
-				Old:   lrs,
+				Old:   formatRulesetSummary(lrs),
 				New:   nil,
 			})
 		}
@@ -1104,6 +1105,52 @@ func formatLabelSummary(color, description string) string {
 		return fmt.Sprintf("#%s %q", color, description)
 	}
 	return "#" + color
+}
+
+func formatBranchProtectionSummary(bp manifest.BranchProtection) string {
+	var parts []string
+	if bp.RequiredReviews != nil {
+		parts = append(parts, fmt.Sprintf("reviews: %d", *bp.RequiredReviews))
+	}
+	if bp.DismissStaleReviews != nil {
+		parts = append(parts, fmt.Sprintf("dismiss_stale: %t", *bp.DismissStaleReviews))
+	}
+	if bp.RequireCodeOwnerReviews != nil {
+		parts = append(parts, fmt.Sprintf("codeowners: %t", *bp.RequireCodeOwnerReviews))
+	}
+	if bp.RequireStatusChecks != nil {
+		parts = append(parts, "status_checks: yes")
+	}
+	if bp.EnforceAdmins != nil {
+		parts = append(parts, fmt.Sprintf("enforce_admins: %t", *bp.EnforceAdmins))
+	}
+	if bp.AllowForcePushes != nil {
+		parts = append(parts, fmt.Sprintf("force_push: %t", *bp.AllowForcePushes))
+	}
+	if bp.AllowDeletions != nil {
+		parts = append(parts, fmt.Sprintf("deletions: %t", *bp.AllowDeletions))
+	}
+	if len(parts) == 0 {
+		return fmt.Sprintf("pattern: %s", bp.Pattern)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatRulesetSummary(rs manifest.Ruleset) string {
+	var parts []string
+	if rs.Target != nil {
+		parts = append(parts, fmt.Sprintf("target: %s", *rs.Target))
+	}
+	if rs.Enforcement != nil {
+		parts = append(parts, fmt.Sprintf("enforcement: %s", *rs.Enforcement))
+	}
+	if len(rs.BypassActors) > 0 {
+		parts = append(parts, fmt.Sprintf("bypass_actors: %d", len(rs.BypassActors)))
+	}
+	if len(parts) == 0 {
+		return rs.Name
+	}
+	return strings.Join(parts, ", ")
 }
 
 // minimalOverride returns the minimal spec override relative to defaults.

--- a/internal/importer/repository_test.go
+++ b/internal/importer/repository_test.go
@@ -1212,6 +1212,25 @@ func TestCompareBranchProtection_DeletedOnGitHub(t *testing.T) {
 	}
 }
 
+func TestCompareBranchProtection_SummaryFormat(t *testing.T) {
+	local := []manifest.BranchProtection{}
+	imported := []manifest.BranchProtection{
+		{Pattern: "main", RequiredReviews: manifest.Ptr(2), EnforceAdmins: manifest.Ptr(true)},
+	}
+
+	diffs := compareBranchProtection(local, imported)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	newStr, ok := diffs[0].New.(string)
+	if !ok {
+		t.Fatalf("New should be string, got %T", diffs[0].New)
+	}
+	if !strings.Contains(newStr, "reviews: 2") || !strings.Contains(newStr, "enforce_admins: true") {
+		t.Errorf("unexpected summary: %q", newStr)
+	}
+}
+
 func TestCompareBranchProtection_Empty(t *testing.T) {
 	diffs := compareBranchProtection(nil, nil)
 	if len(diffs) != 0 {
@@ -1250,6 +1269,25 @@ func TestCompareRulesets_NewOnGitHub(t *testing.T) {
 	}
 	if diffs[0].Old != nil {
 		t.Error("Old should be nil for new ruleset")
+	}
+}
+
+func TestCompareRulesets_SummaryFormat(t *testing.T) {
+	local := []manifest.Ruleset{}
+	imported := []manifest.Ruleset{
+		{Name: "protect-main", Target: manifest.Ptr("branch"), Enforcement: manifest.Ptr("active")},
+	}
+
+	diffs := compareRulesets(local, imported)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	newStr, ok := diffs[0].New.(string)
+	if !ok {
+		t.Fatalf("New should be string, got %T", diffs[0].New)
+	}
+	if !strings.Contains(newStr, "target: branch") || !strings.Contains(newStr, "enforcement: active") {
+		t.Errorf("unexpected summary: %q", newStr)
 	}
 }
 

--- a/internal/infra/import_into.go
+++ b/internal/infra/import_into.go
@@ -157,6 +157,11 @@ func ImportInto(args []string, into string) (*ImportDiff, error) {
 		return nil, err
 	}
 
+	// When no args are given, target all repositories defined in manifests.
+	if len(args) == 0 {
+		args = allRepoFullNames(parsed)
+	}
+
 	targets, err := parseArgs(args)
 	if err != nil {
 		return nil, err
@@ -386,6 +391,30 @@ func planSkipReason(c importer.Change) string {
 		return "skip: reconcile:create_only (Tab to change)"
 	}
 	return "skip"
+}
+
+// allRepoFullNames returns deduplicated "owner/repo" names from all parsed manifests.
+func allRepoFullNames(parsed *manifest.ParseResult) []string {
+	seen := make(map[string]bool)
+	var names []string
+
+	for _, doc := range parsed.RepositoryDocs {
+		name := doc.Resource.Metadata.FullName()
+		if !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	for _, doc := range parsed.FileDocs {
+		for _, repo := range doc.Resource.Spec.Repositories {
+			name := doc.Resource.RepoFullName(repo.Name)
+			if !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+	return names
 }
 
 func writeModeForAction(c importer.Change, action string) importer.WriteMode {

--- a/internal/infra/import_into_test.go
+++ b/internal/infra/import_into_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/babarot/gh-infra/internal/fileset"
 	"github.com/babarot/gh-infra/internal/importer"
+	"github.com/babarot/gh-infra/internal/manifest"
 	"github.com/babarot/gh-infra/internal/ui"
 )
 
@@ -69,6 +70,48 @@ func TestParseArgs_Invalid(t *testing.T) {
 				t.Error("expected error for invalid arg")
 			}
 		})
+	}
+}
+
+// --- allRepoFullNames tests ---
+
+func TestAllRepoFullNames_ReposAndFileSets(t *testing.T) {
+	parsed := &manifest.ParseResult{
+		RepositoryDocs: []*manifest.RepositoryDocument{
+			{Resource: &manifest.Repository{Metadata: manifest.RepositoryMetadata{Owner: "org", Name: "repo-a"}}},
+			{Resource: &manifest.Repository{Metadata: manifest.RepositoryMetadata{Owner: "org", Name: "repo-b"}}},
+		},
+		FileDocs: []*manifest.FileDocument{
+			{Resource: &manifest.FileSet{
+				Metadata: manifest.FileSetMetadata{Owner: "org"},
+				Spec: manifest.FileSetSpec{
+					Repositories: []manifest.FileSetRepository{
+						{Name: "repo-b"}, // duplicate with RepositoryDocs
+						{Name: "repo-c"}, // new
+					},
+				},
+			}},
+		},
+	}
+
+	names := allRepoFullNames(parsed)
+
+	if len(names) != 3 {
+		t.Fatalf("expected 3 names, got %d: %v", len(names), names)
+	}
+	want := map[string]bool{"org/repo-a": true, "org/repo-b": true, "org/repo-c": true}
+	for _, n := range names {
+		if !want[n] {
+			t.Errorf("unexpected name: %q", n)
+		}
+	}
+}
+
+func TestAllRepoFullNames_Empty(t *testing.T) {
+	parsed := &manifest.ParseResult{}
+	names := allRepoFullNames(parsed)
+	if len(names) != 0 {
+		t.Errorf("expected 0 names, got %d", len(names))
 	}
 }
 


### PR DESCRIPTION
## Summary

Two improvements to `import --into`: fix broken multi-line display for branch_protection/rulesets in the import plan, and allow running without repo arguments to target all repositories defined in manifests.

## Background

`compareBranchProtection` and `compareRulesets` were putting raw Go structs into `FieldDiff.Old/New`, causing `FormatValue` to emit multi-line YAML in the terminal plan output. Additionally, `import --into` always required explicit `owner/repo` arguments even though the manifests already declare which repositories they manage.

## Changes

**Commit 1 — Display fix:**
- Add `formatBranchProtectionSummary` and `formatRulesetSummary` to produce concise one-line strings (matching `formatLabelSummary` pattern)
- Add summary format tests for both comparators

**Commit 2 — Optional repo arguments:**
- Change CLI arg validation to `cobra.ArbitraryArgs`, with explicit error for `import` without `--into` and no args
- Add `allRepoFullNames` to enumerate deduplicated repos from `RepositoryDocs` and `FileDocs`
- When no args given with `--into`, automatically target all manifest repos
- Update `import.md` documentation with new usage patterns and examples
- Add unit tests for `allRepoFullNames`