### PR TITLE
Improve plan and import display for rulesets and branch protection

### DIFF
--- a/internal/importer/repository.go
+++ b/internal/importer/repository.go
@@ -954,33 +954,105 @@ func compareBranchProtection(local, imported []manifest.BranchProtection) []Fiel
 	for pattern, ibp := range importedMap {
 		lbp, exists := localMap[pattern]
 		if !exists {
-			diffs = append(diffs, FieldDiff{
-				Field: fmt.Sprintf("branch_protection.%s", pattern),
-				Old:   nil,
-				New:   formatBranchProtectionSummary(ibp),
-			})
+			diffs = append(diffs, branchProtectionCreateDiffs(pattern, ibp)...)
 			continue
 		}
-		if !reflect.DeepEqual(lbp, ibp) {
-			diffs = append(diffs, FieldDiff{
-				Field: fmt.Sprintf("branch_protection.%s", pattern),
-				Old:   formatBranchProtectionSummary(lbp),
-				New:   formatBranchProtectionSummary(ibp),
-			})
-		}
+		diffs = append(diffs, branchProtectionUpdateDiffs(pattern, lbp, ibp)...)
 	}
 
 	// Check for deletions (local has, GitHub doesn't)
 	for pattern, lbp := range localMap {
 		if _, exists := importedMap[pattern]; !exists {
 			diffs = append(diffs, FieldDiff{
-				Field: fmt.Sprintf("branch_protection.%s", pattern),
+				Field: fmt.Sprintf("branch_protection.%s.settings", pattern),
 				Old:   formatBranchProtectionSummary(lbp),
 				New:   nil,
 			})
 		}
 	}
 
+	return diffs
+}
+
+func branchProtectionCreateDiffs(pattern string, bp manifest.BranchProtection) []FieldDiff {
+	var diffs []FieldDiff
+	appendFieldCreate(&diffs, fmt.Sprintf("branch_protection.%s.required_reviews", pattern), bp.RequiredReviews)
+	appendFieldCreate(&diffs, fmt.Sprintf("branch_protection.%s.dismiss_stale_reviews", pattern), bp.DismissStaleReviews)
+	appendFieldCreate(&diffs, fmt.Sprintf("branch_protection.%s.require_code_owner_reviews", pattern), bp.RequireCodeOwnerReviews)
+	appendFieldCreate(&diffs, fmt.Sprintf("branch_protection.%s.enforce_admins", pattern), bp.EnforceAdmins)
+	appendFieldCreate(&diffs, fmt.Sprintf("branch_protection.%s.restrict_pushes", pattern), bp.RestrictPushes)
+	appendFieldCreate(&diffs, fmt.Sprintf("branch_protection.%s.allow_force_pushes", pattern), bp.AllowForcePushes)
+	appendFieldCreate(&diffs, fmt.Sprintf("branch_protection.%s.allow_deletions", pattern), bp.AllowDeletions)
+	if bp.RequireStatusChecks != nil {
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("branch_protection.%s.require_status_checks.strict", pattern),
+			Old:   nil,
+			New:   bp.RequireStatusChecks.Strict,
+		})
+		if len(bp.RequireStatusChecks.Contexts) > 0 {
+			diffs = append(diffs, FieldDiff{
+				Field: fmt.Sprintf("branch_protection.%s.require_status_checks.contexts", pattern),
+				Old:   nil,
+				New:   bp.RequireStatusChecks.Contexts,
+			})
+		}
+	}
+	if len(diffs) == 0 {
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("branch_protection.%s.settings", pattern),
+			Old:   nil,
+			New:   formatBranchProtectionSummary(bp),
+		})
+	}
+	return diffs
+}
+
+func branchProtectionUpdateDiffs(pattern string, local, imported manifest.BranchProtection) []FieldDiff {
+	var diffs []FieldDiff
+	appendFieldUpdate(&diffs, fmt.Sprintf("branch_protection.%s.required_reviews", pattern), local.RequiredReviews, imported.RequiredReviews)
+	appendFieldUpdate(&diffs, fmt.Sprintf("branch_protection.%s.dismiss_stale_reviews", pattern), local.DismissStaleReviews, imported.DismissStaleReviews)
+	appendFieldUpdate(&diffs, fmt.Sprintf("branch_protection.%s.require_code_owner_reviews", pattern), local.RequireCodeOwnerReviews, imported.RequireCodeOwnerReviews)
+	appendFieldUpdate(&diffs, fmt.Sprintf("branch_protection.%s.enforce_admins", pattern), local.EnforceAdmins, imported.EnforceAdmins)
+	appendFieldUpdate(&diffs, fmt.Sprintf("branch_protection.%s.restrict_pushes", pattern), local.RestrictPushes, imported.RestrictPushes)
+	appendFieldUpdate(&diffs, fmt.Sprintf("branch_protection.%s.allow_force_pushes", pattern), local.AllowForcePushes, imported.AllowForcePushes)
+	appendFieldUpdate(&diffs, fmt.Sprintf("branch_protection.%s.allow_deletions", pattern), local.AllowDeletions, imported.AllowDeletions)
+
+	switch {
+	case local.RequireStatusChecks == nil && imported.RequireStatusChecks != nil:
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("branch_protection.%s.require_status_checks.strict", pattern),
+			Old:   nil,
+			New:   imported.RequireStatusChecks.Strict,
+		})
+		if len(imported.RequireStatusChecks.Contexts) > 0 {
+			diffs = append(diffs, FieldDiff{
+				Field: fmt.Sprintf("branch_protection.%s.require_status_checks.contexts", pattern),
+				Old:   nil,
+				New:   imported.RequireStatusChecks.Contexts,
+			})
+		}
+	case local.RequireStatusChecks != nil && imported.RequireStatusChecks == nil:
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("branch_protection.%s.require_status_checks", pattern),
+			Old:   formatStatusChecksSummary(local.RequireStatusChecks),
+			New:   nil,
+		})
+	case local.RequireStatusChecks != nil && imported.RequireStatusChecks != nil:
+		if local.RequireStatusChecks.Strict != imported.RequireStatusChecks.Strict {
+			diffs = append(diffs, FieldDiff{
+				Field: fmt.Sprintf("branch_protection.%s.require_status_checks.strict", pattern),
+				Old:   local.RequireStatusChecks.Strict,
+				New:   imported.RequireStatusChecks.Strict,
+			})
+		}
+		if !reflect.DeepEqual(local.RequireStatusChecks.Contexts, imported.RequireStatusChecks.Contexts) {
+			diffs = append(diffs, FieldDiff{
+				Field: fmt.Sprintf("branch_protection.%s.require_status_checks.contexts", pattern),
+				Old:   local.RequireStatusChecks.Contexts,
+				New:   imported.RequireStatusChecks.Contexts,
+			})
+		}
+	}
 	return diffs
 }
 
