### PR TITLE
Fix progress tracker completion and handle missing RepositorySet spec

### DIFF
--- a/internal/importer/diff.go
+++ b/internal/importer/diff.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/babarot/gh-infra/internal/gh"
 	"github.com/babarot/gh-infra/internal/manifest"
@@ -39,6 +40,50 @@ func Diff(ctx context.Context, opts DiffOptions) (*Result, error) {
 	if tracker == nil {
 		tracker = noopRefreshTracker{}
 	}
+	var completedMu sync.Mutex
+	completed := make(map[string]bool, len(opts.Targets))
+	completeDone := func(name string) {
+		completedMu.Lock()
+		if completed[name] {
+			completedMu.Unlock()
+			return
+		}
+		completed[name] = true
+		completedMu.Unlock()
+		tracker.Done(name)
+	}
+	completeError := func(name string, err error) {
+		completedMu.Lock()
+		if completed[name] {
+			completedMu.Unlock()
+			return
+		}
+		completed[name] = true
+		completedMu.Unlock()
+		tracker.Error(name, err)
+	}
+	completeFail := func(name string) {
+		completedMu.Lock()
+		if completed[name] {
+			completedMu.Unlock()
+			return
+		}
+		completed[name] = true
+		completedMu.Unlock()
+		tracker.Fail(name)
+	}
+	completeRemaining := func() {
+		for _, tm := range opts.Targets {
+			fullName := tm.Target.FullName()
+			completedMu.Lock()
+			if completed[fullName] {
+				completedMu.Unlock()
+				continue
+			}
+			completedMu.Unlock()
+			completeFail(fullName)
+		}
+	}
 
 	// Determine resolver owner from first target.
 	var resolverOwner string
@@ -65,14 +110,14 @@ func Diff(ctx context.Context, opts DiffOptions) (*Result, error) {
 				return fetchResult{tm: tm, fatal: context.Canceled}
 			}
 			if errors.Is(err, gh.ErrUnauthorized) || errors.Is(err, gh.ErrForbidden) {
-				tracker.Fail(fullName)
+				completeFail(fullName)
 				return fetchResult{tm: tm, fatal: fmt.Errorf("fetch %s: %w", fullName, err)}
 			}
-			tracker.Error(fullName, fmt.Errorf("fetch failed: %w", err))
+			completeError(fullName, fmt.Errorf("fetch failed: %w", err))
 			return fetchResult{tm: tm, skip: true}
 		}
 		if current.IsNew {
-			tracker.Error(fullName, fmt.Errorf("repository not found on GitHub"))
+			completeError(fullName, fmt.Errorf("repository not found on GitHub"))
 			return fetchResult{tm: tm, skip: true}
 		}
 
@@ -83,10 +128,12 @@ func Diff(ctx context.Context, opts DiffOptions) (*Result, error) {
 	// Abort on fatal errors (auth failure, context canceled).
 	for _, f := range fetched {
 		if f.fatal != nil {
+			completeRemaining()
 			return nil, f.fatal
 		}
 	}
 	if ctx.Err() != nil {
+		completeRemaining()
 		return nil, context.Canceled
 	}
 
@@ -107,6 +154,8 @@ func Diff(ctx context.Context, opts DiffOptions) (*Result, error) {
 
 		// Ensure manifest bytes are loaded for all relevant source paths.
 		if err := ensureManifestBytes(manifestBytes, f.tm.Matches); err != nil {
+			completeError(fullName, err)
+			completeRemaining()
 			return nil, err
 		}
 
@@ -118,7 +167,10 @@ func Diff(ctx context.Context, opts DiffOptions) (*Result, error) {
 				ManifestBytes: manifestBytes,
 			})
 			if err != nil {
-				return nil, fmt.Errorf("plan repository %s: %w", fullName, err)
+				err := fmt.Errorf("plan repository %s: %w", fullName, err)
+				completeError(fullName, err)
+				completeRemaining()
+				return nil, err
 			}
 			plan.AddRepoResult(rp)
 		}
