### PR TITLE
Unify plan and import --into display with shared DiffGroup model

### DIFF
--- a/internal/infra/format.go
+++ b/internal/infra/format.go
@@ -81,52 +81,10 @@ func printPlan(p ui.Printer, repoChanges []repository.Change, fileChanges []file
 			p.GroupHeader(ui.IconChange, name)
 		}
 
-		// Group consecutive Label/Milestone changes under sub-headers,
-		// preserving the original order relative to other resources.
-		grouped := groupRepoChanges(rChanges)
-		p.SetColumnWidth(repoFieldWidth(rChanges))
-		for _, g := range grouped {
-			if g.resource != "" {
-				// Grouped sub-resource (labels, milestones)
-				icon := groupIcon(g.changes)
-				p.SubGroupHeader(icon, strings.ToLower(g.resource)+"s")
-				for _, c := range g.changes {
-					if len(c.Children) > 0 {
-						for _, child := range c.Children {
-							item := changeToItem(child, ui.IndentSub)
-							item.Field = c.Field + "." + child.Field
-							p.PrintChange(item)
-						}
-					} else {
-						p.PrintChange(changeToItem(c, ui.IndentSub))
-					}
-				}
-			} else {
-				// Regular change
-				c := g.changes[0]
-				if len(c.Children) > 0 {
-					var icon string
-					switch c.Type {
-					case repository.ChangeCreate:
-						icon = ui.IconAdd
-					case repository.ChangeDelete:
-						icon = ui.IconRemove
-					default:
-						icon = ui.IconChange
-					}
-					header := c.Field
-					if s, ok := c.NewValue.(string); ok && s != "" {
-						header = fmt.Sprintf("%s[%s]", c.Field, s)
-					}
-					p.SubGroupHeader(icon, header)
-					for _, child := range c.Children {
-						p.PrintChange(changeToItem(child, ui.IndentSub))
-					}
-				} else {
-					p.PrintChange(changeToItem(c, ui.IndentItem))
-				}
-			}
-		}
+		// Convert to unified display model and render.
+		diffGroups := repoChangesToDiffGroups(rChanges)
+		p.SetColumnWidth(ui.DiffGroupFieldWidth(diffGroups))
+		ui.RenderDiffGroups(p, diffGroups)
 
 		// Print fileset changes (aligned by file path width, independent of repo fields)
 		if len(fChanges) > 0 {
@@ -328,6 +286,75 @@ func groupIcon(changes []repository.Change) string {
 		return ui.IconRemove
 	default:
 		return ui.IconChange
+	}
+}
+
+// repoChangesToDiffGroups converts repository.Change slice to the unified
+// DiffGroup model for rendering. It reuses the existing groupRepoChanges logic.
+func repoChangesToDiffGroups(changes []repository.Change) []ui.DiffGroup {
+	grouped := groupRepoChanges(changes)
+	var result []ui.DiffGroup
+
+	for _, g := range grouped {
+		if g.resource != "" {
+			// Grouped sub-resource (labels, milestones)
+			dg := ui.DiffGroup{
+				Header: strings.ToLower(g.resource) + "s",
+				Icon:   groupIcon(g.changes),
+			}
+			for _, c := range g.changes {
+				if len(c.Children) > 0 {
+					for _, child := range c.Children {
+						item := changeToDiffItem(child)
+						item.Field = c.Field + "." + child.Field
+						dg.Items = append(dg.Items, item)
+					}
+				} else {
+					dg.Items = append(dg.Items, changeToDiffItem(c))
+				}
+			}
+			result = append(result, dg)
+		} else {
+			c := g.changes[0]
+			if len(c.Children) > 0 {
+				var icon string
+				switch c.Type {
+				case repository.ChangeCreate:
+					icon = ui.IconAdd
+				case repository.ChangeDelete:
+					icon = ui.IconRemove
+				default:
+					icon = ui.IconChange
+				}
+				header := c.Field
+				if s, ok := c.NewValue.(string); ok && s != "" {
+					header = fmt.Sprintf("%s[%s]", c.Field, s)
+				}
+				dg := ui.DiffGroup{Header: header, Icon: icon}
+				for _, child := range c.Children {
+					dg.Items = append(dg.Items, changeToDiffItem(child))
+				}
+				result = append(result, dg)
+			} else {
+				result = append(result, ui.DiffGroup{
+					Items: []ui.DiffItem{changeToDiffItem(c)},
+				})
+			}
+		}
+	}
+	return result
+}
+
+func changeToDiffItem(c repository.Change) ui.DiffItem {
+	switch c.Type {
+	case repository.ChangeCreate:
+		return ui.DiffItem{Icon: ui.IconAdd, Field: c.Field, Value: c.NewValue}
+	case repository.ChangeUpdate:
+		return ui.DiffItem{Icon: ui.IconChange, Field: c.Field, Old: ui.FormatValue(c.OldValue), New: ui.FormatValue(c.NewValue)}
+	case repository.ChangeDelete:
+		return ui.DiffItem{Icon: ui.IconRemove, Field: c.Field, Value: c.OldValue}
+	default:
+		return ui.DiffItem{Field: c.Field}
 	}
 }
 