@@ -1004,32 +1076,110 @@ func compareRulesets(local, imported []manifest.Ruleset) []FieldDiff {
 	for name, irs := range importedMap {
 		lrs, exists := localMap[name]
 		if !exists {
-			diffs = append(diffs, FieldDiff{
-				Field: fmt.Sprintf("rulesets.%s", name),
-				Old:   nil,
-				New:   formatRulesetSummary(irs),
-			})
+			diffs = append(diffs, rulesetCreateDiffs(name, irs)...)
 			continue
 		}
-		if !reflect.DeepEqual(lrs, irs) {
-			diffs = append(diffs, FieldDiff{
-				Field: fmt.Sprintf("rulesets.%s", name),
-				Old:   formatRulesetSummary(lrs),
-				New:   formatRulesetSummary(irs),
-			})
-		}
+		diffs = append(diffs, rulesetUpdateDiffs(name, lrs, irs)...)
 	}
 
 	for name, lrs := range localMap {
 		if _, exists := importedMap[name]; !exists {
 			diffs = append(diffs, FieldDiff{
-				Field: fmt.Sprintf("rulesets.%s", name),
+				Field: fmt.Sprintf("rulesets.%s.settings", name),
 				Old:   formatRulesetSummary(lrs),
 				New:   nil,
 			})
 		}
 	}
 
+	return diffs
+}
+
+func rulesetCreateDiffs(name string, rs manifest.Ruleset) []FieldDiff {
+	var diffs []FieldDiff
+	appendFieldCreate(&diffs, fmt.Sprintf("rulesets.%s.target", name), rs.Target)
+	appendFieldCreate(&diffs, fmt.Sprintf("rulesets.%s.enforcement", name), rs.Enforcement)
+	appendFieldCreate(&diffs, fmt.Sprintf("rulesets.%s.rules.non_fast_forward", name), rs.Rules.NonFastForward)
+	appendFieldCreate(&diffs, fmt.Sprintf("rulesets.%s.rules.deletion", name), rs.Rules.Deletion)
+	appendFieldCreate(&diffs, fmt.Sprintf("rulesets.%s.rules.creation", name), rs.Rules.Creation)
+	appendFieldCreate(&diffs, fmt.Sprintf("rulesets.%s.rules.required_linear_history", name), rs.Rules.RequiredLinearHistory)
+	appendFieldCreate(&diffs, fmt.Sprintf("rulesets.%s.rules.required_signatures", name), rs.Rules.RequiredSignatures)
+	if rs.Rules.PullRequest != nil {
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("rulesets.%s.rules.pull_request", name),
+			Old:   nil,
+			New:   "enabled",
+		})
+	}
+	if rs.Rules.RequiredStatusChecks != nil {
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("rulesets.%s.rules.required_status_checks", name),
+			Old:   nil,
+			New:   "enabled",
+		})
+	}
+	if len(rs.BypassActors) > 0 {
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("rulesets.%s.bypass_actors", name),
+			Old:   nil,
+			New:   fmt.Sprintf("%d actors", len(rs.BypassActors)),
+		})
+	}
+	if rs.Conditions != nil && rs.Conditions.RefName != nil {
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("rulesets.%s.conditions", name),
+			Old:   nil,
+			New:   formatRulesetConditions(rs.Conditions),
+		})
+	}
+	if len(diffs) == 0 {
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("rulesets.%s.settings", name),
+			Old:   nil,
+			New:   formatRulesetSummary(rs),
+		})
+	}
+	return diffs
+}
+
+func rulesetUpdateDiffs(name string, local, imported manifest.Ruleset) []FieldDiff {
+	var diffs []FieldDiff
+	appendFieldUpdate(&diffs, fmt.Sprintf("rulesets.%s.target", name), local.Target, imported.Target)
+	appendFieldUpdate(&diffs, fmt.Sprintf("rulesets.%s.enforcement", name), local.Enforcement, imported.Enforcement)
+	appendFieldUpdate(&diffs, fmt.Sprintf("rulesets.%s.rules.non_fast_forward", name), local.Rules.NonFastForward, imported.Rules.NonFastForward)
+	appendFieldUpdate(&diffs, fmt.Sprintf("rulesets.%s.rules.deletion", name), local.Rules.Deletion, imported.Rules.Deletion)
+	appendFieldUpdate(&diffs, fmt.Sprintf("rulesets.%s.rules.creation", name), local.Rules.Creation, imported.Rules.Creation)
+	appendFieldUpdate(&diffs, fmt.Sprintf("rulesets.%s.rules.required_linear_history", name), local.Rules.RequiredLinearHistory, imported.Rules.RequiredLinearHistory)
+	appendFieldUpdate(&diffs, fmt.Sprintf("rulesets.%s.rules.required_signatures", name), local.Rules.RequiredSignatures, imported.Rules.RequiredSignatures)
+
+	if !reflect.DeepEqual(local.Rules.PullRequest, imported.Rules.PullRequest) {
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("rulesets.%s.rules.pull_request", name),
+			Old:   enabledSummary(local.Rules.PullRequest != nil),
+			New:   enabledSummary(imported.Rules.PullRequest != nil),
+		})
+	}
+	if !reflect.DeepEqual(local.Rules.RequiredStatusChecks, imported.Rules.RequiredStatusChecks) {
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("rulesets.%s.rules.required_status_checks", name),
+			Old:   enabledSummary(local.Rules.RequiredStatusChecks != nil),
+			New:   enabledSummary(imported.Rules.RequiredStatusChecks != nil),
+		})
+	}
+	if !reflect.DeepEqual(local.BypassActors, imported.BypassActors) {
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("rulesets.%s.bypass_actors", name),
+			Old:   fmt.Sprintf("%d actors", len(local.BypassActors)),
+			New:   fmt.Sprintf("%d actors", len(imported.BypassActors)),
+		})
+	}
+	if !reflect.DeepEqual(local.Conditions, imported.Conditions) {
+		diffs = append(diffs, FieldDiff{
+			Field: fmt.Sprintf("rulesets.%s.conditions", name),
+			Old:   formatRulesetConditions(local.Conditions),
+			New:   formatRulesetConditions(imported.Conditions),
+		})
+	}
 	return diffs
 }
 