@@ -131,7 +183,10 @@ func Diff(ctx context.Context, opts DiffOptions) (*Result, error) {
 				ManifestBytes: manifestBytes,
 			})
 			if err != nil {
-				return nil, fmt.Errorf("plan repositoryset %s: %w", fullName, err)
+				err := fmt.Errorf("plan repositoryset %s: %w", fullName, err)
+				completeError(fullName, err)
+				completeRemaining()
+				return nil, err
 			}
 			plan.AddRepoResult(rp)
 		}
@@ -147,14 +202,19 @@ func Diff(ctx context.Context, opts DiffOptions) (*Result, error) {
 			})
 			if err != nil {
 				if errors.Is(err, context.Canceled) {
+					completeError(fullName, context.Canceled)
+					completeRemaining()
 					return nil, context.Canceled
 				}
-				return nil, fmt.Errorf("plan files %s: %w", fullName, err)
+				err := fmt.Errorf("plan files %s: %w", fullName, err)
+				completeError(fullName, err)
+				completeRemaining()
+				return nil, err
 			}
 			plan.FileChanges = append(plan.FileChanges, fileChanges...)
 		}
 
-		tracker.Done(fullName)
+		completeDone(fullName)
 	}
 
 	return plan, nil

--- a/internal/importer/repository.go
+++ b/internal/importer/repository.go
@@ -116,6 +116,25 @@ func DiffRepositorySet(input DiffInput) (RepoResult, error) {
 		if !ok {
 			return plan, fmt.Errorf("no manifest bytes for %s", doc.SourcePath)
 		}
+		specExists, err := repositorySetEntrySpecExists(data, doc.DocIndex, doc.SetEntryIndex)
+		if err != nil {
+			return plan, fmt.Errorf("check repositoryset spec for %s doc %d path %s: %w",
+				doc.SourcePath, doc.DocIndex, yamlPath, err)
+		}
+		if !specExists {
+			entryPath := fmt.Sprintf("$.repositories[%d]", doc.SetEntryIndex)
+			updated, err := yamledit.Merge(data, doc.DocIndex, entryPath, map[string]any{
+				"spec": newOverride,
+			})
+			if err != nil {
+				return plan, fmt.Errorf("yamledit patch for %s doc %d path %s: %w",
+					doc.SourcePath, doc.DocIndex, yamlPath, err)
+			}
+			input.ManifestBytes[doc.SourcePath] = updated
+			plan.ManifestEdits[doc.SourcePath] = updated
+			plan.UpdatedDocs++
+			continue
+		}
 
 		updated, err := patchRepositorySpec(repositoryPatchInput{
 			Data:     data,
@@ -135,6 +154,11 @@ func DiffRepositorySet(input DiffInput) (RepoResult, error) {
 	}
 
 	return plan, nil
+}
+
+func repositorySetEntrySpecExists(data []byte, docIndex, entryIndex int) (bool, error) {
+	specPath := fmt.Sprintf("$.repositories[%d].spec", entryIndex)
+	return yamledit.Exists(data, docIndex, specPath)
 }
 
 type repositoryPatchInput struct {

--- a/internal/importer/repository_test.go
+++ b/internal/importer/repository_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/babarot/gh-infra/internal/manifest"
+	"github.com/goccy/go-yaml/parser"
 )
 
 func TestPlanRepository_NoDiff(t *testing.T) {
@@ -985,6 +986,96 @@ repositories:
 	}
 	if !found["description"] {
 		t.Error("expected diff for description")
+	}
+}
+
+func TestDiffRepositorySet_MissingSpecCreatesOverride(t *testing.T) {
+	active := manifest.RulesetEnforcementActive
+	branch := manifest.RulesetTargetBranch
+	defaults := &manifest.RepositorySetDefaults{
+		Spec: manifest.RepositorySpec{
+			Visibility: manifest.Ptr("private"),
+		},
+	}
+	originalEntry := &manifest.RepositorySpec{}
+
+	doc := &manifest.RepositoryDocument{
+		Resource: &manifest.Repository{
+			Metadata: manifest.RepositoryMetadata{Name: "repo", Owner: "org"},
+			Spec: manifest.RepositorySpec{
+				Visibility: manifest.Ptr("private"),
+			},
+		},
+		SourcePath:        "/tmp/set.yaml",
+		DocIndex:          0,
+		FromSet:           true,
+		SetEntryIndex:     0,
+		DefaultsSpec:      defaults,
+		OriginalEntrySpec: originalEntry,
+	}
+
+	yamlData := []byte(`apiVersion: gh-infra/v1
+kind: RepositorySet
+metadata:
+  owner: org
+defaults:
+  spec:
+    visibility: private
+repositories:
+  - name: repo
+`)
+
+	imported := &manifest.Repository{
+		Spec: manifest.RepositorySpec{
+			Visibility:  manifest.Ptr("private"),
+			Description: manifest.Ptr("hello"),
+			Rulesets: []manifest.Ruleset{
+				{
+					Name:        "main",
+					Target:      &branch,
+					Enforcement: &active,
+					Rules: manifest.RulesetRules{
+						NonFastForward:        manifest.Ptr(true),
+						Deletion:              manifest.Ptr(true),
+						Creation:              manifest.Ptr(false),
+						RequiredLinearHistory: manifest.Ptr(false),
+					},
+				},
+			},
+		},
+	}
+
+	mb := map[string][]byte{"/tmp/set.yaml": yamlData}
+	rp, err := DiffRepositorySet(DiffInput{
+		Repos:         []*manifest.RepositoryDocument{doc},
+		Imported:      imported,
+		ManifestBytes: mb,
+	})
+	if err != nil {
+		t.Fatalf("DiffRepositorySet error: %v", err)
+	}
+	if !rp.HasChanges() {
+		t.Fatal("expected changes")
+	}
+
+	updated := string(mb["/tmp/set.yaml"])
+	if !strings.Contains(updated, "spec:") {
+		t.Fatalf("expected missing spec to be created:\n%s", updated)
+	}
+	if !strings.Contains(updated, "description: hello") {
+		t.Fatalf("expected description override to be written:\n%s", updated)
+	}
+	if !strings.Contains(updated, "rulesets:") {
+		t.Fatalf("expected rulesets override to be written:\n%s", updated)
+	}
+	if !strings.Contains(updated, "non_fast_forward: true") {
+		t.Fatalf("expected ruleset rules to be written:\n%s", updated)
+	}
+	if strings.Contains(updated, "spec: {") {
+		t.Fatalf("expected spec to be block style, got flow style:\n%s", updated)
+	}
+	if _, err := parser.ParseBytes([]byte(updated), 0); err != nil {
+		t.Fatalf("expected updated YAML to parse: %v\n%s", err, updated)
 	}
 }
 

--- a/internal/importer/repository_test.go
+++ b/internal/importer/repository_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/babarot/gh-infra/internal/manifest"
+
 	"github.com/goccy/go-yaml/parser"
 )
 


