### PR TITLE
Add pull_requests feature field with bool-or-object YAML support

### DIFF
--- a/docs/src/content/docs/resources/repository-set/defaults.md
+++ b/docs/src/content/docs/resources/repository-set/defaults.md
@@ -156,3 +156,20 @@ repositories:
         # issues: true       ← retained from defaults
         # projects: false    ← retained from defaults
 ```
+
+The `pull_requests` field within `features` is also merged at sub-field level when using the object form:
+
+```yaml
+defaults:
+  spec:
+    features:
+      pull_requests:
+        creation: collaborators_only
+
+repositories:
+  - name: open-repo
+    spec:
+      features:
+        pull_requests:
+          creation: all      # overrides creation; PRs stay enabled
+```

--- a/docs/src/content/docs/resources/repository/general.md
+++ b/docs/src/content/docs/resources/repository/general.md
@@ -51,6 +51,7 @@ spec:
     projects: false
     wiki: false
     discussions: false
+    pull_requests: true
 ```
 
 | Field | Type | Default | Description |
@@ -59,6 +60,30 @@ spec:
 | `projects` | bool | `true` | Enable Projects tab |
 | `wiki` | bool | `true` | Enable Wiki tab |
 | `discussions` | bool | `false` | Enable Discussions tab |
+| `pull_requests` | bool or object | `true` | Enable Pull Requests and optionally restrict creation |
+
+### Pull Request Permissions
+
+The `pull_requests` field accepts either a simple boolean or an object:
+
+```yaml
+# Simple form — enable or disable pull requests
+spec:
+  features:
+    pull_requests: true     # or false to disable
+
+# Object form — restrict who can create PRs
+spec:
+  features:
+    pull_requests:
+      creation: collaborators_only  # all | collaborators_only
+```
+
+Using the object form implicitly enables pull requests — there is no `enabled` field to set.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `creation` | string | `all` | `all` — anyone can create PRs; `collaborators_only` — only collaborators can create PRs |
 
 ## Merge Strategy
 