@@ -1175,6 +1325,73 @@ func formatRulesetSummary(rs manifest.Ruleset) string {
 		return rs.Name
 	}
 	return strings.Join(parts, ", ")
+}
+
+func appendFieldCreate[T any](diffs *[]FieldDiff, field string, value *T) {
+	if value == nil {
+		return
+	}
+	*diffs = append(*diffs, FieldDiff{Field: field, Old: nil, New: *value})
+}
+
+func appendFieldUpdate[T comparable](diffs *[]FieldDiff, field string, local, imported *T) {
+	if ptrEqualValue(local, imported) {
+		return
+	}
+	*diffs = append(*diffs, FieldDiff{
+		Field: field,
+		Old:   valueOfPtr(local),
+		New:   valueOfPtr(imported),
+	})
+}
+
+func ptrEqualValue[T comparable](a, b *T) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil || b == nil:
+		return false
+	default:
+		return *a == *b
+	}
+}
+
+func valueOfPtr[T any](v *T) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func formatStatusChecksSummary(s *manifest.StatusChecks) string {
+	if s == nil {
+		return "(none)"
+	}
+	return fmt.Sprintf("strict: %t, contexts: %d", s.Strict, len(s.Contexts))
+}
+
+func enabledSummary(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+func formatRulesetConditions(c *manifest.RulesetConditions) string {
+	if c == nil || c.RefName == nil {
+		return "(none)"
+	}
+	var parts []string
+	if len(c.RefName.Include) > 0 {
+		parts = append(parts, "include: "+strings.Join(c.RefName.Include, ","))
+	}
+	if len(c.RefName.Exclude) > 0 {
+		parts = append(parts, "exclude: "+strings.Join(c.RefName.Exclude, ","))
+	}
+	if len(parts) == 0 {
+		return "(none)"
+	}
+	return strings.Join(parts, "; ")
 }
 
 // minimalOverride returns the minimal spec override relative to defaults.

--- a/internal/importer/repository_test.go
+++ b/internal/importer/repository_test.go
@@ -1269,8 +1269,8 @@ func TestCompareBranchProtection_Update(t *testing.T) {
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff, got %d: %+v", len(diffs), diffs)
 	}
-	if diffs[0].Field != "branch_protection.main" {
-		t.Errorf("Field = %q, want %q", diffs[0].Field, "branch_protection.main")
+	if diffs[0].Field != "branch_protection.main.required_reviews" {
+		t.Errorf("Field = %q, want %q", diffs[0].Field, "branch_protection.main.required_reviews")
 	}
 }
 
@@ -1304,22 +1304,22 @@ func TestCompareBranchProtection_DeletedOnGitHub(t *testing.T) {
 	}
 }
 