--- a/internal/infra/import_into.go
+++ b/internal/infra/import_into.go
@@ -3,6 +3,7 @@ package infra
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/babarot/gh-infra/internal/fileset"
 	"github.com/babarot/gh-infra/internal/gh"
@@ -277,22 +278,9 @@ func printImportPlan(p ui.Printer, plan *importer.Result) {
 		p.GroupHeader(ui.IconChange, target)
 
 		if len(rDiffs) > 0 {
-			w := 0
-			for _, d := range rDiffs {
-				if len(d.Field) > w {
-					w = len(d.Field)
-				}
-			}
-			p.SetColumnWidth(w)
-
-			for _, d := range rDiffs {
-				p.PrintChange(ui.ChangeItem{
-					Icon:  ui.IconChange,
-					Field: d.Field,
-					Old:   ui.FormatValue(d.Old),
-					New:   ui.FormatValue(d.New),
-				})
-			}
+			groups := fieldDiffsToDiffGroups(rDiffs)
+			p.SetColumnWidth(ui.DiffGroupFieldWidth(groups))
+			ui.RenderDiffGroups(p, groups)
 		}
 
 		if len(fChanges) > 0 {
@@ -391,6 +379,136 @@ func planSkipReason(c importer.Change) string {
 		return "skip: reconcile:create_only (Tab to change)"
 	}
 	return "skip"
+}
+
+// fieldDiffsToDiffGroups converts flat FieldDiff slices into the unified
+// DiffGroup model by parsing dot-notation field names and grouping by prefix.
+func fieldDiffsToDiffGroups(diffs []importer.FieldDiff) []ui.DiffGroup {
+	var result []ui.DiffGroup
+
+	// Prefix classification
+	nestedObject := map[string]bool{
+		"features": true, "merge_strategy": true, "actions": true, "security": true,
+	}
+	keyedCollection := map[string]bool{
+		"branch_protection": true, "rulesets": true,
+	}
+	flatCollection := map[string]bool{
+		"labels": true, "variables": true, "milestones": true,
+	}
+
+	i := 0
+	for i < len(diffs) {
+		d := diffs[i]
+		prefix, rest, hasDot := splitField(d.Field)
+
+		if !hasDot {
+			// Bare field (description, visibility, topics, etc.)
+			result = append(result, ui.DiffGroup{
+				Items: []ui.DiffItem{fieldDiffToItem(d, d.Field)},
+			})
+			i++
+			continue
+		}
+
+		if nestedObject[prefix] {
+			// Collect consecutive diffs with same prefix
+			dg := ui.DiffGroup{Header: prefix, Icon: ui.IconChange}
+			for i < len(diffs) {
+				p, r, ok := splitField(diffs[i].Field)
+				if !ok || p != prefix {
+					break
+				}
+				dg.Items = append(dg.Items, fieldDiffToItem(diffs[i], r))
+				i++
+			}
+			dg.Icon = aggregateIcon(dg.Items)
+			result = append(result, dg)
+			continue
+		}
+
+		if keyedCollection[prefix] {
+			// Each unique key becomes its own group: prefix[key]
+			key := rest
+			header := fmt.Sprintf("%s[%s]", prefix, key)
+			dg := ui.DiffGroup{Header: header}
+			dg.Items = append(dg.Items, fieldDiffToItem(d, key))
+			dg.Icon = aggregateIcon(dg.Items)
+			result = append(result, dg)
+			i++
+			continue
+		}
+
+		if flatCollection[prefix] {
+			// Collect consecutive diffs with same prefix under one header
+			dg := ui.DiffGroup{Header: prefix}
+			for i < len(diffs) {
+				p, r, ok := splitField(diffs[i].Field)
+				if !ok || p != prefix {
+					break
+				}
+				dg.Items = append(dg.Items, fieldDiffToItem(diffs[i], r))
+				i++
+			}
+			dg.Icon = aggregateIcon(dg.Items)
+			result = append(result, dg)
+			continue
+		}
+
+		// Unknown prefix (fallback): group consecutive same-prefix diffs
+		dg := ui.DiffGroup{Header: prefix}
+		for i < len(diffs) {
+			p, r, ok := splitField(diffs[i].Field)
+			if !ok || p != prefix {
+				break
+			}
+			dg.Items = append(dg.Items, fieldDiffToItem(diffs[i], r))
+			i++
+		}
+		dg.Icon = aggregateIcon(dg.Items)
+		result = append(result, dg)
+	}
+
+	return result
+}
+
+func splitField(field string) (prefix, rest string, hasDot bool) {
+	prefix, rest, hasDot = strings.Cut(field, ".")
+	return
+}
+
+func fieldDiffToItem(d importer.FieldDiff, field string) ui.DiffItem {
+	icon := ui.IconChange
+	if d.Old == nil && d.New != nil {
+		icon = ui.IconAdd
+	} else if d.Old != nil && d.New == nil {
+		icon = ui.IconRemove
+	}
+	return ui.DiffItem{
+		Icon:  icon,
+		Field: field,
+		Old:   ui.FormatValue(d.Old),
+		New:   ui.FormatValue(d.New),
+	}
+}
+
+func aggregateIcon(items []ui.DiffItem) string {
+	allAdd, allRemove := true, true
+	for _, item := range items {
+		if item.Icon != ui.IconAdd {
+			allAdd = false
+		}
+		if item.Icon != ui.IconRemove {
+			allRemove = false
+		}
+	}
+	if allAdd {
+		return ui.IconAdd
+	}
+	if allRemove {
+		return ui.IconRemove
+	}
+	return ui.IconChange
 }
 
 // allRepoFullNames returns deduplicated "owner/repo" names from all parsed manifests.

--- a/internal/infra/import_into_test.go
+++ b/internal/infra/import_into_test.go
@@ -115,6 +115,161 @@ func TestAllRepoFullNames_Empty(t *testing.T) {
 	}
 }
 