--- a/docs/src/content/docs/resources/repository/index.md
+++ b/docs/src/content/docs/resources/repository/index.md
@@ -89,7 +89,7 @@ The combination of `owner` and `name` identifies the target repository (`babarot
 | `topics` | GitHub topics for discoverability |
 | `labels` | Repository issue/PR labels — see [Labels](./labels/) |
 | `label_sync` | Label sync mode: `additive` (default) or `mirror` — see [Labels](./labels/#sync-mode) |
-| `features` | Toggle issues, projects, wiki, discussions — see [General Settings](./general/) |
+| `features` | Toggle issues, projects, wiki, discussions, pull requests — see [General Settings](./general/) |
 | `merge_strategy` | Merge commit, squash, rebase options — see [General Settings](./general/) |
 | `branch_protection` | Classic branch protection rules — see [Branch Protection](./branch-protection/) |
 | `rulesets` | Modern rulesets with enforcement modes and bypass actors — see [Rulesets](./rulesets/) |

--- a/docs/tapes/mock-gh
+++ b/docs/tapes/mock-gh
@@ -129,7 +129,9 @@ if [[ "$args" == *"--jq"*"squash_merge_commit_title"* ]]; then
   "squash_merge_commit_message": "COMMIT_MESSAGES",
   "merge_commit_title": "MERGE_MESSAGE",
   "merge_commit_message": "PR_TITLE",
-  "allow_auto_merge": false
+  "allow_auto_merge": false,
+  "has_pull_requests": true,
+  "pull_request_creation_policy": "all"
 }'
   exit 0
 fi

--- a/internal/importer/repository.go
+++ b/internal/importer/repository.go
@@ -557,6 +557,17 @@ func newRepositoryPatchPlan(basePath string) *repositoryPatchPlan {
 }
 
 func applyRepositoryDescriptor(plan *repositoryPatchPlan, field string, desired manifest.RepositorySpec) {
+	// pull_requests is patched as a whole object to avoid scalar/map type
+	// conflicts (e.g. pull_requests: true → pull_requests: {enabled: true, creation: ...}).
+	if strings.HasPrefix(field, "features.pull_requests") {
+		if desired.Features != nil && desired.Features.PullRequests != nil {
+			if plan.nestedMerges["features"] == nil {
+				plan.nestedMerges["features"] = map[string]any{}
+			}
+			plan.nestedMerges["features"]["pull_requests"] = desired.Features.PullRequests
+		}
+		return
+	}
 	for _, desc := range repositoryFieldDescriptors {
 		if desc.matches(field) {
 			desc.apply(plan, desired)
@@ -857,6 +868,8 @@ func compareFeatures(local, imported *manifest.Features) []FieldDiff {
 	diffs = appendBoolPtrDiff(diffs, "features.projects", l.Projects, i.Projects)
 	diffs = appendBoolPtrDiff(diffs, "features.wiki", l.Wiki, i.Wiki)
 	diffs = appendBoolPtrDiff(diffs, "features.discussions", l.Discussions, i.Discussions)
+	diffs = appendBoolPtrDiff(diffs, "features.pull_requests", l.PullRequests.IsEnabled(), i.PullRequests.IsEnabled())
+	diffs = appendPtrDiff(diffs, "features.pull_requests.creation", l.PullRequests.GetCreation(), i.PullRequests.GetCreation())
 	return diffs
 }
 
@@ -1643,10 +1656,24 @@ func minimalFeatures(defaults, imported *manifest.Features) *manifest.Features {
 		f.Discussions = i.Discussions
 		any = true
 	}
+	if !pullRequestsEqual(d.PullRequests, i.PullRequests) {
+		f.PullRequests = i.PullRequests
+		any = true
+	}
 	if !any {
 		return nil
 	}
 	return &f
+}
+
+func pullRequestsEqual(a, b *manifest.PullRequests) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return boolPtrEqual(a.Enabled, b.Enabled) && ptrEqual(a.Creation, b.Creation)
 }
 
 func minimalMergeStrategy(defaults, imported *manifest.MergeStrategy) *manifest.MergeStrategy {

--- a/internal/importer/repository_test.go
+++ b/internal/importer/repository_test.go
@@ -1658,3 +1658,64 @@ func TestCompareActions_SelectedActions(t *testing.T) {
 		t.Error("expected diff for patterns_allowed")
 	}
 }
+
+func TestCompareFeatures_PullRequests(t *testing.T) {
+	local := &manifest.Features{
+		PullRequests: &manifest.PullRequests{Enabled: manifest.Ptr(true)},
+	}
+	imported := &manifest.Features{
+		PullRequests: &manifest.PullRequests{Enabled: manifest.Ptr(false)},
+	}
+
+	diffs := compareFeatures(local, imported)
+	found := make(map[string]bool)
+	for _, d := range diffs {
+		found[d.Field] = true
+	}
+	if !found["features.pull_requests"] {
+		t.Error("expected diff for features.pull_requests")
+	}
+}
+
+func TestCompareFeatures_PullRequestsCreation(t *testing.T) {
+	local := &manifest.Features{
+		PullRequests: &manifest.PullRequests{
+			Enabled:  manifest.Ptr(true),
+			Creation: manifest.Ptr(manifest.PullRequestCreationAll),
+		},
+	}
+	imported := &manifest.Features{
+		PullRequests: &manifest.PullRequests{
+			Enabled:  manifest.Ptr(true),
+			Creation: manifest.Ptr(manifest.PullRequestCreationCollaboratorsOnly),
+		},
+	}
+
+	diffs := compareFeatures(local, imported)
+	found := make(map[string]bool)
+	for _, d := range diffs {
+		found[d.Field] = true
+	}
+	if !found["features.pull_requests.creation"] {
+		t.Error("expected diff for features.pull_requests.creation")
+	}
+	if found["features.pull_requests"] {
+		t.Error("should not diff features.pull_requests when Enabled is the same")
+	}
+}
+
+func TestCompareFeatures_PullRequestsNoDiff(t *testing.T) {
+	local := &manifest.Features{
+		PullRequests: &manifest.PullRequests{Enabled: manifest.Ptr(true)},
+	}
+	imported := &manifest.Features{
+		PullRequests: &manifest.PullRequests{Enabled: manifest.Ptr(true)},
+	}
+
+	diffs := compareFeatures(local, imported)
+	for _, d := range diffs {
+		if strings.HasPrefix(d.Field, "features.pull_requests") {
+			t.Errorf("unexpected diff: %s", d.Field)
+		}
+	}
+}

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -431,6 +431,26 @@ func mergeFeatures(base, override *Features) *Features {
 	if override.Discussions != nil {
 		result.Discussions = override.Discussions
 	}
+	if override.PullRequests != nil {
+		result.PullRequests = mergePullRequests(result.PullRequests, override.PullRequests)
+	}
+	return &result
+}
+
+func mergePullRequests(base, override *PullRequests) *PullRequests {
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		return base
+	}
+	result := *base
+	if override.Enabled != nil {
+		result.Enabled = override.Enabled
+	}
+	if override.Creation != nil {
+		result.Creation = override.Creation
+	}
 	return &result
 }
 

--- a/internal/manifest/pull_requests_test.go
+++ b/internal/manifest/pull_requests_test.go
@@ -1,0 +1,127 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+)
+
+func TestPullRequests_UnmarshalYAML_Bool(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"pull_requests: true", true},
+		{"pull_requests: false", false},
+	}
+	for _, tt := range tests {
+		var out struct {
+			PR *PullRequests `yaml:"pull_requests"`
+		}
+		if err := yaml.Unmarshal([]byte(tt.input), &out); err != nil {
+			t.Fatalf("unmarshal %q: %v", tt.input, err)
+		}
+		if out.PR == nil {
+			t.Fatalf("expected PullRequests, got nil for %q", tt.input)
+		}
+		if out.PR.Enabled == nil || *out.PR.Enabled != tt.want {
+			t.Errorf("Enabled = %v, want %v", out.PR.Enabled, tt.want)
+		}
+		if out.PR.Creation != nil {
+			t.Errorf("Creation should be nil for bool form, got %v", *out.PR.Creation)
+		}
+	}
+}
+
+func TestPullRequests_UnmarshalYAML_Object(t *testing.T) {
+	input := `
+pull_requests:
+  creation: collaborators_only
+`
+	var out struct {
+		PR *PullRequests `yaml:"pull_requests"`
+	}
+	if err := yaml.Unmarshal([]byte(input), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.PR == nil {
+		t.Fatal("expected PullRequests, got nil")
+	}
+	if out.PR.Enabled == nil || !*out.PR.Enabled {
+		t.Error("Enabled should be implicitly true for object form")
+	}
+	if out.PR.Creation == nil || *out.PR.Creation != PullRequestCreationCollaboratorsOnly {
+		t.Errorf("Creation = %v, want collaborators_only", out.PR.Creation)
+	}
+}
+
+func TestPullRequests_MarshalYAML_BoolTrue(t *testing.T) {
+	pr := PullRequests{Enabled: Ptr(true)}
+	data, err := yaml.Marshal(&pr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := strings.TrimSpace(string(data))
+	if s != "true" {
+		t.Errorf("expected bare bool 'true', got %q", s)
+	}
+}
+
+func TestPullRequests_MarshalYAML_BoolFalse(t *testing.T) {
+	pr := PullRequests{Enabled: Ptr(false)}
+	data, err := yaml.Marshal(&pr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := strings.TrimSpace(string(data))
+	if s != "false" {
+		t.Errorf("expected bare bool 'false', got %q", s)
+	}
+}
+
+func TestPullRequests_MarshalYAML_ObjectForm(t *testing.T) {
+	pr := PullRequests{
+		Enabled:  Ptr(true),
+		Creation: Ptr(PullRequestCreationCollaboratorsOnly),
+	}
+	data, err := yaml.Marshal(&pr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "enabled") {
+		t.Errorf("should not contain 'enabled' in output: %q", s)
+	}
+	if !strings.Contains(s, "creation: collaborators_only") {
+		t.Errorf("expected 'creation: collaborators_only' in %q", s)
+	}
+}
+
+func TestPullRequests_MarshalRoundTrip(t *testing.T) {
+	original := Features{
+		Issues: Ptr(true),
+		PullRequests: &PullRequests{
+			Enabled:  Ptr(true),
+			Creation: Ptr(PullRequestCreationCollaboratorsOnly),
+		},
+	}
+	data, err := yaml.Marshal(&original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got Features
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.PullRequests == nil {
+		t.Fatal("PullRequests nil after round-trip")
+	}
+	if got.PullRequests.Enabled == nil || !*got.PullRequests.Enabled {
+		t.Error("Enabled should be true after round-trip")
+	}
+	if got.PullRequests.Creation == nil || *got.PullRequests.Creation != PullRequestCreationCollaboratorsOnly {
+		t.Errorf("Creation = %v, want collaborators_only", got.PullRequests.Creation)
+	}
+}

--- a/internal/manifest/repository_types.go
+++ b/internal/manifest/repository_types.go
@@ -47,6 +47,10 @@ const (
 	MergeCommitMessagePRBody  = "PR_BODY"
 	MergeCommitMessageBlank   = "BLANK"
 
+	// Pull request creation policy values.
+	PullRequestCreationAll               = "all"
+	PullRequestCreationCollaboratorsOnly = "collaborators_only"
+
 	// DefaultMaxRepoList is the maximum number of repos to list in import.
 	DefaultMaxRepoList = "1000"
 )
@@ -98,10 +102,76 @@ type Security struct {
 }
 
 type Features struct {
-	Issues      *bool `yaml:"issues,omitempty"`
-	Projects    *bool `yaml:"projects,omitempty"`
-	Wiki        *bool `yaml:"wiki,omitempty"`
-	Discussions *bool `yaml:"discussions,omitempty"`
+	Issues       *bool         `yaml:"issues,omitempty"`
+	Projects     *bool         `yaml:"projects,omitempty"`
+	Wiki         *bool         `yaml:"wiki,omitempty"`
+	Discussions  *bool         `yaml:"discussions,omitempty"`
+	PullRequests *PullRequests `yaml:"pull_requests,omitempty"`
+}
+
+// PullRequests controls the pull request feature and creation policy.
+// Supports both bool form (pull_requests: true/false) and object form
+// (pull_requests: {creation: collaborators_only}).
+//
+// In bool form, true/false maps directly to has_pull_requests on the API.
+// In object form, pull requests are implicitly enabled and creation controls
+// the pull_request_creation_policy API field.
+//
+// Enabled is an internal field — it is not exposed in YAML.
+type PullRequests struct {
+	Enabled  *bool   `yaml:"-"` // internal; set by UnmarshalYAML
+	Creation *string `yaml:"creation,omitempty" validate:"omitempty,oneof=all collaborators_only"`
+}
+
+// UnmarshalYAML allows PullRequests to be either a bool or a struct.
+// Bool form sets Enabled directly. Object form implies Enabled=true.
+func (pr *PullRequests) UnmarshalYAML(unmarshal func(any) error) error {
+	var b bool
+	if err := unmarshal(&b); err == nil {
+		pr.Enabled = &b
+		return nil
+	}
+	type raw PullRequests
+	var r raw
+	if err := unmarshal(&r); err != nil {
+		return err
+	}
+	*pr = PullRequests(r)
+	// Object form implies enabled=true.
+	t := true
+	pr.Enabled = &t
+	return nil
+}
+
+// MarshalYAML emits a bare bool when Enabled is false or when no Creation
+// is set (simple enable). Only emits the object form when Creation is set.
+func (pr PullRequests) MarshalYAML() (any, error) {
+	if pr.Enabled != nil && !*pr.Enabled {
+		return false, nil
+	}
+	if pr.Creation == nil {
+		return true, nil
+	}
+	// Emit object form with only the creation field.
+	return struct {
+		Creation string `yaml:"creation"`
+	}{Creation: *pr.Creation}, nil
+}
+
+// IsEnabled returns the Enabled pointer, or nil if PullRequests is nil.
+func (pr *PullRequests) IsEnabled() *bool {
+	if pr == nil {
+		return nil
+	}
+	return pr.Enabled
+}
+
+// GetCreation returns the Creation pointer, or nil if PullRequests is nil.
+func (pr *PullRequests) GetCreation() *string {
+	if pr == nil {
+		return nil
+	}
+	return pr.Creation
 }
 
 type MergeStrategy struct {

--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -305,6 +305,14 @@ func (p *Processor) applyRepoPatch(ctx context.Context, fullName string, repo *m
 		if f.Discussions != nil {
 			payload["has_discussions"] = *f.Discussions
 		}
+		if f.PullRequests != nil {
+			if f.PullRequests.Enabled != nil {
+				payload["has_pull_requests"] = *f.PullRequests.Enabled
+			}
+			if f.PullRequests.Creation != nil {
+				payload["pull_request_creation_policy"] = *f.PullRequests.Creation
+			}
+		}
 	}
 
 	// Merge strategy
@@ -473,6 +481,18 @@ func (p *Processor) applyRepoSetting(ctx context.Context, c Change, repo *manife
 			return fmt.Errorf("unexpected type for %s: %T", c.Field, c.NewValue)
 		}
 		return p.toggleFeature(ctx, fullName, "enable-discussions", v)
+	case "pull_requests":
+		v, ok := c.NewValue.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type for %s: %T", c.Field, c.NewValue)
+		}
+		return p.updateRepoField(ctx, owner+"/"+name, "has_pull_requests", fmt.Sprintf("%t", v))
+	case "pull_requests.creation":
+		v, ok := c.NewValue.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type for %s: %T", c.Field, c.NewValue)
+		}
+		return p.updateRepoField(ctx, owner+"/"+name, "pull_request_creation_policy", v)
 	case "allow_merge_commit":
 		v, ok := c.NewValue.(bool)
 		if !ok {

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -204,6 +204,10 @@ func diffFeatures(name string, desired *manifest.Repository, current *CurrentSta
 		appendChildChanged(cc, "projects", f.Projects, current.Features.Projects)
 		appendChildChanged(cc, "wiki", f.Wiki, current.Features.Wiki)
 		appendChildChanged(cc, "discussions", f.Discussions, current.Features.Discussions)
+		appendChildChanged(cc, "pull_requests", f.PullRequests.IsEnabled(), current.Features.PullRequests)
+		if f.PullRequests != nil && f.PullRequests.Creation != nil {
+			appendChildChanged(cc, "pull_requests.creation", f.PullRequests.Creation, current.Features.PullRequestCreation)
+		}
 	})
 }
 

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -576,6 +576,60 @@ func TestDiff_Features_BoolNoChange(t *testing.T) {
 	}
 }
 
+func TestDiff_Features_PullRequests(t *testing.T) {
+	d := baseDesired()
+	d.Spec.Features = &manifest.Features{
+		PullRequests: &manifest.PullRequests{Enabled: manifest.Ptr(false)},
+	}
+	c := baseState()
+	c.Features.PullRequests = true
+
+	changes := diffFeatures("org/repo", d, c)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(changes))
+	}
+	child := changes[0].Children
+	if len(child) != 1 || child[0].Field != "pull_requests" {
+		t.Errorf("expected pull_requests child change, got %+v", child)
+	}
+}
+
+func TestDiff_Features_PullRequestsCreation(t *testing.T) {
+	d := baseDesired()
+	d.Spec.Features = &manifest.Features{
+		PullRequests: &manifest.PullRequests{
+			Enabled:  manifest.Ptr(true),
+			Creation: manifest.Ptr(manifest.PullRequestCreationCollaboratorsOnly),
+		},
+	}
+	c := baseState()
+	c.Features.PullRequests = true
+	c.Features.PullRequestCreation = manifest.PullRequestCreationAll
+
+	changes := diffFeatures("org/repo", d, c)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(changes))
+	}
+	child := changes[0].Children
+	if len(child) != 1 || child[0].Field != "pull_requests.creation" {
+		t.Errorf("expected pull_requests.creation child change, got %+v", child)
+	}
+}
+
+func TestDiff_Features_PullRequestsNoChange(t *testing.T) {
+	d := baseDesired()
+	d.Spec.Features = &manifest.Features{
+		PullRequests: &manifest.PullRequests{Enabled: manifest.Ptr(true)},
+	}
+	c := baseState()
+	c.Features.PullRequests = true
+
+	changes := diffFeatures("org/repo", d, c)
+	if len(changes) != 0 {
+		t.Errorf("expected no changes, got %d", len(changes))
+	}
+}
+
 func TestDiff_MergeStrategy_CommitStrings(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/repository/export.go
+++ b/internal/repository/export.go
@@ -28,12 +28,7 @@ func ToManifest(ctx context.Context, r *CurrentState, resolver *manifest.Resolve
 				AutomatedSecurityFixes:        manifest.Ptr(r.Security.AutomatedSecurityFixes),
 				PrivateVulnerabilityReporting: manifest.Ptr(r.Security.PrivateVulnerabilityReporting),
 			},
-			Features: &manifest.Features{
-				Issues:      manifest.Ptr(r.Features.Issues),
-				Projects:    manifest.Ptr(r.Features.Projects),
-				Wiki:        manifest.Ptr(r.Features.Wiki),
-				Discussions: manifest.Ptr(r.Features.Discussions),
-			},
+			Features: exportFeatures(r),
 			MergeStrategy: &manifest.MergeStrategy{
 				AllowMergeCommit:         manifest.Ptr(r.MergeStrategy.AllowMergeCommit),
 				AllowSquashMerge:         manifest.Ptr(r.MergeStrategy.AllowSquashMerge),
@@ -199,4 +194,20 @@ func ToManifest(ctx context.Context, r *CurrentState, resolver *manifest.Resolve
 	}
 
 	return repo
+}
+
+func exportFeatures(r *CurrentState) *manifest.Features {
+	pr := &manifest.PullRequests{
+		Enabled: manifest.Ptr(r.Features.PullRequests),
+	}
+	if r.Features.PullRequestCreation != "" && r.Features.PullRequestCreation != manifest.PullRequestCreationAll {
+		pr.Creation = manifest.Ptr(r.Features.PullRequestCreation)
+	}
+	return &manifest.Features{
+		Issues:       manifest.Ptr(r.Features.Issues),
+		Projects:     manifest.Ptr(r.Features.Projects),
+		Wiki:         manifest.Ptr(r.Features.Wiki),
+		Discussions:  manifest.Ptr(r.Features.Discussions),
+		PullRequests: pr,
+	}
 }

--- a/internal/repository/state.go
+++ b/internal/repository/state.go
@@ -108,7 +108,12 @@ func (p *Processor) FetchRepository(ctx context.Context, owner, name string, onS
 	})
 
 	var (
-		commitMsgSettings             commitMessageSettings
+		// Initialize with safe defaults so that 403/404 fallback does not
+		// produce a destructive zero-value (e.g. has_pull_requests=false).
+		commitMsgSettings = commitMessageSettings{
+			HasPullRequests:     true,
+			PullRequestCreation: manifest.PullRequestCreationAll,
+		}
 		releaseImmutability           bool
 		vulnerabilityAlerts           bool
 		automatedSecurityFixes        bool
@@ -207,6 +212,8 @@ func (p *Processor) FetchRepository(ctx context.Context, owner, name string, onS
 	repo.MergeStrategy.SquashMergeCommitTitle = commitMsgSettings.SquashMergeCommitTitle
 	repo.MergeStrategy.SquashMergeCommitMessage = commitMsgSettings.SquashMergeCommitMessage
 	repo.MergeStrategy.AllowAutoMerge = commitMsgSettings.AllowAutoMerge
+	repo.Features.PullRequests = commitMsgSettings.HasPullRequests
+	repo.Features.PullRequestCreation = commitMsgSettings.PullRequestCreation
 	repo.Security = CurrentSecurity{
 		VulnerabilityAlerts:           vulnerabilityAlerts,
 		AutomatedSecurityFixes:        automatedSecurityFixes,
@@ -289,23 +296,27 @@ type commitMessageSettings struct {
 	SquashMergeCommitTitle   string
 	SquashMergeCommitMessage string
 	AllowAutoMerge           bool
+	HasPullRequests          bool
+	PullRequestCreation      string
 }
 
 func (p *Processor) fetchCommitMessageSettings(ctx context.Context, owner, name string) (commitMessageSettings, error) {
 	out, err := p.runner.Run(ctx,
 		"api", fmt.Sprintf("repos/%s/%s", owner, name),
-		"--jq", "{squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}",
+		"--jq", "{squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge,has_pull_requests,pull_request_creation_policy}",
 	)
 	if err != nil {
 		return commitMessageSettings{}, err
 	}
 
 	var raw struct {
-		SquashMergeCommitTitle   *string `json:"squash_merge_commit_title"`
-		SquashMergeCommitMessage *string `json:"squash_merge_commit_message"`
-		MergeCommitTitle         *string `json:"merge_commit_title"`
-		MergeCommitMessage       *string `json:"merge_commit_message"`
-		AllowAutoMerge           bool    `json:"allow_auto_merge"`
+		SquashMergeCommitTitle    *string `json:"squash_merge_commit_title"`
+		SquashMergeCommitMessage  *string `json:"squash_merge_commit_message"`
+		MergeCommitTitle          *string `json:"merge_commit_title"`
+		MergeCommitMessage        *string `json:"merge_commit_message"`
+		AllowAutoMerge            bool    `json:"allow_auto_merge"`
+		HasPullRequests           *bool   `json:"has_pull_requests"`
+		PullRequestCreationPolicy *string `json:"pull_request_creation_policy"`
 	}
 	if err := json.Unmarshal(out, &raw); err != nil {
 		return commitMessageSettings{}, err
@@ -318,12 +329,23 @@ func (p *Processor) fetchCommitMessageSettings(ctx context.Context, owner, name 
 		return def
 	}
 
+	hasPR := true
+	if raw.HasPullRequests != nil {
+		hasPR = *raw.HasPullRequests
+	}
+	prCreation := manifest.PullRequestCreationAll
+	if raw.PullRequestCreationPolicy != nil && *raw.PullRequestCreationPolicy != "" {
+		prCreation = *raw.PullRequestCreationPolicy
+	}
+
 	return commitMessageSettings{
 		MergeCommitTitle:         deref(raw.MergeCommitTitle, "MERGE_MESSAGE"),
 		MergeCommitMessage:       deref(raw.MergeCommitMessage, "PR_TITLE"),
 		SquashMergeCommitTitle:   deref(raw.SquashMergeCommitTitle, "COMMIT_OR_PR_TITLE"),
 		SquashMergeCommitMessage: deref(raw.SquashMergeCommitMessage, "COMMIT_MESSAGES"),
 		AllowAutoMerge:           raw.AllowAutoMerge,
+		HasPullRequests:          hasPR,
+		PullRequestCreation:      prCreation,
 	}, nil
 }
 

--- a/internal/repository/state_test.go
+++ b/internal/repository/state_test.go
@@ -42,12 +42,14 @@ func TestFetchRepository(t *testing.T) {
 				"deleteBranchOnMerge": true,
 				"defaultBranchRef": {"name": "main"}
 			}`),