-func TestCompareBranchProtection_SummaryFormat(t *testing.T) {
+func TestCompareBranchProtection_CreateFields(t *testing.T) {
 	local := []manifest.BranchProtection{}
 	imported := []manifest.BranchProtection{
 		{Pattern: "main", RequiredReviews: manifest.Ptr(2), EnforceAdmins: manifest.Ptr(true)},
 	}
 
 	diffs := compareBranchProtection(local, imported)
-	if len(diffs) != 1 {
-		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	if len(diffs) != 2 {
+		t.Fatalf("expected 2 diffs, got %d", len(diffs))
 	}
-	newStr, ok := diffs[0].New.(string)
-	if !ok {
-		t.Fatalf("New should be string, got %T", diffs[0].New)
+	fields := map[string]bool{}
+	for _, d := range diffs {
+		fields[d.Field] = true
 	}
-	if !strings.Contains(newStr, "reviews: 2") || !strings.Contains(newStr, "enforce_admins: true") {
-		t.Errorf("unexpected summary: %q", newStr)
+	if !fields["branch_protection.main.required_reviews"] || !fields["branch_protection.main.enforce_admins"] {
+		t.Errorf("unexpected fields: %+v", diffs)
 	}
 }
 
@@ -1344,8 +1344,8 @@ func TestCompareRulesets_Update(t *testing.T) {
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff, got %d: %+v", len(diffs), diffs)
 	}
-	if diffs[0].Field != "rulesets.protect-main" {
-		t.Errorf("Field = %q, want %q", diffs[0].Field, "rulesets.protect-main")
+	if diffs[0].Field != "rulesets.protect-main.enforcement" {
+		t.Errorf("Field = %q, want %q", diffs[0].Field, "rulesets.protect-main.enforcement")
 	}
 }
 
@@ -1364,22 +1364,22 @@ func TestCompareRulesets_NewOnGitHub(t *testing.T) {
 	}
 }
 
-func TestCompareRulesets_SummaryFormat(t *testing.T) {
+func TestCompareRulesets_CreateFields(t *testing.T) {
 	local := []manifest.Ruleset{}
 	imported := []manifest.Ruleset{
 		{Name: "protect-main", Target: manifest.Ptr("branch"), Enforcement: manifest.Ptr("active")},
 	}
 
 	diffs := compareRulesets(local, imported)
-	if len(diffs) != 1 {
-		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	if len(diffs) != 2 {
+		t.Fatalf("expected 2 diffs, got %d", len(diffs))
 	}
-	newStr, ok := diffs[0].New.(string)
-	if !ok {
-		t.Fatalf("New should be string, got %T", diffs[0].New)
+	fields := map[string]bool{}
+	for _, d := range diffs {
+		fields[d.Field] = true
 	}
-	if !strings.Contains(newStr, "target: branch") || !strings.Contains(newStr, "enforcement: active") {
-		t.Errorf("unexpected summary: %q", newStr)
+	if !fields["rulesets.protect-main.target"] || !fields["rulesets.protect-main.enforcement"] {
+		t.Errorf("unexpected fields: %+v", diffs)
 	}
 }
 

--- a/internal/infra/format.go
+++ b/internal/infra/format.go
@@ -326,10 +326,7 @@ func repoChangesToDiffGroups(changes []repository.Change) []ui.DiffGroup {
 				default:
 					icon = ui.IconChange
 				}
-				header := c.Field
-				if s, ok := c.NewValue.(string); ok && s != "" {
-					header = fmt.Sprintf("%s[%s]", c.Field, s)
-				}
+				header := repoChangeGroupHeader(c)
 				dg := ui.DiffGroup{Header: header, Icon: icon}
 				for _, child := range c.Children {
 					dg.Items = append(dg.Items, changeToDiffItem(child))
@@ -343,6 +340,34 @@ func repoChangesToDiffGroups(changes []repository.Change) []ui.DiffGroup {
 		}
 	}
 	return result
+}
+
+func repoChangeGroupHeader(c repository.Change) string {
+	if resource, key, ok := splitBracketResource(c.Resource); ok {
+		switch resource {
+		case manifest.ResourceRuleset:
+			return fmt.Sprintf("ruleset %q", key)
+		case manifest.ResourceBranchProtection:
+			return fmt.Sprintf("branch protection %q", key)
+		}
+	}
+	header := c.Field
+	if s, ok := c.NewValue.(string); ok && s != "" {
+		header = fmt.Sprintf("%s[%s]", c.Field, s)
+	}
+	return header
+}
+
+func splitBracketResource(resource string) (name, key string, ok bool) {
+	prefix, rest, found := strings.Cut(resource, "[")
+	if !found || !strings.HasSuffix(rest, "]") {
+		return "", "", false
+	}
+	key = strings.TrimSuffix(rest, "]")
+	if prefix == "" || key == "" {
+		return "", "", false
+	}
+	return prefix, key, true
 }
 
 func changeToDiffItem(c repository.Change) ui.DiffItem {

--- a/internal/infra/format_test.go
+++ b/internal/infra/format_test.go
@@ -543,3 +543,44 @@ func TestPrintPlan_GroupedLabelUpdate(t *testing.T) {
 		t.Errorf("expected 'bug.color' flattened field, got:\n%s", out)
 	}
 }
+
+func TestPrintPlan_RulesetAndBranchProtectionHeaders(t *testing.T) {
+	var buf bytes.Buffer
+	p := ui.NewStandardPrinterWith(&buf, &buf)
+
+	repoChanges := []repository.Change{
+		{
+			Type:     repository.ChangeUpdate,
+			Resource: `Ruleset[main-protection]`,
+			Name:     "org/repo",
+			Field:    "ruleset",
+			NewValue: "main-protection",
+			Children: []repository.Change{
+				{Type: repository.ChangeUpdate, Field: "enforcement", OldValue: "evaluate", NewValue: "active"},
+			},
+		},
+		{
+			Type:     repository.ChangeUpdate,
+			Resource: `BranchProtection[main]`,
+			Name:     "org/repo",
+			Field:    "branch_protection",
+			NewValue: "main",
+			Children: []repository.Change{
+				{Type: repository.ChangeUpdate, Field: "required_reviews", OldValue: 0, NewValue: 1},
+			},
+		},
+	}
+
+	printPlan(p, repoChanges, nil)
+	out := buf.String()
+
+	if !strings.Contains(out, `ruleset "main-protection"`) {
+		t.Errorf("expected human ruleset header, got:\n%s", out)
+	}
+	if !strings.Contains(out, `branch protection "main"`) {
+		t.Errorf("expected human branch protection header, got:\n%s", out)
+	}
+	if strings.Contains(out, "ruleset[") || strings.Contains(out, "branch_protection[") {
+		t.Errorf("output contains raw collection header:\n%s", out)
+	}
+}

--- a/internal/infra/import_into.go
+++ b/internal/infra/import_into.go
@@ -430,13 +430,33 @@ func fieldDiffsToDiffGroups(diffs []importer.FieldDiff) []ui.DiffGroup {
 
 		if keyedCollection[prefix] {
 			// Each unique key becomes its own group: prefix[key]
-			key := rest
-			header := fmt.Sprintf("%s[%s]", prefix, key)
+			key, child, _ := strings.Cut(rest, ".")
+			header := keyedCollectionHeader(prefix, key)
 			dg := ui.DiffGroup{Header: header}
-			dg.Items = append(dg.Items, fieldDiffToItem(d, key))
+			for i < len(diffs) {
+				p, r, ok := splitField(diffs[i].Field)
+				if !ok || p != prefix {
+					break
+				}
+				k, ch, _ := strings.Cut(r, ".")
+				if k != key {
+					break
+				}
+				if ch == "" {
+					ch = "settings"
+				}
+				dg.Items = append(dg.Items, fieldDiffToItem(diffs[i], ch))
+				i++
+			}
+			if len(dg.Items) == 0 {
+				if child == "" {
+					child = "settings"
+				}
+				dg.Items = append(dg.Items, fieldDiffToItem(d, child))
+				i++
+			}
 			dg.Icon = aggregateIcon(dg.Items)
 			result = append(result, dg)
-			i++
 			continue
 		}
 
@@ -478,18 +498,30 @@ func splitField(field string) (prefix, rest string, hasDot bool) {
 	return
 }
 
-func fieldDiffToItem(d importer.FieldDiff, field string) ui.DiffItem {
-	icon := ui.IconChange
-	if d.Old == nil && d.New != nil {
-		icon = ui.IconAdd
-	} else if d.Old != nil && d.New == nil {
-		icon = ui.IconRemove
+func keyedCollectionHeader(prefix, key string) string {
+	switch prefix {
+	case "rulesets":
+		return fmt.Sprintf("ruleset %q", key)
+	case "branch_protection":
+		return fmt.Sprintf("branch protection %q", key)
+	default:
+		return fmt.Sprintf("%s[%s]", prefix, key)
 	}
-	return ui.DiffItem{
-		Icon:  icon,
-		Field: field,
-		Old:   ui.FormatValue(d.Old),
-		New:   ui.FormatValue(d.New),
+}
+
+func fieldDiffToItem(d importer.FieldDiff, field string) ui.DiffItem {
+	switch {
+	case d.Old == nil && d.New != nil:
+		return ui.DiffItem{Icon: ui.IconAdd, Field: field, Value: d.New}
+	case d.Old != nil && d.New == nil:
+		return ui.DiffItem{Icon: ui.IconRemove, Field: field, Value: d.Old}
+	default:
+		return ui.DiffItem{
+			Icon:  ui.IconChange,
+			Field: field,
+			Old:   ui.FormatValue(d.Old),
+			New:   ui.FormatValue(d.New),
+		}
 	}
 }
 

--- a/internal/infra/import_into_test.go
+++ b/internal/infra/import_into_test.go
@@ -155,18 +155,21 @@ func TestFieldDiffsToDiffGroups_NestedObject(t *testing.T) {
 
 func TestFieldDiffsToDiffGroups_KeyedCollection(t *testing.T) {
 	diffs := []importer.FieldDiff{
-		{Field: "branch_protection.main", Old: nil, New: "reviews: 1"},
-		{Field: "branch_protection.develop", Old: nil, New: "reviews: 2"},
+		{Field: "branch_protection.main.required_reviews", Old: nil, New: 1},
+		{Field: "branch_protection.develop.required_reviews", Old: nil, New: 2},
 	}
 	groups := fieldDiffsToDiffGroups(diffs)
 	if len(groups) != 2 {
 		t.Fatalf("expected 2 groups (one per key), got %d", len(groups))
 	}
-	if groups[0].Header != "branch_protection[main]" {
-		t.Errorf("expected 'branch_protection[main]', got %q", groups[0].Header)
+	if groups[0].Header != `branch protection "main"` {
+		t.Errorf("expected human branch protection header, got %q", groups[0].Header)
 	}
-	if groups[1].Header != "branch_protection[develop]" {
-		t.Errorf("expected 'branch_protection[develop]', got %q", groups[1].Header)
+	if groups[0].Items[0].Field != "required_reviews" {
+		t.Errorf("expected child field required_reviews, got %q", groups[0].Items[0].Field)
+	}
+	if groups[1].Header != `branch protection "develop"` {
+		t.Errorf("expected human branch protection header, got %q", groups[1].Header)
 	}
 }
 
@@ -218,7 +221,7 @@ func TestFieldDiffsToDiffGroups_Mixed(t *testing.T) {
 	if len(groups) != 4 {
 		t.Fatalf("expected 4 groups, got %d", len(groups))
 	}
-	headers := []string{"", "features", "branch_protection[main]", "labels"}
+	headers := []string{"", "features", `branch protection "main"`, "labels"}
 	for i, want := range headers {
 		if groups[i].Header != want {
 			t.Errorf("group[%d] header = %q, want %q", i, groups[i].Header, want)
@@ -267,6 +270,12 @@ func TestFieldDiffsToDiffGroups_Icons(t *testing.T) {
 	}
 	if groups[0].Items[1].Icon != ui.IconRemove {
 		t.Errorf("removed label should be IconRemove, got %q", groups[0].Items[1].Icon)
+	}
+	if groups[0].Items[0].Value != "#FF0000" {
+		t.Errorf("new label Value = %v, want #FF0000", groups[0].Items[0].Value)
+	}
+	if groups[0].Items[1].Value != "#00FF00" {
+		t.Errorf("removed label Value = %v, want #00FF00", groups[0].Items[1].Value)
 	}
 }
 

--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -73,6 +73,14 @@ func (p *Processor) Apply(ctx context.Context, changes []Change, repos []*manife
 }
 
 func applyStatusTarget(c Change) string {
+	if resource, key, ok := splitApplyResource(c.Resource); ok {
+		switch resource {
+		case manifest.ResourceRuleset:
+			return fmt.Sprintf("ruleset %q", key)
+		case manifest.ResourceBranchProtection:
+			return fmt.Sprintf("branch protection %q", key)
+		}
+	}
 	switch c.Resource {
 	case manifest.ResourceLabel:
 		return fmt.Sprintf("label %q", c.Field)
@@ -99,6 +107,18 @@ func applyStatusTarget(c Change) string {
 		}
 		return c.Field
 	}
+}
+
+func splitApplyResource(resource string) (name, key string, ok bool) {
+	prefix, rest, found := strings.Cut(resource, "[")
+	if !found || !strings.HasSuffix(rest, "]") {
+		return "", "", false
+	}
+	key = strings.TrimSuffix(rest, "]")
+	if prefix == "" || key == "" {
+		return "", "", false
+	}
+	return prefix, key, true
 }
 
 type ApplyResult struct {

--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -41,7 +41,7 @@ func (p *Processor) Apply(ctx context.Context, changes []Change, repos []*manife
 		start := time.Now()
 		var results []ApplyResult
 		for _, c := range g.changes {
-			reporter.UpdateStatus(g.name, "applying "+c.Field+"...")
+			reporter.UpdateStatus(g.name, "applying "+applyStatusTarget(c)+"...")
 			result := p.applyChange(ctx, c, repoMap[c.Name])
 			results = append(results, result)
 		}
@@ -70,6 +70,35 @@ func (p *Processor) Apply(ctx context.Context, changes []Change, repos []*manife
 		results = append(results, r...)
 	}
 	return results
+}
+
+func applyStatusTarget(c Change) string {
+	switch c.Resource {
+	case manifest.ResourceLabel:
+		return fmt.Sprintf("label %q", c.Field)
+	case manifest.ResourceMilestone:
+		return fmt.Sprintf("milestone %q", c.Field)
+	case manifest.ResourceSecret:
+		return fmt.Sprintf("secret %q", c.Field)
+	case manifest.ResourceVariable:
+		return fmt.Sprintf("variable %q", c.Field)
+	case manifest.ResourceRuleset:
+		return fmt.Sprintf("ruleset %q", c.Field)
+	case manifest.ResourceBranchProtection:
+		return fmt.Sprintf("branch protection %q", c.Field)
+	case manifest.ResourceActions:
+		return "actions settings"
+	case manifest.ResourceRepository:
+		if c.Field == "" {
+			return "repository settings"
+		}
+		return "repository " + c.Field
+	default:
+		if c.Field == "" {
+			return strings.ToLower(c.Resource)
+		}
+		return c.Field
+	}
 }
 
 type ApplyResult struct {

--- a/internal/repository/apply_test.go
+++ b/internal/repository/apply_test.go
@@ -42,6 +42,16 @@ func TestApplyStatusTarget(t *testing.T) {
 			c:    Change{Resource: manifest.ResourceRepository, Field: "description"},
 			want: "repository description",
 		},
+		{
+			name: "ruleset resource key",
+			c:    Change{Resource: `Ruleset[main-protection]`, Field: "ruleset"},
+			want: `ruleset "main-protection"`,
+		},
+		{
+			name: "branch protection resource key",
+			c:    Change{Resource: `BranchProtection[main]`, Field: "branch_protection"},
+			want: `branch protection "main"`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/repository/apply_test.go
+++ b/internal/repository/apply_test.go
@@ -21,6 +21,38 @@ func newTestRepo(owner, name string) *manifest.Repository {
 	}
 }
 
+func TestApplyStatusTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		c    Change
+		want string
+	}{
+		{
+			name: "label",
+			c:    Change{Resource: manifest.ResourceLabel, Field: "bug"},
+			want: `label "bug"`,
+		},
+		{
+			name: "milestone",
+			c:    Change{Resource: manifest.ResourceMilestone, Field: "v1.0"},
+			want: `milestone "v1.0"`,
+		},
+		{
+			name: "repository field",
+			c:    Change{Resource: manifest.ResourceRepository, Field: "description"},
+			want: "repository description",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := applyStatusTarget(tt.c); got != tt.want {
+				t.Fatalf("applyStatusTarget() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyRepoDescription(t *testing.T) {
 	mock := &gh.MockRunner{}
 	proc := NewProcessor(mock, nil)

--- a/internal/repository/plan.go
+++ b/internal/repository/plan.go
@@ -81,6 +81,10 @@ func (p *Processor) Plan(ctx context.Context, repos []*manifest.Repository, opts
 		}
 
 		changes := Diff(ctx, r, current, diffOpts)
+		if hasLabelDeleteChanges(changes) {
+			tracker.UpdateStatus(fullName, "checking label usage...")
+			p.enrichLabelDeleteInfo(ctx, changes)
+		}
 		logger.Debug("diff done", "repo", fullName, "changes", len(changes))
 		tracker.Done(fullName)
 		return repoResult{index: idx, repo: r, changes: changes}
@@ -107,9 +111,15 @@ func (p *Processor) Plan(ctx context.Context, repos []*manifest.Repository, opts
 		targetRepos = append(targetRepos, res.repo)
 	}
 
-	// Enrich label delete changes with usage stats (issue/PR count, last used)
-	p.enrichLabelDeleteInfo(ctx, allChanges)
-
 	logger.Info("plan complete", "total_changes", len(allChanges), "skipped", skipped)
 	return allChanges, targetRepos, nil
+}
+
+func hasLabelDeleteChanges(changes []Change) bool {
+	for _, c := range changes {
+		if c.Resource == manifest.ResourceLabel && c.Type == ChangeDelete {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

Replace opaque one-line summaries for rulesets and branch protection with per-field diffs, show human-readable group headers (e.g. `ruleset "main"` instead of `rulesets[main]`), and improve apply-time spinner status text with resource-aware descriptions.

## Background

Ruleset and branch protection changes were previously displayed as single-line summary strings (e.g. `"target: branch, enforcement: active, rules: non_fast_forward, deletion"`). This made it difficult to identify which specific fields changed. The plan, import --into, and apply outputs all used raw field names or bracket-style headers (`rulesets[name]`, `branch_protection[pattern]`) that were inconsistent with the human-readable style used elsewhere.

Additionally, label-delete enrichment (issue/PR usage stats) was done as a bulk post-processing step after all diffs completed, leaving no progress indication in the spinner.

## Changes

- **Per-field diffs for rulesets and branch protection** (`importer/repository.go`): Break `compareBranchProtection` and `compareRulesets` into dedicated create/update diff functions that emit individual field-level `FieldDiff` entries instead of opaque summary strings. Add generic helpers (`appendFieldCreate`, `appendFieldUpdate`, `ptrEqualValue`, `valueOfPtr`) for concise pointer-field comparison.

- **Human-readable group headers** (`infra/format.go`, `infra/import_into.go`): Display `ruleset "name"` and `branch protection "pattern"` instead of `rulesets[name]` / `branch_protection[pattern]` in both plan and import --into output. The import --into path now groups multiple child fields under the same keyed-collection header.

- **Resource-aware apply status** (`repository/apply.go`): Format spinner status as `applying label "bug"...`, `applying ruleset "main"...`, `applying actions settings...` etc. instead of the raw field name.

- **Per-repo label enrichment** (`repository/plan.go`): Move `enrichLabelDeleteInfo` into the per-repo planning loop with a `"checking label usage..."` status update, instead of a silent bulk pass after all diffs.

- **Import --into `fieldDiffToItem` improvement**: Use `Value` field (add/remove) instead of always formatting as old/new, matching how plan output renders single-value changes.