+// --- fieldDiffsToDiffGroups tests ---
+
+func TestFieldDiffsToDiffGroups_BareFields(t *testing.T) {
+	diffs := []importer.FieldDiff{
+		{Field: "description", Old: `""`, New: "My repo"},
+		{Field: "visibility", Old: "private", New: "public"},
+	}
+	groups := fieldDiffsToDiffGroups(diffs)
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	for _, g := range groups {
+		if g.Header != "" {
+			t.Errorf("bare field should have empty header, got %q", g.Header)
+		}
+	}
+}
+
+func TestFieldDiffsToDiffGroups_NestedObject(t *testing.T) {
+	diffs := []importer.FieldDiff{
+		{Field: "features.issues", Old: false, New: true},
+		{Field: "features.wiki", Old: true, New: false},
+	}
+	groups := fieldDiffsToDiffGroups(diffs)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if groups[0].Header != "features" {
+		t.Errorf("expected header 'features', got %q", groups[0].Header)
+	}
+	if len(groups[0].Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(groups[0].Items))
+	}
+	if groups[0].Items[0].Field != "issues" {
+		t.Errorf("expected field 'issues', got %q", groups[0].Items[0].Field)
+	}
+}
+
+func TestFieldDiffsToDiffGroups_KeyedCollection(t *testing.T) {
+	diffs := []importer.FieldDiff{
+		{Field: "branch_protection.main", Old: nil, New: "reviews: 1"},
+		{Field: "branch_protection.develop", Old: nil, New: "reviews: 2"},
+	}
+	groups := fieldDiffsToDiffGroups(diffs)
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups (one per key), got %d", len(groups))
+	}
+	if groups[0].Header != "branch_protection[main]" {
+		t.Errorf("expected 'branch_protection[main]', got %q", groups[0].Header)
+	}
+	if groups[1].Header != "branch_protection[develop]" {
+		t.Errorf("expected 'branch_protection[develop]', got %q", groups[1].Header)
+	}
+}
+
+func TestFieldDiffsToDiffGroups_FlatCollection(t *testing.T) {
+	diffs := []importer.FieldDiff{
+		{Field: "labels.kind/bug", Old: nil, New: `#d73a4a "A bug"`},
+		{Field: "labels.kind/feature", Old: nil, New: `#425df5 "A feature"`},
+	}
+	groups := fieldDiffsToDiffGroups(diffs)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if groups[0].Header != "labels" {
+		t.Errorf("expected header 'labels', got %q", groups[0].Header)
+	}
+	if len(groups[0].Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(groups[0].Items))
+	}
+	if groups[0].Items[0].Field != "kind/bug" {
+		t.Errorf("expected field 'kind/bug', got %q", groups[0].Items[0].Field)
+	}
+}
+
+func TestFieldDiffsToDiffGroups_DeepNesting(t *testing.T) {
+	diffs := []importer.FieldDiff{
+		{Field: "actions.enabled", Old: false, New: true},
+		{Field: "actions.selected_actions.github_owned_allowed", Old: false, New: true},
+	}
+	groups := fieldDiffsToDiffGroups(diffs)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if groups[0].Header != "actions" {
+		t.Errorf("expected header 'actions', got %q", groups[0].Header)
+	}
+	if groups[0].Items[1].Field != "selected_actions.github_owned_allowed" {
+		t.Errorf("expected deep field, got %q", groups[0].Items[1].Field)
+	}
+}
+
+func TestFieldDiffsToDiffGroups_Mixed(t *testing.T) {
+	diffs := []importer.FieldDiff{
+		{Field: "description", Old: `""`, New: "test"},
+		{Field: "features.issues", Old: false, New: true},
+		{Field: "branch_protection.main", Old: nil, New: "reviews: 1"},
+		{Field: "labels.bug", Old: nil, New: "#d73a4a"},
+	}
+	groups := fieldDiffsToDiffGroups(diffs)
+	if len(groups) != 4 {
+		t.Fatalf("expected 4 groups, got %d", len(groups))
+	}
+	headers := []string{"", "features", "branch_protection[main]", "labels"}
+	for i, want := range headers {
+		if groups[i].Header != want {
+			t.Errorf("group[%d] header = %q, want %q", i, groups[i].Header, want)
+		}
+	}
+}
+
+func TestFieldDiffsToDiffGroups_UnknownPrefix(t *testing.T) {
+	diffs := []importer.FieldDiff{
+		{Field: "future_resource.field1", Old: nil, New: "value"},
+		{Field: "future_resource.field2", Old: nil, New: "value"},
+	}
+	groups := fieldDiffsToDiffGroups(diffs)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if groups[0].Header != "future_resource" {
+		t.Errorf("expected header 'future_resource', got %q", groups[0].Header)
+	}
+	if len(groups[0].Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(groups[0].Items))
+	}
+}
+
+func TestFieldDiffsToDiffGroups_Empty(t *testing.T) {
+	groups := fieldDiffsToDiffGroups(nil)
+	if len(groups) != 0 {
+		t.Errorf("expected 0 groups, got %d", len(groups))
+	}
+}
+
+func TestFieldDiffsToDiffGroups_Icons(t *testing.T) {
+	diffs := []importer.FieldDiff{
+		{Field: "labels.new-label", Old: nil, New: "#FF0000"},
+		{Field: "labels.removed", Old: "#00FF00", New: nil},
+	}
+	groups := fieldDiffsToDiffGroups(diffs)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if groups[0].Icon != ui.IconChange {
+		t.Errorf("mixed add/remove should be IconChange, got %q", groups[0].Icon)
+	}
+	if groups[0].Items[0].Icon != ui.IconAdd {
+		t.Errorf("new label should be IconAdd, got %q", groups[0].Items[0].Icon)
+	}
+	if groups[0].Items[1].Icon != ui.IconRemove {
+		t.Errorf("removed label should be IconRemove, got %q", groups[0].Items[1].Icon)
+	}
+}
+
 // --- localPath tests ---
 
 func TestLocalPath_WriteSource(t *testing.T) {

--- a/internal/ui/diffgroup.go
+++ b/internal/ui/diffgroup.go
@@ -1,0 +1,60 @@
+package ui
+
+// DiffGroup represents a block of related changes for rendering.
+// When Header is empty, items are rendered at IndentItem level (bare fields).
+// When Header is set, a SubGroupHeader is printed and items render at IndentSub.
+type DiffGroup struct {
+	Header string     // e.g. "features", "branch_protection[main]", "labels", or ""
+	Icon   string     // aggregate icon for the header (IconAdd, IconChange, IconRemove)
+	Items  []DiffItem // individual field changes within this group
+}
+
+// DiffItem represents a single field-level change within a DiffGroup.
+type DiffItem struct {
+	Icon  string // IconAdd, IconChange, IconRemove
+	Field string // leaf field name (not full dotted path)
+	Value any    // for create/delete
+	Old   string // for update (pre-formatted)
+	New   string // for update (pre-formatted)
+}
+
+// RenderDiffGroups renders a sequence of DiffGroups through the printer.
+// Groups with a Header get a SubGroupHeader; bare groups render items directly.
+func RenderDiffGroups(p Printer, groups []DiffGroup) {
+	for _, g := range groups {
+		if g.Header != "" {
+			p.SubGroupHeader(g.Icon, g.Header)
+			for _, item := range g.Items {
+				p.PrintChange(itemToChangeItem(item, IndentSub))
+			}
+		} else {
+			for _, item := range g.Items {
+				p.PrintChange(itemToChangeItem(item, IndentItem))
+			}
+		}
+	}
+}
+
+// DiffGroupFieldWidth returns the maximum field name width across all items.
+func DiffGroupFieldWidth(groups []DiffGroup) int {
+	w := 0
+	for _, g := range groups {
+		for _, item := range g.Items {
+			if len(item.Field) > w {
+				w = len(item.Field)
+			}
+		}
+	}
+	return w
+}
+
+func itemToChangeItem(item DiffItem, level IndentLevel) ChangeItem {
+	return ChangeItem{
+		Icon:  item.Icon,
+		Field: item.Field,
+		Value: item.Value,
+		Old:   item.Old,
+		New:   item.New,
+		Level: level,
+	}
+}

--- a/internal/ui/diffgroup_test.go
+++ b/internal/ui/diffgroup_test.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRenderDiffGroups_BareItems(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewStandardPrinterWith(&buf, &buf)
+
+	groups := []DiffGroup{
+		{Items: []DiffItem{{Icon: IconChange, Field: "description", Old: `""`, New: "My repo"}}},
+		{Items: []DiffItem{{Icon: IconChange, Field: "visibility", Old: "private", New: "public"}}},
+	}
+	p.SetColumnWidth(DiffGroupFieldWidth(groups))
+	RenderDiffGroups(p, groups)
+
+	out := buf.String()
+	if !strings.Contains(out, "description") || !strings.Contains(out, "visibility") {
+		t.Errorf("expected bare items, got:\n%s", out)
+	}
+}
+
+func TestRenderDiffGroups_GroupWithHeader(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewStandardPrinterWith(&buf, &buf)
+
+	groups := []DiffGroup{
+		{
+			Header: "features",
+			Icon:   IconChange,
+			Items: []DiffItem{
+				{Icon: IconChange, Field: "issues", Old: "false", New: "true"},
+				{Icon: IconChange, Field: "wiki", Old: "true", New: "false"},
+			},
+		},
+	}
+	p.SetColumnWidth(DiffGroupFieldWidth(groups))
+	RenderDiffGroups(p, groups)
+
+	out := buf.String()
+	if !strings.Contains(out, "features") {
+		t.Errorf("expected 'features' header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "issues") || !strings.Contains(out, "wiki") {
+		t.Errorf("expected child items, got:\n%s", out)
+	}
+}
+
+func TestRenderDiffGroups_Mixed(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewStandardPrinterWith(&buf, &buf)
+
+	groups := []DiffGroup{
+		{Items: []DiffItem{{Icon: IconChange, Field: "description", Old: `""`, New: "test"}}},
+		{
+			Header: "labels",
+			Icon:   IconAdd,
+			Items: []DiffItem{
+				{Icon: IconAdd, Field: "kind/bug", Value: "#d73a4a"},
+			},
+		},
+	}
+	p.SetColumnWidth(DiffGroupFieldWidth(groups))
+	RenderDiffGroups(p, groups)
+
+	out := buf.String()
+	if !strings.Contains(out, "description") {
+		t.Errorf("expected bare item")
+	}
+	if !strings.Contains(out, "labels") {
+		t.Errorf("expected labels header")
+	}
+	if !strings.Contains(out, "kind/bug") {
+		t.Errorf("expected label item")
+	}
+}
+
+func TestRenderDiffGroups_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewStandardPrinterWith(&buf, &buf)
+	RenderDiffGroups(p, nil)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for empty groups")
+	}
+}
+
+func TestDiffGroupFieldWidth(t *testing.T) {
+	groups := []DiffGroup{
+		{Items: []DiffItem{{Field: "ab"}, {Field: "abcdef"}}},
+		{Header: "x", Items: []DiffItem{{Field: "abc"}}},
+	}
+	if w := DiffGroupFieldWidth(groups); w != 6 {
+		t.Errorf("expected width 6, got %d", w)
+	}
+}
+
+func TestDiffGroupFieldWidth_Empty(t *testing.T) {
+	if w := DiffGroupFieldWidth(nil); w != 0 {
+		t.Errorf("expected 0, got %d", w)
+	}
+}