### PR DESCRIPTION
## Summary

Fix two issues in the importer: ensure each progress tracker target is marked complete exactly once, and handle RepositorySet entries that lack a `spec` field.

## Background

The `Diff` function in the importer had two problems:

1. **Tracker completion gaps**: When `Diff` returned early due to errors (auth failures, context cancellation, plan errors), targets that hadn't been processed yet were left in an incomplete spinner state — the UI would freeze or never clear. Additionally, tracker methods (`Done`, `Error`, `Fail`) could be called multiple times for the same target when errors cascaded.

2. **Missing `spec` in RepositorySet entries**: `DiffRepositorySet` assumed every entry in a RepositorySet had a `spec:` node to patch. When an entry only had `name:` (inheriting everything from defaults), `patchRepositorySpec` would fail because it tried to patch a non-existent YAML node.

## Changes

- Add a mutex-guarded `completed` map in `Diff` that ensures each target's tracker callback (`Done`/`Error`/`Fail`) fires exactly once
- Add `completeRemaining()` helper that marks all unfinished targets as failed, called at every early-return path
- Replace all direct `tracker.Done`/`tracker.Error`/`tracker.Fail` calls with the deduplicating wrappers
- Add `repositorySetEntrySpecExists` helper using `yamledit.Exists` to check for spec presence
- When spec is missing, use `yamledit.Merge` to create the entire spec block instead of patching
- Add `TestDiffRepositorySet_MissingSpecCreatesOverride` test covering the new code path