### PR TITLE
Add checkpoint status and done-label to refresh tracker

### DIFF
--- a/internal/importer/diff.go
+++ b/internal/importer/diff.go
@@ -122,6 +122,7 @@ func Diff(ctx context.Context, opts DiffOptions) (*Result, error) {
 		}
 
 		imported := repository.ToManifest(ctx, current, resolver)
+		tracker.Checkpoint(fullName, "fetched repository state")
 		return fetchResult{tm: tm, imported: imported}
 	})
 

--- a/internal/importer/interfaces.go
+++ b/internal/importer/interfaces.go
@@ -3,6 +3,7 @@ package importer
 // RefreshTracker reports import-time refresh progress.
 type RefreshTracker interface {
 	UpdateStatus(name, status string)
+	Checkpoint(name, status string)
 	Done(name string)
 	Fail(name string)
 	Error(name string, err error)
@@ -11,6 +12,7 @@ type RefreshTracker interface {
 type noopRefreshTracker struct{}
 
 func (noopRefreshTracker) UpdateStatus(string, string) {}
+func (noopRefreshTracker) Checkpoint(string, string)   {}
 func (noopRefreshTracker) Done(string)                 {}
 func (noopRefreshTracker) Fail(string)                 {}
 func (noopRefreshTracker) Error(string, error)         {}

--- a/internal/infra/apply.go
+++ b/internal/infra/apply.go
@@ -96,8 +96,9 @@ func Apply(result *PlanResult, opts ApplyOptions) error {
 			}
 			seen[n] = true
 			allTasks = append(allTasks, ui.RefreshTask{
-				Name:    n,
-				Pending: taskMap[n],
+				Name:      n,
+				DoneLabel: "applied changes",
+				Pending:   taskMap[n],
 			})
 		}
 		tracker := ui.RunRefresh(allTasks)

--- a/internal/infra/import_into.go
+++ b/internal/infra/import_into.go
@@ -188,6 +188,7 @@ func ImportInto(args []string, into string) (*ImportDiff, error) {
 	for _, tm := range matched {
 		tasks = append(tasks, ui.RefreshTask{
 			Name:      tm.Target.FullName(),
+			DoneLabel: "fetched repository state",
 			FailLabel: tm.Target.FullName(),
 		})
 	}

--- a/internal/infra/plan.go
+++ b/internal/infra/plan.go
@@ -124,8 +124,9 @@ func Plan(opts PlanOptions) (*PlanResult, error) {
 		}
 		seen[n] = true
 		allTasks = append(allTasks, ui.RefreshTask{
-			Name:    n,
-			Pending: taskMap[n],
+			Name:      n,
+			DoneLabel: "planned desired changes",
+			Pending:   taskMap[n],
 		})
 	}
 	tracker := ui.RunRefresh(allTasks)

--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -41,6 +41,7 @@ func (p *Processor) Apply(ctx context.Context, changes []Change, repos []*manife
 		start := time.Now()
 		var results []ApplyResult
 		for _, c := range g.changes {
+			reporter.UpdateStatus(g.name, "applying "+c.Field+"...")
 			result := p.applyChange(ctx, c, repoMap[c.Name])
 			results = append(results, result)
 		}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -14,6 +14,7 @@ type ProgressReporter interface {
 // RefreshTracker reports plan-time refresh progress.
 type RefreshTracker interface {
 	UpdateStatus(name, status string)
+	Checkpoint(name, status string)
 	Done(name string)
 	Error(name string, err error)
 }
@@ -29,5 +30,6 @@ func (noopProgressReporter) Wait()                              {}
 type noopRefreshTracker struct{}
 
 func (noopRefreshTracker) UpdateStatus(string, string) {}
+func (noopRefreshTracker) Checkpoint(string, string)   {}
 func (noopRefreshTracker) Done(string)                 {}
 func (noopRefreshTracker) Error(string, error)         {}

--- a/internal/repository/plan.go
+++ b/internal/repository/plan.go
@@ -67,6 +67,7 @@ func (p *Processor) Plan(ctx context.Context, repos []*manifest.Repository, opts
 			tracker.Error(fullName, err)
 			return repoResult{index: idx, repo: r, err: err}
 		}
+		tracker.Checkpoint(fullName, "fetched repository state")
 
 		// Cross-field dependencies that need current state to evaluate.
 		// Only relevant for existing repos; for new repos these are validated

--- a/internal/ui/refresh.go
+++ b/internal/ui/refresh.go
@@ -39,6 +39,7 @@ type refreshItem struct {
 	status     taskStatus
 	errMsg     string
 	statusText string // right-side live status (e.g. "secrets...", ".github/ci.yml...")
+	checkpoint bool   // true when a sub-phase completed but the task is still running
 	pending    int    // expected Done() calls before marking complete (default 1)
 	spinner    spinner.Model
 }
@@ -56,6 +57,10 @@ type taskErrorMsg struct {
 	err  error
 }
 type taskFailMsg struct{ name string }
+type taskCheckpointMsg struct {
+	name   string
+	status string
+}
 type taskStatusMsg struct {
 	name   string
 	status string
@@ -115,6 +120,17 @@ func (m refreshModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		for i := range m.items {
 			if m.items[i].name == msg.name && m.items[i].status == taskRunning {
 				m.items[i].statusText = msg.status
+				m.items[i].checkpoint = false
+				break
+			}
+		}
+		return m, nil
+
+	case taskCheckpointMsg:
+		for i := range m.items {
+			if m.items[i].name == msg.name && m.items[i].status == taskRunning {
+				m.items[i].statusText = msg.status
+				m.items[i].checkpoint = true
 				break
 			}
 		}
@@ -130,6 +146,7 @@ func (m refreshModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.items[i].pending <= 0 {
 					m.items[i].status = taskDone
 					m.items[i].statusText = ""
+					m.items[i].checkpoint = false
 					m.remaining--
 				}
 			} else if m.items[i].pending > 0 {
@@ -152,6 +169,7 @@ func (m refreshModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.items[i].status = taskError
 				m.items[i].errMsg = msg.err.Error()
 				m.items[i].statusText = ""
+				m.items[i].checkpoint = false
 				m.items[i].pending--
 				if m.items[i].pending <= 0 {
 					m.remaining--
@@ -169,6 +187,7 @@ func (m refreshModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.items[i].name == msg.name && m.items[i].status == taskRunning {
 				m.items[i].status = taskFailed
 				m.items[i].statusText = ""
+				m.items[i].checkpoint = false
 				m.items[i].pending--
 				if m.items[i].pending <= 0 {
 					m.remaining--
@@ -222,11 +241,11 @@ func (m refreshModel) View() tea.View {
 		padded := fmt.Sprintf("%-*s", maxName, item.name)
 		switch item.status {
 		case taskDone:
-			label := item.doneLabel
-			if label == item.name {
-				label = padded
+			if item.doneLabel != "" && item.doneLabel != item.name {
+				fmt.Fprintf(&b, "  %s %s  %s\n", Green.Render(IconSuccess), padded, Dim.Render(item.doneLabel))
+			} else {
+				fmt.Fprintf(&b, "  %s %s\n", Green.Render(IconSuccess), padded)
 			}
-			fmt.Fprintf(&b, "  %s %s\n", Green.Render(IconSuccess), label)
 		case taskError:
 			// Show only a brief, single-line error; full details are printed after the spinner.
 			prefix := 2 + 1 + 1 + maxName + 2 // "  " + icon + " " + padded + "  "
@@ -243,7 +262,9 @@ func (m refreshModel) View() tea.View {
 		case taskCanceled:
 			fmt.Fprintf(&b, "  %s %s\n", Dim.Render(IconError), Dim.Render(padded+" (canceled)"))
 		case taskRunning:
-			if item.statusText != "" {
+			if item.checkpoint {
+				fmt.Fprintf(&b, "  %s %s  %s\n", Green.Render(IconSuccess), padded, Dim.Render(item.statusText))
+			} else if item.statusText != "" {
 				fmt.Fprintf(&b, "  %s %s  %s\n", item.spinner.View(), padded, Dim.Render(item.statusText))
 			} else {
 				fmt.Fprintf(&b, "  %s %s\n", item.spinner.View(), padded)
@@ -326,6 +347,21 @@ func (t *RefreshTracker) UpdateStatus(name, status string) {
 	defer t.mu.Unlock()
 	if t.program != nil {
 		t.program.Send(taskStatusMsg{name: name, status: status})
+	}
+}
+
+// Checkpoint marks a sub-phase as completed while the task remains running.
+func (t *RefreshTracker) Checkpoint(name, status string) {
+	if t == nil {
+		return
+	}
+	if t.fallback {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.program != nil {
+		t.program.Send(taskCheckpointMsg{name: name, status: status})
 	}
 }
 

--- a/internal/ui/refresh_test.go
+++ b/internal/ui/refresh_test.go
@@ -137,6 +137,26 @@ func TestRefreshModel_StatusUpdate(t *testing.T) {
 	}
 }
 
+func TestRefreshModel_CheckpointRemainsRunning(t *testing.T) {
+	m := makeModel(task("a", 1))
+	m = update(t, m, taskCheckpointMsg{name: "a", status: "fetched repository state"})
+
+	if m.items[0].status != taskRunning {
+		t.Errorf("status = %v, want taskRunning", m.items[0].status)
+	}
+	if !m.items[0].checkpoint {
+		t.Fatal("checkpoint should be set")
+	}
+	if m.remaining != 1 {
+		t.Errorf("remaining = %d, want 1", m.remaining)
+	}
+
+	m = update(t, m, taskErrorMsg{name: "a", err: fmt.Errorf("validation failed")})
+	if m.items[0].status != taskError {
+		t.Errorf("status after error = %v, want taskError", m.items[0].status)
+	}
+}
+
 func TestRefreshModel_StatusIgnoredAfterError(t *testing.T) {
 	m := makeModel(task("a", 1))
 
@@ -261,6 +281,16 @@ func TestView_StatusTextRendered(t *testing.T) {
 	}
 }
 
+func TestView_CheckpointRenderedWithCheckmark(t *testing.T) {
+	m := makeModel(task("repo", 1))
+	m = update(t, m, taskCheckpointMsg{name: "repo", status: "fetched repository state"})
+
+	view := stripANSIForTest(m.View().Content)
+	if !strings.Contains(view, "repo  fetched repository state") {
+		t.Errorf("view missing checkpoint text, got:\n%s", view)
+	}
+}
+
 func TestView_DoneHidesStatusText(t *testing.T) {
 	m := makeModel(task("repo", 1))
 	m = update(t, m, taskStatusMsg{name: "repo", status: "fetching..."})
@@ -269,6 +299,19 @@ func TestView_DoneHidesStatusText(t *testing.T) {
 	view := m.View().Content
 	if strings.Contains(view, "fetching...") {
 		t.Errorf("view should not contain status text after Done, got:\n%s", view)
+	}
+}
+
+func TestView_DoneLabelRenderedAsStatus(t *testing.T) {
+	m := newRefreshModel([]RefreshTask{
+		{Name: "short", DoneLabel: "fetched repository state"},
+		{Name: "much-longer-name"},
+	})
+	m = update(t, m, taskDoneMsg{name: "short"})
+
+	view := stripANSIForTest(m.View().Content)
+	if !strings.Contains(view, "short             fetched repository state") {
+		t.Errorf("view missing aligned done label, got:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add a `Checkpoint` method to the refresh tracker that visually marks completed sub-phases with a green checkmark while the task continues running. Also improve the done-state rendering to show a descriptive label next to the task name.

## Background

The spinner-based progress tracker previously had only two visual states for in-progress work: a spinning indicator with optional status text, or a final done/error/fail state. Multi-phase tasks like `plan` and `import --into` go through distinct sub-phases (fetch repository state, then compute diffs), but the user saw only the spinning status text change — there was no visual signal that one phase completed successfully before the next began.

Similarly, when a task completed, the done state showed only the task name with a checkmark. There was no way to communicate *what* completed (e.g., "fetched repository state" vs "planned desired changes" vs "applied changes"), making the spinner output less informative.

## Changes

- Add `Checkpoint(name, status)` method to `RefreshTracker` and both domain tracker interfaces (`importer.RefreshTracker`, `repository.RefreshTracker`) — renders a green checkmark with status text while the task remains running
- Add `DoneLabel` field to `RefreshTask` — rendered as dimmed text next to the task name when the task completes, keeping the name column-aligned
- Rework the `taskDone` view branch: show name + done-label when set, plain name otherwise (previously it replaced the name with the label, breaking column alignment)
- Wire `Checkpoint("fetched repository state")` into plan and import-into flows after successful repository fetch
- Wire `DoneLabel` per command: `"planned desired changes"` (plan), `"applied changes"` (apply), `"fetched repository state"` (import --into)
- Add per-field `UpdateStatus` during apply so the spinner shows which field is being applied
- Add unit tests for checkpoint state transitions, checkpoint rendering, and done-label alignment