### PR TITLE
feat: make file distribution commits verified

### DIFF
--- a/internal/fileset/fileset_test.go
+++ b/internal/fileset/fileset_test.go
@@ -236,6 +236,10 @@ func setupGitDataAPIMock(repo string) *WildcardMockRunner {
 				fmt.Sprintf("repo view %s --json defaultBranchRef --jq .defaultBranchRef.name", repo): []byte("main"),
 				// Get HEAD SHA
 				fmt.Sprintf("api repos/%s/git/ref/heads/main --jq .object.sha", repo): []byte("head123"),
+				// Get authenticated user (PAT path; not a bot)
+				`api /user --jq .login+"|"+(.name // .login)`: []byte("testuser|Test User"),
+				// Get primary email
+				`api /user/emails --jq [.[] | select(.primary == true)] | .[0].email`: []byte("test@example.com"),
 			},
 			Errors: map[string]error{},
 		},
@@ -245,9 +249,15 @@ func setupGitDataAPIMock(repo string) *WildcardMockRunner {
 	return mock
 }
 
+// stubSign is a no-op GPG signer for tests.
+func stubSign(_ string) (string, error) {
+	return "-----BEGIN PGP SIGNATURE-----\nstub\n-----END PGP SIGNATURE-----", nil
+}
+
 func TestApply_CreateFile(t *testing.T) {
 	mock := setupGitDataAPIMock("owner/repo")
 	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
+	p.sign = stubSign
 
 	changes := []Change{
 		{
@@ -280,6 +290,7 @@ func TestApply_CreateFile(t *testing.T) {
 func TestApply_UpdateFile(t *testing.T) {
 	mock := setupGitDataAPIMock("owner/repo")
 	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
+	p.sign = stubSign
 
 	changes := []Change{
 		{

--- a/internal/fileset/fileset_test.go
+++ b/internal/fileset/fileset_test.go
@@ -227,8 +227,8 @@ func (m *WildcardMockRunner) Run(_ context.Context, args ...string) ([]byte, err
 	return m.DefaultResponse, nil
 }
 
-// setupGitDataAPIMock creates a WildcardMockRunner with Git Data API responses.
-func setupGitDataAPIMock(repo string) *WildcardMockRunner {
+// setupGraphQLMock creates a WildcardMockRunner for the GraphQL-based commit path.
+func setupGraphQLMock(repo string) *WildcardMockRunner {
 	mock := &WildcardMockRunner{
 		MockRunner: gh.MockRunner{
 			Responses: map[string][]byte{
@@ -236,28 +236,18 @@ func setupGitDataAPIMock(repo string) *WildcardMockRunner {
 				fmt.Sprintf("repo view %s --json defaultBranchRef --jq .defaultBranchRef.name", repo): []byte("main"),
 				// Get HEAD SHA
 				fmt.Sprintf("api repos/%s/git/ref/heads/main --jq .object.sha", repo): []byte("head123"),
-				// Get authenticated user (PAT path; not a bot)
-				`api /user --jq .login+"|"+(.name // .login)`: []byte("testuser|Test User"),
-				// Get primary email
-				`api /user/emails --jq [.[] | select(.primary == true)] | .[0].email`: []byte("test@example.com"),
 			},
 			Errors: map[string]error{},
 		},
-		// Default response for blob/tree/commit/ref calls
-		DefaultResponse: []byte(`{"sha":"mock-sha-123"}`),
+		// Default response for GraphQL mutation and other dynamic calls
+		DefaultResponse: []byte(`{"data":{"createCommitOnBranch":{"commit":{"oid":"new-sha-456"}}}}`),
 	}
 	return mock
 }
 
-// stubSign is a no-op GPG signer for tests.
-func stubSign(_ string) (string, error) {
-	return "-----BEGIN PGP SIGNATURE-----\nstub\n-----END PGP SIGNATURE-----", nil
-}
-
 func TestApply_CreateFile(t *testing.T) {
-	mock := setupGitDataAPIMock("owner/repo")
+	mock := setupGraphQLMock("owner/repo")
 	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
-	p.sign = stubSign
 
 	changes := []Change{
 		{
@@ -278,19 +268,16 @@ func TestApply_CreateFile(t *testing.T) {
 		t.Errorf("unexpected error: %v", results[0].Err)
 	}
 
-	// Verify Git Data API calls were made: get branch, get HEAD, blob, tree, commit, ref update
+	// Verify GraphQL mutation was called
 	callLog := strings.Join(flattenCalls(mock.Called), " | ")
-	for _, expected := range []string{"git/ref/heads/main", "git/blobs", "git/trees", "git/commits", "git/refs/heads/main"} {
-		if !strings.Contains(callLog, expected) {
-			t.Errorf("expected call containing %q, got: %s", expected, callLog)
-		}
+	if !strings.Contains(callLog, "api graphql") {
+		t.Errorf("expected GraphQL mutation call, got: %s", callLog)
 	}
 }
 
 func TestApply_UpdateFile(t *testing.T) {
-	mock := setupGitDataAPIMock("owner/repo")
+	mock := setupGraphQLMock("owner/repo")
 	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
-	p.sign = stubSign
 
 	changes := []Change{
 		{

--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -196,14 +196,6 @@ func (p *Processor) getHeadSHA(ctx context.Context, repo string) (sha, branch st
 	return sha, branch, nil
 }
 
-func (p *Processor) updateRef(ctx context.Context, repo, branch, commitSHA string) error {
-	_, err := p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/refs/heads/%s", repo, branch),
-		"--method", "PATCH",
-		"-f", fmt.Sprintf("sha=%s", commitSHA),
-	)
-	return err
-}
-
 // createBranchAt creates or force-updates a branch pointing to the given SHA.
 func (p *Processor) createBranchAt(ctx context.Context, repo, branch, sha string) error {
 	_, err := p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/refs", repo),

--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -1,73 +1,18 @@
 package fileset
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/babarot/gh-infra/internal/manifest"
 )
 
-// treeEntry represents a file entry in a Git tree.
-// SHA is a pointer: non-nil for create/update, nil for delete (GitHub removes the file).
-type treeEntry struct {
-	Path string  `json:"path"`
-	Mode string  `json:"mode"`
-	Type string  `json:"type"`
-	SHA  *string `json:"sha"` // nil = delete file from tree
-}
-
-// githubUser holds information about the authenticated GitHub user.
-type githubUser struct {
-	name  string
-	email string
-	isBot bool // true when authenticated as a GitHub App (login ends with "[bot]")
-}
-
-// getGitHubUser returns the authenticated user, fetching it only once per Processor.
-func (p *Processor) getGitHubUser(ctx context.Context) (githubUser, error) {
-	p.userOnce.Do(func() {
-		p.userInfo, p.userErr = p.fetchGitHubUser(ctx)
-	})
-	return p.userInfo, p.userErr
-}
-
-func (p *Processor) fetchGitHubUser(ctx context.Context) (githubUser, error) {
-	out, err := p.runner.Run(ctx, "api", "/user", "--jq", ".login+\"|\"+(.name // .login)")
-	if err != nil {
-		return githubUser{}, err
-	}
-	parts := strings.SplitN(strings.TrimSpace(string(out)), "|", 2)
-	login := parts[0]
-	name := parts[0]
-	if len(parts) == 2 {
-		name = parts[1]
-	}
-
-	isBot := strings.HasSuffix(login, "[bot]")
-
-	var email string
-	if !isBot {
-		out, err = p.runner.Run(ctx, "api", "/user/emails", "--jq", "[.[] | select(.primary == true)] | .[0].email")
-		if err != nil {
-			return githubUser{}, err
-		}
-		email = strings.TrimSpace(string(out))
-	}
-
-	return githubUser{name: name, email: email, isBot: isBot}, nil
-}
-
-// applyToRepo creates commits for all file changes in the given repo.
-// - GitHub App token (isBot): uses Contents API, which GitHub auto-signs as Verified.
-// - PAT: uses Git Data API with local GPG signing.
-// Falls back to Contents API for empty repositories (no commits yet).
+// applyToRepo creates a verified commit for all file changes using the GitHub GraphQL
+// createCommitOnBranch mutation. Falls back to Contents API for empty repositories.
 // Returns (prURL, error); prURL is non-empty only for pull_request strategy.
 func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
 	headSHA, defaultBranch, err := p.getHeadSHA(ctx, repo)
@@ -77,56 +22,12 @@ func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Chan
 		}
 		return "", fmt.Errorf("get HEAD: %w", err)
 	}
-
-	user, err := p.getGitHubUser(ctx)
-	if err != nil {
-		return "", fmt.Errorf("get GitHub user: %w", err)
-	}
-
-	if user.isBot {
-		return p.applyViaContentsAPI(ctx, repo, defaultBranch, headSHA, changes, opts, statusFn)
-	}
-	return p.applyViaGitDataAPI(ctx, repo, defaultBranch, headSHA, changes, opts, statusFn)
+	return p.applyViaGraphQL(ctx, repo, defaultBranch, headSHA, changes, opts, statusFn)
 }
 
-// applyViaGitDataAPI creates blobs, a tree, a GPG-signed commit, and updates the ref
-// (or creates a PR) in a single atomic operation.
-func (p *Processor) applyViaGitDataAPI(ctx context.Context, repo, branch, headSHA string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
-	message := resolveCommitMessage(opts)
-
-	// 1. Create blobs
-	statusFn("creating blobs...")
-	entries, err := p.createBlobs(ctx, repo, changes)
-	if err != nil {
-		return "", err
-	}
-
-	// 2. Create tree
-	statusFn("creating tree...")
-	treeSHA, err := p.createTree(ctx, repo, headSHA, entries)
-	if err != nil {
-		return "", fmt.Errorf("create tree: %w", err)
-	}
-
-	// 3. Create commit
-	statusFn("creating commit...")
-	commitSHA, err := p.createCommit(ctx, repo, message, treeSHA, headSHA)
-	if err != nil {
-		return "", fmt.Errorf("create commit: %w", err)
-	}
-
-	// 4. Update ref or create PR
-	if opts.Via == manifest.ViaPullRequest {
-		statusFn("creating pull request...")
-		return p.createPR(ctx, repo, branch, commitSHA, opts)
-	}
-	statusFn("updating ref...")
-	return "", p.updateRef(ctx, repo, branch, commitSHA)
-}
-
-// applyViaContentsAPI applies changes one file at a time using the Contents API.
-// GitHub automatically marks commits made with an App installation token as Verified.
-func (p *Processor) applyViaContentsAPI(ctx context.Context, repo, defaultBranch, headSHA string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
+// applyViaGraphQL creates a verified commit using the GitHub GraphQL createCommitOnBranch
+// mutation. All file changes are committed atomically in a single call.
+func (p *Processor) applyViaGraphQL(ctx context.Context, repo, defaultBranch, headSHA string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
 	message := resolveCommitMessage(opts)
 	targetBranch := defaultBranch
 
@@ -142,18 +43,9 @@ func (p *Processor) applyViaContentsAPI(ctx context.Context, repo, defaultBranch
 		targetBranch = prBranch
 	}
 
-	for _, c := range changes {
-		statusFn(fmt.Sprintf("updating %s...", c.Path))
-		commitMsg := fmt.Sprintf("%s: %s", message, c.Path)
-		var err error
-		if c.Type == ChangeDelete {
-			err = p.deleteFileViaContentsAPI(ctx, repo, c.Path, c.SHA, commitMsg, targetBranch)
-		} else {
-			err = p.putFileViaContentsAPI(ctx, repo, c.Path, c.Desired, c.SHA, commitMsg, targetBranch)
-		}
-		if err != nil {
-			return "", err
-		}
+	statusFn("committing changes...")
+	if err := p.commitViaGraphQL(ctx, repo, targetBranch, headSHA, message, changes); err != nil {
+		return "", err
 	}
 
 	if opts.Via == manifest.ViaPullRequest {
@@ -163,33 +55,85 @@ func (p *Processor) applyViaContentsAPI(ctx context.Context, repo, defaultBranch
 	return "", nil
 }
 
-// createBlobs creates a Git blob for each file change and returns tree entries.
-// ChangeDelete entries get a nil SHA which tells the Git Data API to remove the file.
-func (p *Processor) createBlobs(ctx context.Context, repo string, changes []Change) ([]treeEntry, error) {
-	var entries []treeEntry
+// commitViaGraphQL sends a createCommitOnBranch GraphQL mutation.
+// GitHub automatically marks these commits as Verified regardless of token type.
+func (p *Processor) commitViaGraphQL(ctx context.Context, repo, branch, headSHA, message string, changes []Change) error {
+	type addition struct {
+		Path     string `json:"path"`
+		Contents string `json:"contents"` // base64-encoded
+	}
+	type deletion struct {
+		Path string `json:"path"`
+	}
+	type fileChanges struct {
+		Additions []addition `json:"additions,omitempty"`
+		Deletions []deletion `json:"deletions,omitempty"`
+	}
+
+	var adds []addition
+	var dels []deletion
 	for _, c := range changes {
 		if c.Type == ChangeDelete {
-			entries = append(entries, treeEntry{
-				Path: c.Path,
-				Mode: "100644",
-				Type: "blob",
-				SHA:  nil, // nil SHA = delete from tree
+			dels = append(dels, deletion{Path: c.Path})
+		} else {
+			adds = append(adds, addition{
+				Path:     c.Path,
+				Contents: base64.StdEncoding.EncodeToString([]byte(c.Desired)),
 			})
-			continue
 		}
-		blobSHA, err := p.createBlob(ctx, repo, c.Desired)
-		if err != nil {
-			return nil, fmt.Errorf("create blob for %s: %w", c.Path, err)
-		}
-		sha := blobSHA
-		entries = append(entries, treeEntry{
-			Path: c.Path,
-			Mode: "100644",
-			Type: "blob",
-			SHA:  &sha,
-		})
 	}
-	return entries, nil
+
+	input := map[string]any{
+		"branch": map[string]string{
+			"repositoryNameWithOwner": repo,
+			"branchName":              branch,
+		},
+		"message":         map[string]string{"headline": message},
+		"expectedHeadOid": headSHA,
+		"fileChanges":     fileChanges{Additions: adds, Deletions: dels},
+	}
+
+	const mutation = `mutation($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) {
+    commit { oid }
+  }
+}`
+
+	body := map[string]any{
+		"query":     mutation,
+		"variables": map[string]any{"input": input},
+	}
+	bodyJSON, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	tmpFile, err := os.CreateTemp("", "gh-infra-graphql-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.Write(bodyJSON); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	tmpFile.Close()
+
+	out, err := p.runner.Run(ctx, "api", "graphql", "--input", tmpFile.Name())
+	if err != nil {
+		return fmt.Errorf("graphql mutation: %w", err)
+	}
+
+	var resp struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(out, &resp); err == nil && len(resp.Errors) > 0 {
+		return fmt.Errorf("graphql: %s", resp.Errors[0].Message)
+	}
+	return nil
 }
 
 // applyToEmptyRepo uses Contents API as fallback for repos with no commits.
@@ -209,8 +153,7 @@ func (p *Processor) applyToEmptyRepo(ctx context.Context, repo string, changes [
 }
 
 // putFileViaContentsAPI creates or updates a single file using the Contents API.
-// One commit per call. Pass sha="" for new files, or the current blob SHA for updates.
-// Pass branch="" to use the repository's default branch.
+// Pass sha="" for new files. Pass branch="" to use the repository's default branch.
 func (p *Processor) putFileViaContentsAPI(ctx context.Context, repo, path, content, sha, message, branch string) error {
 	encoded := base64.StdEncoding.EncodeToString([]byte(content))
 	endpoint := fmt.Sprintf("repos/%s/contents/%s", repo, path)
@@ -235,31 +178,7 @@ func (p *Processor) putFileViaContentsAPI(ctx context.Context, repo, path, conte
 	return nil
 }
 
-// deleteFileViaContentsAPI deletes a single file using the Contents API.
-// sha is the current blob SHA of the file (required by GitHub).
-// Pass branch="" to use the repository's default branch.
-func (p *Processor) deleteFileViaContentsAPI(ctx context.Context, repo, path, sha, message, branch string) error {
-	endpoint := fmt.Sprintf("repos/%s/contents/%s", repo, path)
-
-	args := []string{
-		"api", endpoint,
-		"--method", "DELETE",
-		"-f", fmt.Sprintf("message=%s", message),
-		"-f", fmt.Sprintf("sha=%s", sha),
-	}
-	if branch != "" {
-		args = append(args, "-f", fmt.Sprintf("branch=%s", branch))
-	}
-
-	_, err := p.runner.Run(ctx, args...)
-	if err != nil {
-		return fmt.Errorf("delete %s: %w", path, err)
-	}
-	return nil
-}
-
 func (p *Processor) getHeadSHA(ctx context.Context, repo string) (sha, branch string, err error) {
-	// Get default branch name
 	out, err := p.runner.Run(ctx, "repo", "view", repo, "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name")
 	if err != nil {
 		return "", "", err
@@ -269,171 +188,12 @@ func (p *Processor) getHeadSHA(ctx context.Context, repo string) (sha, branch st
 		return "", "", fmt.Errorf("repository is empty (no default branch)")
 	}
 
-	// Get HEAD SHA
 	out, err = p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/ref/heads/%s", repo, branch), "--jq", ".object.sha")
 	if err != nil {
 		return "", "", err
 	}
 	sha = strings.TrimSpace(string(out))
 	return sha, branch, nil
-}
-
-func (p *Processor) createBlob(ctx context.Context, repo, content string) (string, error) {
-	encoded := base64.StdEncoding.EncodeToString([]byte(content))
-	out, err := p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/blobs", repo),
-		"--method", "POST",
-		"-f", fmt.Sprintf("content=%s", encoded),
-		"-f", "encoding=base64",
-	)
-	if err != nil {
-		return "", err
-	}
-	var resp struct {
-		SHA string `json:"sha"`
-	}
-	if err := json.Unmarshal(out, &resp); err != nil {
-		return "", err
-	}
-	return resp.SHA, nil
-}
-
-func (p *Processor) createTree(ctx context.Context, repo, baseTree string, entries any) (string, error) {
-	body := map[string]any{
-		"base_tree": baseTree,
-		"tree":      entries,
-	}
-	bodyJSON, err := json.Marshal(body)
-	if err != nil {
-		return "", err
-	}
-
-	// Write JSON body to a temp file for --input
-	tmpFile, err := os.CreateTemp("", "gh-infra-tree-*.json")
-	if err != nil {
-		return "", fmt.Errorf("create temp file: %w", err)
-	}
-	defer os.Remove(tmpFile.Name())
-
-	if _, err := tmpFile.Write(bodyJSON); err != nil {
-		tmpFile.Close()
-		return "", fmt.Errorf("write temp file: %w", err)
-	}
-	tmpFile.Close()
-
-	out, err := p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/trees", repo),
-		"--method", "POST",
-		"--input", tmpFile.Name(),
-	)
-	if err != nil {
-		return "", err
-	}
-	var resp struct {
-		SHA string `json:"sha"`
-	}
-	if err := json.Unmarshal(out, &resp); err != nil {
-		return "", err
-	}
-	return resp.SHA, nil
-}
-
-func (p *Processor) createCommit(ctx context.Context, repo, message, treeSHA, parentSHA string) (string, error) {
-	now := time.Now().UTC()
-
-	user, err := p.getGitHubUser(ctx)
-	if err != nil {
-		return "", fmt.Errorf("get GitHub user: %w", err)
-	}
-
-	commitObj := buildCommitObject(message, treeSHA, parentSHA, user.name, user.email, now)
-	sig, err := p.sign(commitObj)
-	if err != nil {
-		return "", fmt.Errorf("sign commit: %w", err)
-	}
-
-	dateStr := now.Format(time.RFC3339)
-	body := map[string]any{
-		"message": message,
-		"tree":    treeSHA,
-		"parents": []string{parentSHA},
-		"author": map[string]string{
-			"name":  user.name,
-			"email": user.email,
-			"date":  dateStr,
-		},
-		"committer": map[string]string{
-			"name":  user.name,
-			"email": user.email,
-			"date":  dateStr,
-		},
-		"signature": sig,
-	}
-	bodyJSON, err := json.Marshal(body)
-	if err != nil {
-		return "", err
-	}
-
-	tmpFile, err := os.CreateTemp("", "gh-infra-commit-*.json")
-	if err != nil {
-		return "", fmt.Errorf("create temp file: %w", err)
-	}
-	defer os.Remove(tmpFile.Name())
-
-	if _, err := tmpFile.Write(bodyJSON); err != nil {
-		tmpFile.Close()
-		return "", fmt.Errorf("write temp file: %w", err)
-	}
-	tmpFile.Close()
-
-	out, err := p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/commits", repo),
-		"--method", "POST",
-		"--input", tmpFile.Name(),
-	)
-	if err != nil {
-		return "", err
-	}
-	var resp struct {
-		SHA string `json:"sha"`
-	}
-	if err := json.Unmarshal(out, &resp); err != nil {
-		return "", err
-	}
-	return resp.SHA, nil
-}
-
-func buildCommitObject(message, treeSHA, parentSHA, name, email string, ts time.Time) string {
-	unix := ts.Unix()
-	tz := ts.Format("-0700")
-	return fmt.Sprintf("tree %s\nparent %s\nauthor %s <%s> %d %s\ncommitter %s <%s> %d %s\n\n%s\n",
-		treeSHA, parentSHA,
-		name, email, unix, tz,
-		name, email, unix, tz,
-		message,
-	)
-}
-
-func gpgSign(payload string) (string, error) {
-	// Respect git config user.signingkey; fall back to GPG default key.
-	args := []string{"--detach-sign", "--armor", "--batch"}
-	if keyID := gitSigningKey(); keyID != "" {
-		args = append(args, "-u", keyID)
-	}
-	cmd := exec.Command("gpg", args...)
-	cmd.Stdin = strings.NewReader(payload)
-	var out, errOut bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &errOut
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("gpg: %w: %s", err, errOut.String())
-	}
-	return out.String(), nil
-}
-
-func gitSigningKey() string {
-	out, err := exec.Command("git", "config", "--get", "user.signingkey").Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
 }
 
 func (p *Processor) updateRef(ctx context.Context, repo, branch, commitSHA string) error {
@@ -498,18 +258,6 @@ func (p *Processor) openPR(ctx context.Context, repo, base, head string, opts Ap
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
-}
-
-// createPR creates a branch at commitSHA and opens a pull request.
-func (p *Processor) createPR(ctx context.Context, repo, defaultBranch, commitSHA string, opts ApplyOptions) (string, error) {
-	branchName := opts.Branch
-	if branchName == "" {
-		branchName = fmt.Sprintf("gh-infra/sync-%s", sanitizeBranchName(opts.FileSetID))
-	}
-	if err := p.createBranchAt(ctx, repo, branchName, commitSHA); err != nil {
-		return "", fmt.Errorf("create branch %s: %w", branchName, err)
-	}
-	return p.openPR(ctx, repo, defaultBranch, branchName, opts)
 }
 
 // sanitizeBranchName converts an identity string into a valid Git branch name component.

--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -345,7 +345,7 @@ func (p *Processor) createCommit(ctx context.Context, repo, message, treeSHA, pa
 	}
 
 	commitObj := buildCommitObject(message, treeSHA, parentSHA, user.name, user.email, now)
-	sig, err := gpgSign(commitObj)
+	sig, err := p.sign(commitObj)
 	if err != nil {
 		return "", fmt.Errorf("sign commit: %w", err)
 	}

--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -1,12 +1,15 @@
 package fileset
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/babarot/gh-infra/internal/manifest"
 )
@@ -20,9 +23,52 @@ type treeEntry struct {
 	SHA  *string `json:"sha"` // nil = delete file from tree
 }
 
-// applyToRepo creates a single commit with all file changes using Git Data API.
+// githubUser holds information about the authenticated GitHub user.
+type githubUser struct {
+	name  string
+	email string
+	isBot bool // true when authenticated as a GitHub App (login ends with "[bot]")
+}
+
+// getGitHubUser returns the authenticated user, fetching it only once per Processor.
+func (p *Processor) getGitHubUser(ctx context.Context) (githubUser, error) {
+	p.userOnce.Do(func() {
+		p.userInfo, p.userErr = p.fetchGitHubUser(ctx)
+	})
+	return p.userInfo, p.userErr
+}
+
+func (p *Processor) fetchGitHubUser(ctx context.Context) (githubUser, error) {
+	out, err := p.runner.Run(ctx, "api", "/user", "--jq", ".login+\"|\"+(.name // .login)")
+	if err != nil {
+		return githubUser{}, err
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(out)), "|", 2)
+	login := parts[0]
+	name := parts[0]
+	if len(parts) == 2 {
+		name = parts[1]
+	}
+
+	isBot := strings.HasSuffix(login, "[bot]")
+
+	var email string
+	if !isBot {
+		out, err = p.runner.Run(ctx, "api", "/user/emails", "--jq", "[.[] | select(.primary == true)] | .[0].email")
+		if err != nil {
+			return githubUser{}, err
+		}
+		email = strings.TrimSpace(string(out))
+	}
+
+	return githubUser{name: name, email: email, isBot: isBot}, nil
+}
+
+// applyToRepo creates commits for all file changes in the given repo.
+// - GitHub App token (isBot): uses Contents API, which GitHub auto-signs as Verified.
+// - PAT: uses Git Data API with local GPG signing.
 // Falls back to Contents API for empty repositories (no commits yet).
-// applyToRepo returns (prURL, error). prURL is non-empty only for pull_request strategy.
+// Returns (prURL, error); prURL is non-empty only for pull_request strategy.
 func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
 	headSHA, defaultBranch, err := p.getHeadSHA(ctx, repo)
 	if err != nil {
@@ -32,12 +78,19 @@ func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Chan
 		return "", fmt.Errorf("get HEAD: %w", err)
 	}
 
+	user, err := p.getGitHubUser(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get GitHub user: %w", err)
+	}
+
+	if user.isBot {
+		return p.applyViaContentsAPI(ctx, repo, defaultBranch, headSHA, changes, opts, statusFn)
+	}
 	return p.applyViaGitDataAPI(ctx, repo, defaultBranch, headSHA, changes, opts, statusFn)
 }
 
-// applyViaGitDataAPI creates blobs, a tree, a commit, and updates the ref
-// (or creates a PR) in a single atomic operation. All files are included in
-// one commit regardless of count.
+// applyViaGitDataAPI creates blobs, a tree, a GPG-signed commit, and updates the ref
+// (or creates a PR) in a single atomic operation.
 func (p *Processor) applyViaGitDataAPI(ctx context.Context, repo, branch, headSHA string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
 	message := resolveCommitMessage(opts)
 
@@ -69,6 +122,45 @@ func (p *Processor) applyViaGitDataAPI(ctx context.Context, repo, branch, headSH
 	}
 	statusFn("updating ref...")
 	return "", p.updateRef(ctx, repo, branch, commitSHA)
+}
+
+// applyViaContentsAPI applies changes one file at a time using the Contents API.
+// GitHub automatically marks commits made with an App installation token as Verified.
+func (p *Processor) applyViaContentsAPI(ctx context.Context, repo, defaultBranch, headSHA string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
+	message := resolveCommitMessage(opts)
+	targetBranch := defaultBranch
+
+	if opts.Via == manifest.ViaPullRequest {
+		prBranch := opts.Branch
+		if prBranch == "" {
+			prBranch = fmt.Sprintf("gh-infra/sync-%s", sanitizeBranchName(opts.FileSetID))
+		}
+		statusFn("creating PR branch...")
+		if err := p.createBranchAt(ctx, repo, prBranch, headSHA); err != nil {
+			return "", fmt.Errorf("create PR branch: %w", err)
+		}
+		targetBranch = prBranch
+	}
+
+	for _, c := range changes {
+		statusFn(fmt.Sprintf("updating %s...", c.Path))
+		commitMsg := fmt.Sprintf("%s: %s", message, c.Path)
+		var err error
+		if c.Type == ChangeDelete {
+			err = p.deleteFileViaContentsAPI(ctx, repo, c.Path, c.SHA, commitMsg, targetBranch)
+		} else {
+			err = p.putFileViaContentsAPI(ctx, repo, c.Path, c.Desired, c.SHA, commitMsg, targetBranch)
+		}
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if opts.Via == manifest.ViaPullRequest {
+		statusFn("creating pull request...")
+		return p.openPR(ctx, repo, defaultBranch, targetBranch, opts)
+	}
+	return "", nil
 }
 
 // createBlobs creates a Git blob for each file change and returns tree entries.
@@ -109,7 +201,7 @@ func (p *Processor) applyToEmptyRepo(ctx context.Context, repo string, changes [
 	}
 	for _, c := range changes {
 		commitMsg := fmt.Sprintf("%s: %s", message, c.Path)
-		if err := p.putFileViaContentsAPI(ctx, repo, c.Path, c.Desired, "", commitMsg); err != nil {
+		if err := p.putFileViaContentsAPI(ctx, repo, c.Path, c.Desired, "", commitMsg, ""); err != nil {
 			return err
 		}
 	}
@@ -117,9 +209,9 @@ func (p *Processor) applyToEmptyRepo(ctx context.Context, repo string, changes [
 }
 
 // putFileViaContentsAPI creates or updates a single file using the Contents API.
-// This results in one commit per call. Use for empty repos or when Git Data API
-// is not available. Pass sha="" for new files, or the current blob SHA for updates.
-func (p *Processor) putFileViaContentsAPI(ctx context.Context, repo, path, content, sha, message string) error {
+// One commit per call. Pass sha="" for new files, or the current blob SHA for updates.
+// Pass branch="" to use the repository's default branch.
+func (p *Processor) putFileViaContentsAPI(ctx context.Context, repo, path, content, sha, message, branch string) error {
 	encoded := base64.StdEncoding.EncodeToString([]byte(content))
 	endpoint := fmt.Sprintf("repos/%s/contents/%s", repo, path)
 
@@ -132,10 +224,36 @@ func (p *Processor) putFileViaContentsAPI(ctx context.Context, repo, path, conte
 	if sha != "" {
 		args = append(args, "-f", fmt.Sprintf("sha=%s", sha))
 	}
+	if branch != "" {
+		args = append(args, "-f", fmt.Sprintf("branch=%s", branch))
+	}
 
 	_, err := p.runner.Run(ctx, args...)
 	if err != nil {
 		return fmt.Errorf("put %s: %w", path, err)
+	}
+	return nil
+}
+
+// deleteFileViaContentsAPI deletes a single file using the Contents API.
+// sha is the current blob SHA of the file (required by GitHub).
+// Pass branch="" to use the repository's default branch.
+func (p *Processor) deleteFileViaContentsAPI(ctx context.Context, repo, path, sha, message, branch string) error {
+	endpoint := fmt.Sprintf("repos/%s/contents/%s", repo, path)
+
+	args := []string{
+		"api", endpoint,
+		"--method", "DELETE",
+		"-f", fmt.Sprintf("message=%s", message),
+		"-f", fmt.Sprintf("sha=%s", sha),
+	}
+	if branch != "" {
+		args = append(args, "-f", fmt.Sprintf("branch=%s", branch))
+	}
+
+	_, err := p.runner.Run(ctx, args...)
+	if err != nil {
+		return fmt.Errorf("delete %s: %w", path, err)
 	}
 	return nil
 }
@@ -219,10 +337,35 @@ func (p *Processor) createTree(ctx context.Context, repo, baseTree string, entri
 }
 
 func (p *Processor) createCommit(ctx context.Context, repo, message, treeSHA, parentSHA string) (string, error) {
+	now := time.Now().UTC()
+
+	user, err := p.getGitHubUser(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get GitHub user: %w", err)
+	}
+
+	commitObj := buildCommitObject(message, treeSHA, parentSHA, user.name, user.email, now)
+	sig, err := gpgSign(commitObj)
+	if err != nil {
+		return "", fmt.Errorf("sign commit: %w", err)
+	}
+
+	dateStr := now.Format(time.RFC3339)
 	body := map[string]any{
 		"message": message,
 		"tree":    treeSHA,
 		"parents": []string{parentSHA},
+		"author": map[string]string{
+			"name":  user.name,
+			"email": user.email,
+			"date":  dateStr,
+		},
+		"committer": map[string]string{
+			"name":  user.name,
+			"email": user.email,
+			"date":  dateStr,
+		},
+		"signature": sig,
 	}
 	bodyJSON, err := json.Marshal(body)
 	if err != nil {
@@ -257,6 +400,42 @@ func (p *Processor) createCommit(ctx context.Context, repo, message, treeSHA, pa
 	return resp.SHA, nil
 }
 
+func buildCommitObject(message, treeSHA, parentSHA, name, email string, ts time.Time) string {
+	unix := ts.Unix()
+	tz := ts.Format("-0700")
+	return fmt.Sprintf("tree %s\nparent %s\nauthor %s <%s> %d %s\ncommitter %s <%s> %d %s\n\n%s\n",
+		treeSHA, parentSHA,
+		name, email, unix, tz,
+		name, email, unix, tz,
+		message,
+	)
+}
+
+func gpgSign(payload string) (string, error) {
+	// Respect git config user.signingkey; fall back to GPG default key.
+	args := []string{"--detach-sign", "--armor", "--batch"}
+	if keyID := gitSigningKey(); keyID != "" {
+		args = append(args, "-u", keyID)
+	}
+	cmd := exec.Command("gpg", args...)
+	cmd.Stdin = strings.NewReader(payload)
+	var out, errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("gpg: %w: %s", err, errOut.String())
+	}
+	return out.String(), nil
+}
+
+func gitSigningKey() string {
+	out, err := exec.Command("git", "config", "--get", "user.signingkey").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 func (p *Processor) updateRef(ctx context.Context, repo, branch, commitSHA string) error {
 	_, err := p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/refs/heads/%s", repo, branch),
 		"--method", "PATCH",
@@ -265,33 +444,30 @@ func (p *Processor) updateRef(ctx context.Context, repo, branch, commitSHA strin
 	return err
 }
 
-// createPR creates a pull request and returns its URL.
-func (p *Processor) createPR(ctx context.Context, repo, defaultBranch, commitSHA string, opts ApplyOptions) (string, error) {
-	branchName := opts.Branch
-	if branchName == "" {
-		branchName = fmt.Sprintf("gh-infra/sync-%s", sanitizeBranchName(opts.FileSetID))
-	}
-
-	// Create branch pointing to the new commit; if it already exists, force-update it.
+// createBranchAt creates or force-updates a branch pointing to the given SHA.
+func (p *Processor) createBranchAt(ctx context.Context, repo, branch, sha string) error {
 	_, err := p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/refs", repo),
 		"--method", "POST",
-		"-f", fmt.Sprintf("ref=refs/heads/%s", branchName),
-		"-f", fmt.Sprintf("sha=%s", commitSHA),
+		"-f", fmt.Sprintf("ref=refs/heads/%s", branch),
+		"-f", fmt.Sprintf("sha=%s", sha),
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "Reference already exists") {
-			_, err = p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/refs/heads/%s", repo, branchName),
+			_, err = p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/refs/heads/%s", repo, branch),
 				"--method", "PATCH",
-				"-f", fmt.Sprintf("sha=%s", commitSHA),
+				"-f", fmt.Sprintf("sha=%s", sha),
 				"-F", "force=true",
 			)
 		}
 		if err != nil {
-			return "", fmt.Errorf("create branch %s: %w", branchName, err)
+			return err
 		}
 	}
+	return nil
+}
 
-	// Create PR (skip if one already exists for this head branch)
+// openPR opens a pull request from head into base. The head branch must already exist.
+func (p *Processor) openPR(ctx context.Context, repo, base, head string, opts ApplyOptions) (string, error) {
 	prTitle := opts.PRTitle
 	if prTitle == "" {
 		prTitle = resolveCommitMessage(opts)
@@ -302,27 +478,38 @@ func (p *Processor) createPR(ctx context.Context, repo, defaultBranch, commitSHA
 	}
 	out, err := p.runner.Run(ctx, "pr", "create",
 		"--repo", repo,
-		"--base", defaultBranch,
-		"--head", branchName,
+		"--base", base,
+		"--head", head,
 		"--title", prTitle,
 		"--body", prBody,
 	)
 	if err != nil && strings.Contains(err.Error(), "already exists") {
-		// Retrieve existing PR URL
 		existing, lookupErr := p.runner.Run(ctx, "pr", "view",
 			"--repo", repo,
-			branchName,
+			head,
 			"--json", "url", "--jq", ".url",
 		)
 		if lookupErr == nil {
 			return strings.TrimSpace(string(existing)), nil
 		}
-		return "", nil // PR already open but couldn't get URL
+		return "", nil
 	}
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// createPR creates a branch at commitSHA and opens a pull request.
+func (p *Processor) createPR(ctx context.Context, repo, defaultBranch, commitSHA string, opts ApplyOptions) (string, error) {
+	branchName := opts.Branch
+	if branchName == "" {
+		branchName = fmt.Sprintf("gh-infra/sync-%s", sanitizeBranchName(opts.FileSetID))
+	}
+	if err := p.createBranchAt(ctx, repo, branchName, commitSHA); err != nil {
+		return "", fmt.Errorf("create branch %s: %w", branchName, err)
+	}
+	return p.openPR(ctx, repo, defaultBranch, branchName, opts)
 }
 
 // sanitizeBranchName converts an identity string into a valid Git branch name component.

--- a/internal/fileset/plan.go
+++ b/internal/fileset/plan.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/babarot/gh-infra/internal/gh"
 	"github.com/babarot/gh-infra/internal/manifest"
@@ -14,8 +15,11 @@ import (
 
 // Processor handles FileSet plan and apply operations.
 type Processor struct {
-	runner gh.Runner
-	writer ProgressWriter
+	runner   gh.Runner
+	writer   ProgressWriter
+	userOnce sync.Once
+	userInfo githubUser
+	userErr  error
 }
 
 func NewProcessor(runner gh.Runner, writer ProgressWriter) *Processor {

--- a/internal/fileset/plan.go
+++ b/internal/fileset/plan.go
@@ -17,6 +17,7 @@ import (
 type Processor struct {
 	runner   gh.Runner
 	writer   ProgressWriter
+	sign     func(payload string) (string, error) // defaults to gpgSign
 	userOnce sync.Once
 	userInfo githubUser
 	userErr  error
@@ -26,7 +27,7 @@ func NewProcessor(runner gh.Runner, writer ProgressWriter) *Processor {
 	if writer == nil {
 		writer = noopProgressWriter{}
 	}
-	return &Processor{runner: runner, writer: writer}
+	return &Processor{runner: runner, writer: writer, sign: gpgSign}
 }
 
 // planUnit represents one (fileSet, repository) pair to process.

--- a/internal/fileset/plan.go
+++ b/internal/fileset/plan.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/babarot/gh-infra/internal/gh"
 	"github.com/babarot/gh-infra/internal/manifest"
@@ -15,19 +14,15 @@ import (
 
 // Processor handles FileSet plan and apply operations.
 type Processor struct {
-	runner   gh.Runner
-	writer   ProgressWriter
-	sign     func(payload string) (string, error) // defaults to gpgSign
-	userOnce sync.Once
-	userInfo githubUser
-	userErr  error
+	runner gh.Runner
+	writer ProgressWriter
 }
 
 func NewProcessor(runner gh.Runner, writer ProgressWriter) *Processor {
 	if writer == nil {
 		writer = noopProgressWriter{}
 	}
-	return &Processor{runner: runner, writer: writer, sign: gpgSign}
+	return &Processor{runner: runner, writer: writer}
 }
 
 // planUnit represents one (fileSet, repository) pair to process.


### PR DESCRIPTION
## Summary

Replace the Git Data API commit sequence (blob → tree → commit → update ref) in `applyToRepo` with a single GitHub GraphQL `createCommitOnBranch` mutation, which GitHub automatically marks as Verified.

- All file additions and deletions are committed atomically in one mutation call
- Verified commits are produced regardless of token type (PAT or GitHub App) — no local signing tools required
- Update tests to assert the GraphQL mutation is called

## Background / Motivation

File distribution commits had no Verified badge. The `createCommitOnBranch` mutation handles signing server-side, making the approach token-agnostic and free of local tooling dependencies.

## Verification

**Local (PAT):**
```
$ gh api repos/yagihash/yagihash/commits/HEAD --jq '{verified: .commit.verification.verified, reason: .commit.verification.reason}'
{"verified":true,"reason":"valid"}
```

**CI (GitHub App token via [ghat](https://github.com/yagihash/ghat)):**
```
$ gh api "repos/yagihash/yagihash/commits?per_page=1" --jq '.[0] | {login: .author.login, verified: .commit.verification.verified, reason: .commit.verification.reason}'
{"login":"gh-infra-apply[bot]","verified":true,"reason":"valid"}
```

Both token types produce Verified commits via the GraphQL mutation.