-			"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}": []byte(`{
+			"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge,has_pull_requests,pull_request_creation_policy}": []byte(`{
 				"squash_merge_commit_title": "PR_TITLE",
 				"squash_merge_commit_message": "COMMIT_MESSAGES",
 				"merge_commit_title": "MERGE_MESSAGE",
 				"merge_commit_message": "PR_BODY",
-				"allow_auto_merge": false
+				"allow_auto_merge": false,
+				"has_pull_requests": true,
+				"pull_request_creation_policy": "collaborators_only"
 			}`),
 			"api repos/myorg/myrepo/immutable-releases":                                       []byte(`{"enabled": false}`),
 			"api repos/myorg/myrepo/vulnerability-alerts":                                     []byte(``),
@@ -99,6 +101,12 @@ func TestFetchRepository(t *testing.T) {
 	}
 	if state.Features.Discussions {
 		t.Error("expected Discussions = false")
+	}
+	if !state.Features.PullRequests {
+		t.Error("expected PullRequests = true")
+	}
+	if state.Features.PullRequestCreation != "collaborators_only" {
+		t.Errorf("expected PullRequestCreation = collaborators_only, got %q", state.Features.PullRequestCreation)
 	}
 
 	// Merge strategy
@@ -306,7 +314,7 @@ func TestFetchVariables(t *testing.T) {
 func TestFetchCommitMessageSettings_NullValues(t *testing.T) {
 	mock := &gh.MockRunner{
 		Responses: map[string][]byte{
-			"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}": []byte(`{
+			"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge,has_pull_requests,pull_request_creation_policy}": []byte(`{
 				"squash_merge_commit_title": null,
 				"squash_merge_commit_message": null,
 				"merge_commit_title": null,
@@ -332,6 +340,12 @@ func TestFetchCommitMessageSettings_NullValues(t *testing.T) {
 	}
 	if settings.SquashMergeCommitMessage != "COMMIT_MESSAGES" {
 		t.Errorf("SquashMergeCommitMessage = %q, want COMMIT_MESSAGES", settings.SquashMergeCommitMessage)
+	}
+	if !settings.HasPullRequests {
+		t.Error("HasPullRequests should default to true when absent")
+	}
+	if settings.PullRequestCreation != "all" {
+		t.Errorf("PullRequestCreation = %q, want all (default)", settings.PullRequestCreation)
 	}
 }
 
@@ -361,7 +375,7 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 			"deleteBranchOnMerge": true,
 			"defaultBranchRef": {"name": "main"}
 		}`),
-		"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}": []byte(`{
+		"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge,has_pull_requests,pull_request_creation_policy}": []byte(`{
 			"squash_merge_commit_title": "PR_TITLE",
 			"squash_merge_commit_message": "COMMIT_MESSAGES",
 			"merge_commit_title": "MERGE_MESSAGE",
@@ -376,12 +390,12 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 	t.Run("commit message settings 404 is ignored", func(t *testing.T) {
 		responses := make(map[string][]byte)
 		maps.Copy(responses, baseResponses)
-		delete(responses, "api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}")
+		delete(responses, "api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge,has_pull_requests,pull_request_creation_policy}")
 
 		mock := &gh.MockRunner{
 			Responses: responses,
 			Errors: map[string]error{
-				"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}": fmt.Errorf("%w: api error", gh.ErrNotFound),
+				"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge,has_pull_requests,pull_request_creation_policy}": fmt.Errorf("%w: api error", gh.ErrNotFound),
 			},
 		}
 		p := NewProcessor(mock, nil)
@@ -418,12 +432,12 @@ func TestFetchRepoSettings_FetchErrorHandling(t *testing.T) {
 	t.Run("commit message settings 500 propagates error", func(t *testing.T) {
 		responses := make(map[string][]byte)
 		maps.Copy(responses, baseResponses)
-		delete(responses, "api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}")
+		delete(responses, "api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge,has_pull_requests,pull_request_creation_policy}")
 
 		mock := &gh.MockRunner{
 			Responses: responses,
 			Errors: map[string]error{
-				"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge}": fmt.Errorf("internal server error"),
+				"api repos/myorg/myrepo --jq {squash_merge_commit_title,squash_merge_commit_message,merge_commit_title,merge_commit_message,allow_auto_merge,has_pull_requests,pull_request_creation_policy}": fmt.Errorf("internal server error"),
 			},
 		}
 		p := NewProcessor(mock, nil)

--- a/internal/repository/state_types.go
+++ b/internal/repository/state_types.go
@@ -43,10 +43,12 @@ type CurrentSecurity struct {
 }
 
 type CurrentFeatures struct {
-	Issues      bool
-	Projects    bool
-	Wiki        bool
-	Discussions bool
+	Issues              bool
+	Projects            bool
+	Wiki                bool
+	Discussions         bool
+	PullRequests        bool
+	PullRequestCreation string // "all" or "collaborators_only"
 }
 
 type CurrentMergeStrategy struct {

--- a/skills/repository-manifest/references/general.md
+++ b/skills/repository-manifest/references/general.md
@@ -24,7 +24,21 @@ spec:
     projects: false
     wiki: false
     discussions: false
+    pull_requests: true
 ```
+
+`pull_requests` accepts bool or object:
+
+```yaml
+# Object form with creation restriction (implicitly enables PRs)
+pull_requests:
+  creation: collaborators_only  # "all" (default) or "collaborators_only"
+```
+
+- `pull_requests: true` enables PRs (default behavior)
+- `pull_requests: false` disables the PR feature entirely
+- Object form implicitly enables PRs; there is no `enabled` field
+- In RepositorySet defaults, `pull_requests.creation` is independently overridable
 
 ## Merge Strategy
 

--- a/skills/repository-manifest/references/repository-set.md
+++ b/skills/repository-manifest/references/repository-set.md
@@ -29,6 +29,7 @@ Examples:
 - `visibility`, `label_sync`: scalar replace
 - `topics`, `labels`, `branch_protection`, `rulesets`, `secrets`, `variables`: list replace
 - `features`, `merge_strategy`, `actions`: map merge by key (individual fields like `enabled`, `allowed_actions` are independently overridable)
+- `features.pull_requests`: map merge by key (`enabled` and `creation` are independently overridable)
 - `actions.selected_actions`: map merge by key
 - `actions.selected_actions.patterns_allowed`: list replace
 


### PR DESCRIPTION
## Summary

Add a `pull_requests` field to `Features` that manages GitHub's `has_pull_requests` and `pull_request_creation_policy` settings, supporting both simple bool and object YAML forms.

## Background

GitHub's repository settings include a "Pull requests" toggle and a "Pull request permissions" dropdown (`Creation allowed by: All users / Collaborators only`). Neither was managed by gh-infra. This adds full lifecycle support — fetch, diff, plan, apply, export, and import — using a bool-or-object YAML syntax that keeps the simple case (`pull_requests: true`) consistent with other feature fields while allowing the creation policy restriction via an object form.

## Changes

- **Type system** (`manifest/repository_types.go`): Add `PullRequests` struct with `UnmarshalYAML` (bool → sets internal `Enabled`; object → sets `Creation` and implies `Enabled=true`) and `MarshalYAML` (emits bare bool when no `Creation`, object with only `creation` field otherwise). The `Enabled` field uses `yaml:"-"` — it is not exposed in YAML.
- **Fetch** (`repository/state.go`): Extend the commit-settings REST API call to include `has_pull_requests` and `pull_request_creation_policy`. Initialize `commitMsgSettings` with safe defaults (`HasPullRequests: true`) before the errgroup to prevent destructive zero-value on 403/404 fallback.
- **Diff** (`repository/diff.go`): Add `pull_requests` and `pull_requests.creation` child changes to `diffFeatures`.
- **Apply** (`repository/apply.go`): Route `pull_requests` to `has_pull_requests` and `pull_requests.creation` to `pull_request_creation_policy` via REST PATCH. Also included in the `applyRepoPatch` creation payload.
- **Export** (`repository/export.go`): Build `PullRequests` from `CurrentFeatures`, omitting `Creation` when it equals the default `"all"` so export produces clean `pull_requests: true`.
- **Parser** (`manifest/parser.go`): Add `mergePullRequests` for RepositorySet defaults merge.
- **Importer** (`importer/repository.go`): Extend `compareFeatures` with pull_requests diffs. Patch `pull_requests` as a whole object via `applyRepositoryDescriptor` to avoid scalar↔map type conflicts.
- **Documentation**: Update `general.md`, `index.md`, `defaults.md`, and skill references with the new field and its syntax.
- **Mock/Tests**: Update mock-gh default JSON, state_test mock keys, and add tests for unmarshal/marshal, diff, and import comparison.