### PR TITLE
fix: add --accept-visibility-change-consequences flag when editing visibility

### DIFF
--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -411,7 +411,7 @@ func (p *Processor) applyRepoSetting(ctx context.Context, c Change, repo *manife
 		return wrapError(err, fullName, c.Field)
 
 	case "visibility":
-		_, err := p.runner.Run(ctx, "repo", "edit", fullName, "--visibility", fmt.Sprintf("%v", c.NewValue))
+		_, err := p.runner.Run(ctx, "repo", "edit", fullName, "--visibility", fmt.Sprintf("%v", c.NewValue), "--accept-visibility-change-consequences")
 		return wrapError(err, fullName, c.Field)
 
 	case "archived":

--- a/internal/repository/apply_test.go
+++ b/internal/repository/apply_test.go
@@ -142,7 +142,7 @@ func TestApplyVisibility(t *testing.T) {
 		t.Fatalf("unexpected error: %v", results[0].Err)
 	}
 	args := mock.Called[0]
-	expected := []string{"repo", "edit", "myorg/myrepo", "--visibility", "private"}
+	expected := []string{"repo", "edit", "myorg/myrepo", "--visibility", "private", "--accept-visibility-change-consequences"}
 	if strings.Join(args, " ") != strings.Join(expected, " ") {
 		t.Errorf("args: got %v, want %v", args, expected)
 	}


### PR DESCRIPTION
## Summary
- `gh repo edit --visibility` requires `--accept-visibility-change-consequences` flag since gh CLI v2.x, but gh-infra was not passing it
- Add the flag to the `visibility` case in `applyChange`
- Update the corresponding test

## Background / Motivation
Without this flag, any attempt to change repository visibility via `gh infra apply` fails with:

```
use of --visibility flag requires --accept-visibility-change-consequences flag
```

This makes `visibility` effectively read-only in gh-infra, even though it appears in the plan output as a pending change.