### PR DESCRIPTION
## Summary

Introduce a shared display model (`DiffGroup`/`DiffItem`) in the UI layer so that both `plan` and `import --into` produce identical hierarchical terminal output through a single rendering path.

## Background

`plan` and `import --into` rendered repository diffs using completely separate code paths. Plan used `repository.Change` with hierarchical `Children` and `SubGroupHeader` for nested fields, while import used flat `importer.FieldDiff` with dot-notation (`features.issues`) at a single indentation level. This was not intentional design — it was drift from independent implementation. Any display change to one command required a parallel change to the other, and the inconsistency was confusing for users.

## Changes

- **`ui/diffgroup.go`** (new): Define `DiffGroup` and `DiffItem` types as a thin display-only model. `RenderDiffGroups` renders groups through `SubGroupHeader` + `IndentSub` for headed groups, and `IndentItem` for bare fields. `DiffGroupFieldWidth` computes alignment width.
- **`infra/format.go`**: Add `repoChangesToDiffGroups` converter that reuses existing `groupRepoChanges` logic to build DiffGroups from `repository.Change`. Replace the 40-line inline rendering loop in `printPlan` with 3 lines calling `RenderDiffGroups`.
- **`infra/import_into.go`**: Add `fieldDiffsToDiffGroups` converter that parses dot-notation fields and groups them by prefix type (nested objects, keyed collections, flat collections, with fallback for unknown prefixes). Replace the flat rendering loop in `printImportPlan` with `RenderDiffGroups`.
- **Tests**: 6 tests for `RenderDiffGroups`/`DiffGroupFieldWidth`, 9 tests for `fieldDiffsToDiffGroups` covering bare fields, nested objects, keyed collections, flat collections, deep nesting, mixed input, unknown prefixes, empty input, and icon aggregation.