### PR TITLE
Add collection reconciliation policy (additive/authoritative modes)

### DIFF
--- a/docs/adr/005-collection-reconciliation-policy.md
+++ b/docs/adr/005-collection-reconciliation-policy.md
@@ -1,0 +1,376 @@
+# ADR-005: Collection reconciliation policy
+
+## Status
+
+Accepted
+
+## Context
+
+gh-infra is intentionally stateless. Every `plan` and `apply` fetches current
+GitHub state and compares it with the YAML manifest. This avoids state files,
+locking, and backend configuration, but it also means gh-infra cannot infer that
+a resource removed from YAML should be deleted from GitHub.
+
+ADR-003 and ADR-004 explored `field: null` as an explicit deletion marker for
+collection fields such as `branch_protection` and `rulesets`. Both approaches
+were rejected before merge:
+
+- ADR-003 used `Nullable[T]` and a fork of `goccy/go-yaml`.
+- ADR-004 replaced the fork with parser-side null detection and renamed the
+  wrapper to `Deletable[T]`.
+
+The implementations proved that explicit deletion markers are possible, but
+the schema question remained unresolved. `field: null` can only express
+full-collection deletion. It does not address the broader problem of choosing
+whether a collection is managed additively or as an exact mirror of YAML.
+
+YAML itself distinguishes the following states:
+
+| YAML | YAML-level state |
+|---|---|
+| key omitted | absent |
+| `rulesets:` | explicit null |
+| `rulesets: null` | explicit null |
+| `rulesets: []` | empty sequence |
+| `rulesets: [ ... ]` | non-empty sequence |
+
+This suggests a possible exact-set model:
+
+| YAML | Possible meaning |
+|---|---|
+| key omitted | collection unmanaged |
+| `rulesets: []` | managed empty collection; delete all remote rulesets |
+| `rulesets: [ ... ]` | exact desired collection; delete remote rulesets not listed |
+| `rulesets:` / `rulesets: null` | invalid |
+
+That model is clean, but it would change existing behavior. Today, non-empty
+collections are additive: gh-infra creates or updates listed entries and leaves
+unlisted remote entries untouched. Changing list presence to mean exact-set
+ownership would make existing manifests destructive.
+
+We need a design that:
+
+- preserves existing additive behavior by default
+- allows users to opt into exact-set reconciliation
+- keeps destructive behavior visible in the manifest
+- avoids adding many `rulesets_sync`, `branch_protection_sync`, etc. fields to
+  `spec`
+- keeps GitHub desired state separate from gh-infra reconciliation behavior
+
+## Decision
+
+Introduce a top-level `reconcile` block for repository resources. `spec`
+continues to describe desired GitHub resource values. `reconcile` describes how
+gh-infra should compare those desired values with current remote state.
+
+Initial form:
+
+```yaml
+apiVersion: gh-infra/v1
+kind: Repository
+metadata:
+  owner: my-org
+  name: my-repo
+
+reconcile:
+  rulesets: mirror
+  branch_protection: additive
+
+spec:
+  rulesets:
+    - name: protect-main
+      target: branch
+      rules:
+        non_fast_forward: true
+```
+
+Initial supported collections:
+
+| Reconcile field | Applies to |
+|---|---|
+| `rulesets` | `spec.rulesets` |
+| `branch_protection` | `spec.branch_protection` |
+
+Initial supported modes:
+
+| Mode | Semantics |
+|---|---|
+| `additive` | Create/update entries declared in YAML. Leave undeclared remote entries untouched. |
+| `mirror` | Make the remote collection match YAML exactly. Delete undeclared remote entries. |
+
+Default mode is `additive`. This preserves existing behavior for manifests that
+do not specify `reconcile`.
+
+### Field presence semantics
+
+`reconcile` only changes behavior for collections that are present in `spec`.
+
+| YAML | Meaning |
+|---|---|
+| `spec.rulesets` omitted | rulesets unmanaged |
+| `spec.rulesets` present, `reconcile.rulesets` omitted | additive management |
+| `reconcile.rulesets: additive` + non-empty `spec.rulesets` | create/update listed rulesets only |
+| `reconcile.rulesets: mirror` + non-empty `spec.rulesets` | exact-set management; delete remote rulesets not listed |
+| `reconcile.rulesets: mirror` + `spec.rulesets: []` | managed empty collection; delete all remote rulesets |
+| `rulesets:` / `rulesets: null` | invalid |
+
+If `reconcile.rulesets` is set but `spec.rulesets` is omitted, parsing should
+fail. A reconciliation policy without a corresponding desired collection is
+ambiguous and likely a mistake.
+
+The same rules apply to `branch_protection`.
+
+### Empty sequences
+
+Empty sequences are meaningful only when the collection is managed.
+
+```yaml
+reconcile:
+  rulesets: mirror
+spec:
+  rulesets: []
+```
+
+This means "rulesets should be an empty collection" and deletes all repository
+rulesets.
+
+With `additive`, an empty list is valid but has no create/update work and does
+not delete remote entries:
+
+```yaml
+reconcile:
+  rulesets: additive
+spec:
+  rulesets: []
+```
+
+This is effectively a no-op for `rulesets`. The implementation may warn about
+it, but it should not reinterpret additive empty lists as deletion.
+
+### Null values
+
+`null` is not used for collection deletion in this design.
+
+```yaml
+spec:
+  rulesets:
+```
+
+and:
+
+```yaml
+spec:
+  rulesets: null
+```
+
+should be parse errors. Users should write:
+
+```yaml
+reconcile:
+  rulesets: mirror
+spec:
+  rulesets: []
+```
+
+to delete all remote rulesets.
+
+### RepositorySet semantics
+
+`RepositorySet` should support `reconcile` at both defaults and repository
+entry levels:
+
+```yaml
+apiVersion: gh-infra/v1
+kind: RepositorySet
+metadata:
+  owner: my-org
+
+defaults:
+  reconcile:
+    rulesets: mirror
+  spec:
+    rulesets:
+      - name: protect-main
+        rules:
+          non_fast_forward: true
+
+repositories:
+  - name: repo-a
+  - name: repo-b
+    reconcile:
+      rulesets: additive
+```
+
+Merge behavior:
+
+- `defaults.reconcile` provides default reconciliation policy.
+- `repositories[].reconcile` overrides defaults per collection.
+- `defaults.spec` and `repositories[].spec` continue to merge as today.
+- After merge, any reconcile policy that targets an omitted collection is an
+  error.
+
+This lets an organization use `mirror` by default while allowing individual
+repositories to opt back into `additive`.
+
+### Plan and apply behavior
+
+Plan output should make mirror-driven deletes explicit. A delete caused by
+mirror reconciliation is not the same as an update to a listed item; it is the
+removal of a remote item that is absent from YAML.
+
+Example wording:
+
+```text
+- ruleset "old-ruleset" (not declared; reconcile.rulesets=mirror)
+```
+
+Apply should execute those deletes only after they appear in plan, using the
+existing GitHub delete APIs:
+
+- branch protection: `DELETE /repos/{owner}/{repo}/branches/{pattern}/protection`
+- rulesets: `DELETE /repos/{owner}/{repo}/rulesets/{id}`
+
+### Import/export behavior
+
+`import` and export flows should not emit `reconcile: mirror` by default.
+Exporting current GitHub state into YAML should remain conservative and
+non-destructive unless the user opts into mirror policy.
+
+`import --into` should preserve an existing `reconcile` block. If a user already
+declared `reconcile.rulesets: mirror`, import-into should update the listed
+rulesets without silently removing the reconciliation policy.
+
+## Alternatives Considered
+
+### Keep `field: null` deletion markers
+
+Rejected by ADR-004. `field: null` is concise for full-collection deletion, but
+it does not solve item-level deletion or exact-set reconciliation. It also
+reserves YAML null for destructive behavior, which may conflict with a future
+canonical collection model.
+
+### Infer exact-set ownership from list presence
+
+Rejected for compatibility. This model is elegant:
+
+```text
+omitted = unmanaged
+[]      = managed empty
+[...]   = managed exact set
+null    = invalid
+```
+
+But it changes existing non-empty list behavior from additive to exact-set,
+which can delete remote resources that users expected gh-infra to leave alone.
+
+### Add per-collection sibling fields in `spec`
+
+Example:
+
+```yaml
+spec:
+  rulesets_sync: mirror
+  rulesets:
+    - name: protect-main
+```
+
+Rejected as the primary direction. It follows the existing `label_sync` pattern,
+but scales poorly as more collections need sync policy. It also mixes gh-infra
+reconciliation behavior into `spec`, which otherwise describes desired GitHub
+resource values.
+
+### Add sync policy inside collection object form
+
+Example:
+
+```yaml
+spec:
+  rulesets:
+    sync: mirror
+    items:
+      - name: protect-main
+```
+
+This keeps policy near items and avoids `rulesets_sync`, but it requires
+list/object dual decoding for every collection. It also puts reconciliation
+policy inside `spec`. This remains a possible future refinement, but top-level
+`reconcile` provides a clearer separation of responsibilities.
+
+### Use CLI flags or user config
+
+Example:
+
+```sh
+gh infra apply ./infra --sync-mode=mirror
+```
+
+or:
+
+```yaml
+# ~/.config/gh-infra/config.yaml
+repository:
+  collection_sync: mirror
+```
+
+Rejected as the primary source of truth. Destructive behavior should be visible
+in the manifest under review. User-global config can make the same manifest
+produce different plans on different machines or in CI.
+
+CLI flags may still be useful for preview or migration diagnostics, for example
+to show what would be deleted if a collection were mirrored, but they should not
+silently change normal apply semantics.
+
+### Use YAML comments as directives
+
+Example:
+
+```yaml
+spec:
+  # gh-infra:sync=mirror
+  rulesets:
+    - name: protect-main
+```
+
+Rejected. Comments are not part of the YAML data model. Formatters, import,
+export, and YAML edit tools may move or drop them. Destructive behavior should
+be represented as data, not comments.
+
+## Consequences
+
+### Positive
+
+- Existing manifests remain additive by default.
+- Exact-set reconciliation becomes possible without state files.
+- Full-collection deletion can be expressed without `null` by using
+  `reconcile.<collection>: mirror` plus an empty list.
+- Destructive behavior is visible in the manifest and can be reviewed in PRs.
+- `spec` remains focused on desired GitHub resource values.
+- `reconcile` creates a single place for future reconciliation policy instead
+  of adding many `xxx_sync` fields.
+
+### Negative / Tradeoffs
+
+- The schema becomes larger: `Repository`, `RepositorySet.defaults`, and
+  `RepositorySet.repositories[]` need `reconcile` blocks.
+- Users must learn a new top-level concept.
+- `reconcile` and `spec` can become inconsistent, so validation must catch
+  policies targeting omitted collections.
+- Mirror mode can delete remote resources created manually or by other tools.
+  Plan output must make that reason explicit.
+- `label_sync` remains a pre-existing special case. A later ADR may decide
+  whether to keep it, deprecate it, or migrate labels into the same `reconcile`
+  model.
+
+### Implementation Notes
+
+- Start with `rulesets` and `branch_protection` only.
+- Keep `additive` as the default for both collections.
+- Reject explicit null for these collection fields.
+- Track field presence during parsing so `omitted`, `[]`, and non-empty lists
+  remain distinguishable.
+- In mirror mode, diff should generate `ChangeDelete` for current remote entries
+  not present in the desired collection.
+- In additive mode, diff should not generate deletes for undeclared remote
+  entries.
+- `plan` should include the reconcile policy in delete reasons.
+- `apply` can reuse existing delete APIs once diff emits delete changes.

--- a/docs/adr/005-collection-reconciliation-policy.md
+++ b/docs/adr/005-collection-reconciliation-policy.md
@@ -22,7 +22,7 @@ were rejected before merge:
 The implementations proved that explicit deletion markers are possible, but
 the schema question remained unresolved. `field: null` can only express
 full-collection deletion. It does not address the broader problem of choosing
-whether a collection is managed additively or as an exact mirror of YAML.
+whether a collection is managed additively or authoritatively.
 
 YAML itself distinguishes the following states:
 
@@ -73,7 +73,7 @@ metadata:
   name: my-repo
 
 reconcile:
-  rulesets: mirror
+  rulesets: authoritative
   branch_protection: additive
 
 spec:
@@ -96,7 +96,7 @@ Initial supported modes:
 | Mode | Semantics |
 |---|---|
 | `additive` | Create/update entries declared in YAML. Leave undeclared remote entries untouched. |
-| `mirror` | Make the remote collection match YAML exactly. Delete undeclared remote entries. |
+| `authoritative` | Make the remote collection match YAML exactly. Delete undeclared remote entries. |
 
 Default mode is `additive`. This preserves existing behavior for manifests that
 do not specify `reconcile`.
@@ -110,8 +110,8 @@ do not specify `reconcile`.
 | `spec.rulesets` omitted | rulesets unmanaged |
 | `spec.rulesets` present, `reconcile.rulesets` omitted | additive management |
 | `reconcile.rulesets: additive` + non-empty `spec.rulesets` | create/update listed rulesets only |
-| `reconcile.rulesets: mirror` + non-empty `spec.rulesets` | exact-set management; delete remote rulesets not listed |
-| `reconcile.rulesets: mirror` + `spec.rulesets: []` | managed empty collection; delete all remote rulesets |
+| `reconcile.rulesets: authoritative` + non-empty `spec.rulesets` | exact-set management; delete remote rulesets not listed |
+| `reconcile.rulesets: authoritative` + `spec.rulesets: []` | managed empty collection; delete all remote rulesets |
 | `rulesets:` / `rulesets: null` | invalid |
 
 If `reconcile.rulesets` is set but `spec.rulesets` is omitted, parsing should
@@ -126,7 +126,7 @@ Empty sequences are meaningful only when the collection is managed.
 
 ```yaml
 reconcile:
-  rulesets: mirror
+  rulesets: authoritative
 spec:
   rulesets: []
 ```
@@ -167,7 +167,7 @@ should be parse errors. Users should write:
 
 ```yaml
 reconcile:
-  rulesets: mirror
+  rulesets: authoritative
 spec:
   rulesets: []
 ```
@@ -187,7 +187,7 @@ metadata:
 
 defaults:
   reconcile:
-    rulesets: mirror
+    rulesets: authoritative
   spec:
     rulesets:
       - name: protect-main
@@ -209,19 +209,19 @@ Merge behavior:
 - After merge, any reconcile policy that targets an omitted collection is an
   error.
 
-This lets an organization use `mirror` by default while allowing individual
+This lets an organization use `authoritative` by default while allowing individual
 repositories to opt back into `additive`.
 
 ### Plan and apply behavior
 
-Plan output should make mirror-driven deletes explicit. A delete caused by
-mirror reconciliation is not the same as an update to a listed item; it is the
+Plan output should make authoritative-driven deletes explicit. A delete caused by
+authoritative reconciliation is not the same as an update to a listed item; it is the
 removal of a remote item that is absent from YAML.
 
 Example wording:
 
 ```text
-- ruleset "old-ruleset" (not declared; reconcile.rulesets=mirror)
+- ruleset "old-ruleset" (not declared; reconcile.rulesets=authoritative)
 ```
 
 Apply should execute those deletes only after they appear in plan, using the
@@ -232,12 +232,12 @@ existing GitHub delete APIs:
 
 ### Import/export behavior
 
-`import` and export flows should not emit `reconcile: mirror` by default.
+`import` and export flows should not emit `reconcile: authoritative` by default.
 Exporting current GitHub state into YAML should remain conservative and
-non-destructive unless the user opts into mirror policy.
+non-destructive unless the user opts into authoritative policy.
 
 `import --into` should preserve an existing `reconcile` block. If a user already
-declared `reconcile.rulesets: mirror`, import-into should update the listed
+declared `reconcile.rulesets: authoritative`, import-into should update the listed
 rulesets without silently removing the reconciliation policy.
 
 ## Alternatives Considered
@@ -342,7 +342,7 @@ be represented as data, not comments.
 - Existing manifests remain additive by default.
 - Exact-set reconciliation becomes possible without state files.
 - Full-collection deletion can be expressed without `null` by using
-  `reconcile.<collection>: mirror` plus an empty list.
+  `reconcile.<collection>: authoritative` plus an empty list.
 - Destructive behavior is visible in the manifest and can be reviewed in PRs.
 - `spec` remains focused on desired GitHub resource values.
 - `reconcile` creates a single place for future reconciliation policy instead
@@ -355,7 +355,7 @@ be represented as data, not comments.
 - Users must learn a new top-level concept.
 - `reconcile` and `spec` can become inconsistent, so validation must catch
   policies targeting omitted collections.
-- Mirror mode can delete remote resources created manually or by other tools.
+- Authoritative mode can delete remote resources created manually or by other tools.
   Plan output must make that reason explicit.
 - `label_sync` remains a pre-existing special case. A later ADR may decide
   whether to keep it, deprecate it, or migrate labels into the same `reconcile`
@@ -368,8 +368,8 @@ be represented as data, not comments.
 - Reject explicit null for these collection fields.
 - Track field presence during parsing so `omitted`, `[]`, and non-empty lists
   remain distinguishable.
-- In mirror mode, diff should generate `ChangeDelete` for current remote entries
-  not present in the desired collection.
+- In authoritative mode, diff should generate `ChangeDelete` for current remote
+  entries not present in the desired collection.
 - In additive mode, diff should not generate deletes for undeclared remote
   entries.
 - `plan` should include the reconcile policy in delete reasons.

--- a/docs/src/content/docs/resources/repository-set/defaults.md
+++ b/docs/src/content/docs/resources/repository-set/defaults.md
@@ -6,6 +6,8 @@ The `defaults` block defines shared settings applied to all repositories in the 
 
 ```yaml
 defaults:
+  reconcile:
+    rulesets: mirror
   spec:
     visibility: public
     features:
@@ -41,6 +43,28 @@ repositories:
     spec:
       description: "Internal"  # visibility stays private (not specified)
 ```
+
+### Reconcile — merged by collection
+
+`defaults.reconcile` sets default collection reconciliation policy for every repository in the set. A repository entry can override one collection without redefining the others.
+
+```yaml
+defaults:
+  reconcile:
+    rulesets: mirror
+    branch_protection: additive
+  spec:
+    rulesets:
+      - name: protect-main
+
+repositories:
+  - name: strict-repo       # rulesets mirror
+  - name: manual-repo
+    reconcile:
+      rulesets: additive    # overrides only rulesets
+```
+
+If a reconcile policy is set, the corresponding collection must be present after defaults and overrides are merged. For example, `reconcile.rulesets: mirror` requires `spec.rulesets` to exist. Use `spec.rulesets: []` for an explicitly empty managed collection.
 
 ### Lists — replaced entirely
 

--- a/docs/src/content/docs/resources/repository-set/defaults.md
+++ b/docs/src/content/docs/resources/repository-set/defaults.md
@@ -7,7 +7,7 @@ The `defaults` block defines shared settings applied to all repositories in the 
 ```yaml
 defaults:
   reconcile:
-    rulesets: mirror
+    rulesets: authoritative
   spec:
     visibility: public
     features:
@@ -51,20 +51,20 @@ repositories:
 ```yaml
 defaults:
   reconcile:
-    rulesets: mirror
+    rulesets: authoritative
     branch_protection: additive
   spec:
     rulesets:
       - name: protect-main
 
 repositories:
-  - name: strict-repo       # rulesets mirror
+  - name: strict-repo       # rulesets authoritative
   - name: manual-repo
     reconcile:
       rulesets: additive    # overrides only rulesets
 ```
 
-If a reconcile policy is set, the corresponding collection must be present after defaults and overrides are merged. For example, `reconcile.rulesets: mirror` requires `spec.rulesets` to exist. Use `spec.rulesets: []` for an explicitly empty managed collection.
+If a reconcile policy is set, the corresponding collection must be present after defaults and overrides are merged. For example, `reconcile.rulesets: authoritative` requires `spec.rulesets` to exist. Use `spec.rulesets: []` for an explicitly empty managed collection.
 
 ### Lists — replaced entirely
 

--- a/docs/src/content/docs/resources/repository/branch-protection.md
+++ b/docs/src/content/docs/resources/repository/branch-protection.md
@@ -42,22 +42,22 @@ Multiple patterns can be defined. Each entry creates a separate branch protectio
 
 Classic branch protection is additive by default. gh-infra creates and updates rules listed in `spec.branch_protection`, but it does not delete branch protection rules that exist on GitHub and are missing from YAML.
 
-Set `reconcile.branch_protection: mirror` to make GitHub branch protection rules match YAML exactly:
+Set `reconcile.branch_protection: authoritative` to make GitHub branch protection rules match YAML exactly:
 
 ```yaml
 reconcile:
-  branch_protection: mirror
+  branch_protection: authoritative
 spec:
   branch_protection:
     - pattern: main
       required_reviews: 1
 ```
 
-With `mirror`, any classic branch protection rule not declared in `spec.branch_protection` is planned for deletion. To delete all classic branch protection rules:
+With `authoritative`, any classic branch protection rule not declared in `spec.branch_protection` is planned for deletion. To delete all classic branch protection rules:
 
 ```yaml
 reconcile:
-  branch_protection: mirror
+  branch_protection: authoritative
 spec:
   branch_protection: []
 ```

--- a/docs/src/content/docs/resources/repository/branch-protection.md
+++ b/docs/src/content/docs/resources/repository/branch-protection.md
@@ -13,6 +13,9 @@ Classic branch protection still works and is fully supported by gh-infra, but fo
 ## Example
 
 ```yaml
+reconcile:
+  branch_protection: additive
+
 spec:
   branch_protection:
     - pattern: main
@@ -34,6 +37,32 @@ spec:
 ```
 
 Multiple patterns can be defined. Each entry creates a separate branch protection rule.
+
+## Reconcile Mode
+
+Classic branch protection is additive by default. gh-infra creates and updates rules listed in `spec.branch_protection`, but it does not delete branch protection rules that exist on GitHub and are missing from YAML.
+
+Set `reconcile.branch_protection: mirror` to make GitHub branch protection rules match YAML exactly:
+
+```yaml
+reconcile:
+  branch_protection: mirror
+spec:
+  branch_protection:
+    - pattern: main
+      required_reviews: 1
+```
+
+With `mirror`, any classic branch protection rule not declared in `spec.branch_protection` is planned for deletion. To delete all classic branch protection rules:
+
+```yaml
+reconcile:
+  branch_protection: mirror
+spec:
+  branch_protection: []
+```
+
+`branch_protection: null` and `branch_protection:` are invalid. Use `[]` for an explicitly empty managed collection.
 
 ## Fields
 

--- a/docs/src/content/docs/resources/repository/index.md
+++ b/docs/src/content/docs/resources/repository/index.md
@@ -15,6 +15,9 @@ metadata:
   name: my-project
   owner: babarot
 
+reconcile:
+  rulesets: mirror
+
 spec:
   description: "My awesome project"
   homepage: "https://example.com"
@@ -99,6 +102,41 @@ The combination of `owner` and `name` identifies the target repository (`babarot
 
 All fields are optional — declare only what you want to manage. Fields not present in the YAML are left unchanged on GitHub.
 The one exception is `spec.actions.enabled`: when managing any other Actions setting, GitHub requires `enabled` to be sent too. See [Actions](./actions/).
+
+## Reconcile
+
+By default, collection fields are managed additively: gh-infra creates or updates entries declared in YAML and leaves undeclared GitHub resources untouched.
+
+Use top-level `reconcile` to make selected collections match YAML exactly:
+
+```yaml
+reconcile:
+  rulesets: mirror
+  branch_protection: additive
+
+spec:
+  rulesets:
+    - name: protect-main
+      target: branch
+      rules:
+        non_fast_forward: true
+```
+
+| Field | Modes | Description |
+|---|---|---|
+| `reconcile.rulesets` | `additive`, `mirror` | Controls how `spec.rulesets` is compared with existing GitHub rulesets |
+| `reconcile.branch_protection` | `additive`, `mirror` | Controls how `spec.branch_protection` is compared with existing classic branch protection rules |
+
+`additive` is the default. `mirror` deletes remote entries that are not declared in YAML. To delete all rulesets or branch protection rules, use `mirror` with an empty list:
+
+```yaml
+reconcile:
+  rulesets: mirror
+spec:
+  rulesets: []
+```
+
+`rulesets: null`, `rulesets:`, `branch_protection: null`, and `branch_protection:` are invalid. Use an empty list when you mean an empty managed collection.
 
 ## When to Use
 

--- a/docs/src/content/docs/resources/repository/index.md
+++ b/docs/src/content/docs/resources/repository/index.md
@@ -16,7 +16,7 @@ metadata:
   owner: babarot
 
 reconcile:
-  rulesets: mirror
+  rulesets: authoritative
 
 spec:
   description: "My awesome project"
@@ -111,7 +111,7 @@ Use top-level `reconcile` to make selected collections match YAML exactly:
 
 ```yaml
 reconcile:
-  rulesets: mirror
+  rulesets: authoritative
   branch_protection: additive
 
 spec:
@@ -124,14 +124,14 @@ spec:
 
 | Field | Modes | Description |
 |---|---|---|
-| `reconcile.rulesets` | `additive`, `mirror` | Controls how `spec.rulesets` is compared with existing GitHub rulesets |
-| `reconcile.branch_protection` | `additive`, `mirror` | Controls how `spec.branch_protection` is compared with existing classic branch protection rules |
+| `reconcile.rulesets` | `additive`, `authoritative` | Controls how `spec.rulesets` is compared with existing GitHub rulesets |
+| `reconcile.branch_protection` | `additive`, `authoritative` | Controls how `spec.branch_protection` is compared with existing classic branch protection rules |
 
-`additive` is the default. `mirror` deletes remote entries that are not declared in YAML. To delete all rulesets or branch protection rules, use `mirror` with an empty list:
+`additive` is the default. `authoritative` deletes remote entries that are not declared in YAML. To delete all rulesets or branch protection rules, use `authoritative` with an empty list:
 
 ```yaml
 reconcile:
-  rulesets: mirror
+  rulesets: authoritative
 spec:
   rulesets: []
 ```

--- a/docs/src/content/docs/resources/repository/rulesets.md
+++ b/docs/src/content/docs/resources/repository/rulesets.md
@@ -22,6 +22,9 @@ To use rulesets on private repositories, upgrade to GitHub Pro, GitHub Team, or 
 ## Example
 
 ```yaml
+reconcile:
+  rulesets: additive
+
 spec:
   rulesets:
     - name: protect-main
@@ -65,6 +68,34 @@ spec:
         deletion: true
         non_fast_forward: true
 ```
+
+## Reconcile Mode
+
+Rulesets are additive by default. gh-infra creates and updates rulesets listed in `spec.rulesets`, but it does not delete rulesets that exist on GitHub and are missing from YAML.
+
+Set `reconcile.rulesets: mirror` to make GitHub rulesets match YAML exactly:
+
+```yaml
+reconcile:
+  rulesets: mirror
+spec:
+  rulesets:
+    - name: protect-main
+      target: branch
+      rules:
+        non_fast_forward: true
+```
+
+With `mirror`, any repository ruleset not declared in `spec.rulesets` is planned for deletion. To delete all repository rulesets:
+
+```yaml
+reconcile:
+  rulesets: mirror
+spec:
+  rulesets: []
+```
+
+`rulesets: null` and `rulesets:` are invalid. Use `[]` for an explicitly empty managed collection.
 
 ## Top-level Fields
 

--- a/docs/src/content/docs/resources/repository/rulesets.md
+++ b/docs/src/content/docs/resources/repository/rulesets.md
@@ -73,11 +73,11 @@ spec:
 
 Rulesets are additive by default. gh-infra creates and updates rulesets listed in `spec.rulesets`, but it does not delete rulesets that exist on GitHub and are missing from YAML.
 
-Set `reconcile.rulesets: mirror` to make GitHub rulesets match YAML exactly:
+Set `reconcile.rulesets: authoritative` to make GitHub rulesets match YAML exactly:
 
 ```yaml
 reconcile:
-  rulesets: mirror
+  rulesets: authoritative
 spec:
   rulesets:
     - name: protect-main
@@ -86,11 +86,11 @@ spec:
         non_fast_forward: true
 ```
 
-With `mirror`, any repository ruleset not declared in `spec.rulesets` is planned for deletion. To delete all repository rulesets:
+With `authoritative`, any repository ruleset not declared in `spec.rulesets` is planned for deletion. To delete all repository rulesets:
 
 ```yaml
 reconcile:
-  rulesets: mirror
+  rulesets: authoritative
 spec:
   rulesets: []
 ```

--- a/internal/infra/format_test.go
+++ b/internal/infra/format_test.go
@@ -584,3 +584,52 @@ func TestPrintPlan_RulesetAndBranchProtectionHeaders(t *testing.T) {
 		t.Errorf("output contains raw collection header:\n%s", out)
 	}
 }
+
+func TestPrintPlan_DeleteRulesetAndBranchProtectionWithChildren(t *testing.T) {
+	var buf bytes.Buffer
+	p := ui.NewStandardPrinterWith(&buf, &buf)
+
+	repoChanges := []repository.Change{
+		{
+			Type:     repository.ChangeDelete,
+			Resource: `Ruleset[old-ruleset]`,
+			Name:     "org/repo",
+			Field:    "ruleset",
+			OldValue: 42,
+			Children: []repository.Change{
+				{Type: repository.ChangeDelete, Field: "target", OldValue: "branch"},
+				{Type: repository.ChangeDelete, Field: "enforcement", OldValue: "active"},
+			},
+		},
+		{
+			Type:     repository.ChangeDelete,
+			Resource: `BranchProtection[main]`,
+			Name:     "org/repo",
+			Field:    "branch_protection",
+			OldValue: "main",
+			Children: []repository.Change{
+				{Type: repository.ChangeDelete, Field: "required_reviews", OldValue: 1},
+				{Type: repository.ChangeDelete, Field: "enforce_admins", OldValue: false},
+			},
+		},
+	}
+
+	printPlan(p, repoChanges, nil)
+	out := buf.String()
+
+	for _, want := range []string{
+		`ruleset "old-ruleset"`,
+		"target",
+		"enforcement",
+		`branch protection "main"`,
+		"required_reviews",
+		"enforce_admins",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "branch_protection      main") {
+		t.Errorf("expected grouped branch protection delete, got flat output:\n%s", out)
+	}
+}

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -213,7 +213,8 @@ func parseRepositorySet(data []byte, path string, docIndex int) ([]*Repository, 
 				Name:  entry.Name,
 				Owner: set.Metadata.Owner,
 			},
-			Spec: mergeSpecs(set.Defaults, entry.Spec),
+			Reconcile: mergeReconcile(set.Defaults, entry.Reconcile),
+			Spec:      mergeSpecs(set.Defaults, entry.Spec),
 		}
 		if err := repo.Validate(); err != nil {
 			return nil, nil, fmt.Errorf("%s: %w", path, err)
@@ -385,11 +386,13 @@ func mergeSpecs(defaults *RepositorySetDefaults, override RepositorySpec) Reposi
 	if override.Actions != nil {
 		result.Actions = mergeActions(result.Actions, override.Actions)
 	}
-	if len(override.BranchProtection) > 0 {
+	if override.BranchProtectionSet {
 		result.BranchProtection = mergeBranchProtection(result.BranchProtection, override.BranchProtection)
+		result.BranchProtectionSet = true
 	}
-	if len(override.Rulesets) > 0 {
+	if override.RulesetsSet {
 		result.Rulesets = mergeRulesets(result.Rulesets, override.Rulesets)
+		result.RulesetsSet = true
 	}
 	if len(override.Secrets) > 0 {
 		result.Secrets = override.Secrets
@@ -408,6 +411,29 @@ func mergeSpecs(defaults *RepositorySetDefaults, override RepositorySpec) Reposi
 	}
 
 	return result
+}
+
+func mergeReconcile(defaults *RepositorySetDefaults, override *RepositoryReconcile) *RepositoryReconcile {
+	var base *RepositoryReconcile
+	if defaults != nil {
+		base = defaults.Reconcile
+	}
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		result := *base
+		return &result
+	}
+
+	result := *base
+	if override.BranchProtection != nil {
+		result.BranchProtection = override.BranchProtection
+	}
+	if override.Rulesets != nil {
+		result.Rulesets = override.Rulesets
+	}
+	return &result
 }
 
 func mergeFeatures(base, override *Features) *Features {

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -1836,6 +1837,164 @@ spec:
 	_, err := ParsePath(path)
 	if err == nil {
 		t.Fatal("expected validation error for invalid label_sync value")
+	}
+}
+
+func TestRepositoryReconcileValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name: "reconcile without spec collection",
+			content: `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+reconcile:
+  rulesets: mirror
+spec:
+  description: repo
+`,
+			wantErr: "reconcile.rulesets requires spec.rulesets",
+		},
+		{
+			name: "invalid reconcile mode",
+			content: `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+reconcile:
+  rulesets: replace
+spec:
+  rulesets: []
+`,
+			wantErr: "invalid reconcile.rulesets",
+		},
+		{
+			name: "null rulesets rejected",
+			content: `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+spec:
+  rulesets:
+`,
+			wantErr: "rulesets must be a sequence",
+		},
+		{
+			name: "null branch protection rejected",
+			content: `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+spec:
+  branch_protection: null
+`,
+			wantErr: "branch_protection must be a sequence",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "repo.yaml")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := ParsePath(path)
+			if err == nil {
+				t.Fatal("expected parse error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRepositoryReconcileMirrorEmptyCollection(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+reconcile:
+  rulesets: mirror
+spec:
+  rulesets: []
+`
+	path := filepath.Join(dir, "repo.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath error: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+	if !repos[0].Spec.RulesetsSet {
+		t.Fatal("rulesets presence was not tracked")
+	}
+	if got := RulesetsReconcileMode(repos[0].Reconcile); got != CollectionReconcileMirror {
+		t.Fatalf("rulesets reconcile mode = %q, want %q", got, CollectionReconcileMirror)
+	}
+	if len(repos[0].Spec.Rulesets) != 0 {
+		t.Fatalf("rulesets length = %d, want 0", len(repos[0].Spec.Rulesets))
+	}
+}
+
+func TestRepositorySet_ReconcileMerge(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: RepositorySet
+metadata:
+  owner: org
+defaults:
+  reconcile:
+    rulesets: mirror
+  spec:
+    rulesets:
+      - name: protect-main
+repositories:
+  - name: inherits-reconcile
+  - name: overrides-reconcile
+    reconcile:
+      rulesets: additive
+`
+	path := filepath.Join(dir, "reposet.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath error: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+	if got := RulesetsReconcileMode(repos[0].Reconcile); got != CollectionReconcileMirror {
+		t.Fatalf("repo[0] rulesets reconcile mode = %q, want %q", got, CollectionReconcileMirror)
+	}
+	if got := RulesetsReconcileMode(repos[1].Reconcile); got != CollectionReconcileAdditive {
+		t.Fatalf("repo[1] rulesets reconcile mode = %q, want %q", got, CollectionReconcileAdditive)
 	}
 }
 

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -1855,7 +1855,7 @@ metadata:
   owner: org
   name: repo
 reconcile:
-  rulesets: mirror
+  rulesets: authoritative
 spec:
   description: repo
 `,
@@ -1923,7 +1923,7 @@ spec:
 	}
 }
 
-func TestRepositoryReconcileMirrorEmptyCollection(t *testing.T) {
+func TestRepositoryReconcileAuthoritativeEmptyCollection(t *testing.T) {
 	dir := t.TempDir()
 	content := `
 apiVersion: v1
@@ -1932,7 +1932,7 @@ metadata:
   owner: org
   name: repo
 reconcile:
-  rulesets: mirror
+  rulesets: authoritative
 spec:
   rulesets: []
 `
@@ -1951,8 +1951,8 @@ spec:
 	if !repos[0].Spec.RulesetsSet {
 		t.Fatal("rulesets presence was not tracked")
 	}
-	if got := RulesetsReconcileMode(repos[0].Reconcile); got != CollectionReconcileMirror {
-		t.Fatalf("rulesets reconcile mode = %q, want %q", got, CollectionReconcileMirror)
+	if got := RulesetsReconcileMode(repos[0].Reconcile); got != CollectionReconcileAuthoritative {
+		t.Fatalf("rulesets reconcile mode = %q, want %q", got, CollectionReconcileAuthoritative)
 	}
 	if len(repos[0].Spec.Rulesets) != 0 {
 		t.Fatalf("rulesets length = %d, want 0", len(repos[0].Spec.Rulesets))
@@ -1968,7 +1968,7 @@ metadata:
   owner: org
 defaults:
   reconcile:
-    rulesets: mirror
+    rulesets: authoritative
   spec:
     rulesets:
       - name: protect-main
@@ -1990,8 +1990,8 @@ repositories:
 	if len(repos) != 2 {
 		t.Fatalf("expected 2 repos, got %d", len(repos))
 	}
-	if got := RulesetsReconcileMode(repos[0].Reconcile); got != CollectionReconcileMirror {
-		t.Fatalf("repo[0] rulesets reconcile mode = %q, want %q", got, CollectionReconcileMirror)
+	if got := RulesetsReconcileMode(repos[0].Reconcile); got != CollectionReconcileAuthoritative {
+		t.Fatalf("repo[0] rulesets reconcile mode = %q, want %q", got, CollectionReconcileAuthoritative)
 	}
 	if got := RulesetsReconcileMode(repos[1].Reconcile); got != CollectionReconcileAdditive {
 		t.Fatalf("repo[1] rulesets reconcile mode = %q, want %q", got, CollectionReconcileAdditive)

--- a/internal/manifest/repository_types.go
+++ b/internal/manifest/repository_types.go
@@ -23,8 +23,8 @@ const (
 	LabelSyncMirror   = "mirror"
 
 	// Collection reconcile mode values.
-	CollectionReconcileAdditive = "additive"
-	CollectionReconcileMirror   = "mirror"
+	CollectionReconcileAdditive      = "additive"
+	CollectionReconcileAuthoritative = "authoritative"
 
 	// Ruleset enforcement values.
 	RulesetEnforcementActive   = "active"
@@ -103,8 +103,8 @@ type RepositorySpec struct {
 }
 
 type RepositoryReconcile struct {
-	BranchProtection *string `yaml:"branch_protection,omitempty" validate:"omitempty,oneof=additive mirror"`
-	Rulesets         *string `yaml:"rulesets,omitempty"           validate:"omitempty,oneof=additive mirror"`
+	BranchProtection *string `yaml:"branch_protection,omitempty" validate:"omitempty,oneof=additive authoritative"`
+	Rulesets         *string `yaml:"rulesets,omitempty"           validate:"omitempty,oneof=additive authoritative"`
 }
 
 // UnmarshalYAML tracks whether collection fields were present in YAML. For
@@ -126,13 +126,13 @@ func (s *RepositorySpec) UnmarshalYAML(unmarshal func(any) error) error {
 	if v, ok := fields["branch_protection"]; ok {
 		s.BranchProtectionSet = true
 		if v == nil {
-			return fmt.Errorf("branch_protection must be a sequence; use [] with reconcile.branch_protection=mirror to delete all branch protection rules")
+			return fmt.Errorf("branch_protection must be a sequence; use [] with reconcile.branch_protection=authoritative to delete all branch protection rules")
 		}
 	}
 	if v, ok := fields["rulesets"]; ok {
 		s.RulesetsSet = true
 		if v == nil {
-			return fmt.Errorf("rulesets must be a sequence; use [] with reconcile.rulesets=mirror to delete all rulesets")
+			return fmt.Errorf("rulesets must be a sequence; use [] with reconcile.rulesets=authoritative to delete all rulesets")
 		}
 	}
 

--- a/internal/manifest/repository_types.go
+++ b/internal/manifest/repository_types.go
@@ -1,5 +1,7 @@
 package manifest
 
+import "fmt"
+
 const (
 	// Visibility values for repository visibility.
 	VisibilityPublic   = "public"
@@ -19,6 +21,10 @@ const (
 	// Label sync mode values.
 	LabelSyncAdditive = "additive"
 	LabelSyncMirror   = "mirror"
+
+	// Collection reconcile mode values.
+	CollectionReconcileAdditive = "additive"
+	CollectionReconcileMirror   = "mirror"
 
 	// Ruleset enforcement values.
 	RulesetEnforcementActive   = "active"
@@ -57,10 +63,11 @@ const (
 
 // Repository represents a single repository declaration.
 type Repository struct {
-	APIVersion string             `yaml:"apiVersion"`
-	Kind       string             `yaml:"kind"`
-	Metadata   RepositoryMetadata `yaml:"metadata"`
-	Spec       RepositorySpec     `yaml:"spec"`
+	APIVersion string               `yaml:"apiVersion"`
+	Kind       string               `yaml:"kind"`
+	Metadata   RepositoryMetadata   `yaml:"metadata"`
+	Reconcile  *RepositoryReconcile `yaml:"reconcile,omitempty"`
+	Spec       RepositorySpec       `yaml:"spec"`
 }
 
 type RepositoryMetadata struct {
@@ -90,6 +97,46 @@ type RepositorySpec struct {
 	Secrets             []Secret           `yaml:"secrets,omitempty"           validate:"unique=name"`
 	Variables           []Variable         `yaml:"variables,omitempty"         validate:"unique=name"`
 	Actions             *Actions           `yaml:"actions,omitempty"`
+
+	BranchProtectionSet bool `yaml:"-"`
+	RulesetsSet         bool `yaml:"-"`
+}
+
+type RepositoryReconcile struct {
+	BranchProtection *string `yaml:"branch_protection,omitempty" validate:"omitempty,oneof=additive mirror"`
+	Rulesets         *string `yaml:"rulesets,omitempty"           validate:"omitempty,oneof=additive mirror"`
+}
+
+// UnmarshalYAML tracks whether collection fields were present in YAML. For
+// stateless reconciliation, omitted, empty, and non-empty collections have
+// different meanings; explicit null remains invalid.
+func (s *RepositorySpec) UnmarshalYAML(unmarshal func(any) error) error {
+	type raw RepositorySpec
+	var r raw
+	if err := unmarshal(&r); err != nil {
+		return err
+	}
+	*s = RepositorySpec(r)
+
+	var fields map[string]any
+	if err := unmarshal(&fields); err != nil {
+		return err
+	}
+
+	if v, ok := fields["branch_protection"]; ok {
+		s.BranchProtectionSet = true
+		if v == nil {
+			return fmt.Errorf("branch_protection must be a sequence; use [] with reconcile.branch_protection=mirror to delete all branch protection rules")
+		}
+	}
+	if v, ok := fields["rulesets"]; ok {
+		s.RulesetsSet = true
+		if v == nil {
+			return fmt.Errorf("rulesets must be a sequence; use [] with reconcile.rulesets=mirror to delete all rulesets")
+		}
+	}
+
+	return nil
 }
 
 // Security groups GitHub Advanced Security related repository settings,
@@ -291,6 +338,20 @@ func LabelSyncMode(s *string) string {
 		return LabelSyncAdditive
 	}
 	return *s
+}
+
+func BranchProtectionReconcileMode(r *RepositoryReconcile) string {
+	if r == nil || r.BranchProtection == nil {
+		return CollectionReconcileAdditive
+	}
+	return *r.BranchProtection
+}
+
+func RulesetsReconcileMode(r *RepositoryReconcile) string {
+	if r == nil || r.Rulesets == nil {
+		return CollectionReconcileAdditive
+	}
+	return *r.Rulesets
 }
 
 type Milestone struct {

--- a/internal/manifest/repositoryset_types.go
+++ b/internal/manifest/repositoryset_types.go
@@ -14,10 +14,12 @@ type RepositorySetMetadata struct {
 }
 
 type RepositorySetDefaults struct {
-	Spec RepositorySpec `yaml:"spec"`
+	Reconcile *RepositoryReconcile `yaml:"reconcile,omitempty"`
+	Spec      RepositorySpec       `yaml:"spec"`
 }
 
 type RepositorySetEntry struct {
-	Name string         `yaml:"name"`
-	Spec RepositorySpec `yaml:"spec"`
+	Name      string               `yaml:"name"`
+	Reconcile *RepositoryReconcile `yaml:"reconcile,omitempty"`
+	Spec      RepositorySpec       `yaml:"spec"`
 }

--- a/internal/manifest/validation.go
+++ b/internal/manifest/validation.go
@@ -12,6 +12,14 @@ func (r *Repository) Validate() error {
 		return err
 	}
 	name := r.Metadata.Name
+	if r.Reconcile != nil {
+		if r.Reconcile.BranchProtection != nil && !r.Spec.BranchProtectionSet {
+			return fmt.Errorf("%s: reconcile.branch_protection requires spec.branch_protection to be present", name)
+		}
+		if r.Reconcile.Rulesets != nil && !r.Spec.RulesetsSet {
+			return fmt.Errorf("%s: reconcile.rulesets requires spec.rulesets to be present", name)
+		}
+	}
 	// Branch protection: element tag validation
 	for i, bp := range r.Spec.BranchProtection {
 		if err := ValidateStruct(fmt.Sprintf("%s: spec.branch_protection[%d]", name, i), &bp); err != nil {

--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -142,7 +142,7 @@ func (p *Processor) applyChange(ctx context.Context, c Change, repo *manifest.Re
 	// Generic: if this change has children, expand and apply each child.
 	// Label and Milestone updates carry children for display (e.g. color, description)
 	// but should be applied as a single API call using the parent's Field (the name/title).
-	if len(c.Children) > 0 && c.Resource != manifest.ResourceLabel && c.Resource != manifest.ResourceMilestone {
+	if len(c.Children) > 0 && c.Type != ChangeDelete && c.Resource != manifest.ResourceLabel && c.Resource != manifest.ResourceMilestone {
 		for _, child := range c.Children {
 			child.Resource = c.Resource
 			child.Name = c.Name
@@ -635,6 +635,12 @@ func (p *Processor) applyBranchProtection(ctx context.Context, c Change, repo *m
 		pattern = strings.TrimSuffix(after, "]")
 	}
 
+	if c.Type == ChangeDelete {
+		endpoint := fmt.Sprintf("repos/%s/%s/branches/%s/protection", owner, name, pattern)
+		_, err := p.runner.Run(ctx, "api", endpoint, "--method", "DELETE")
+		return wrapError(err, owner+"/"+name, "branch_protection:"+pattern)
+	}
+
 	var bp *manifest.BranchProtection
 	for i := range repo.Spec.BranchProtection {
 		if repo.Spec.BranchProtection[i].Pattern == pattern {
@@ -711,6 +717,15 @@ func (p *Processor) applyRuleset(ctx context.Context, c Change, repo *manifest.R
 
 	// Extract ruleset name from resource like "Ruleset[protect-main]"
 	rulesetName := strings.TrimSuffix(strings.TrimPrefix(c.Resource, manifest.ResourceRuleset+"["), "]")
+
+	if c.Type == ChangeDelete {
+		rulesetID, ok := c.OldValue.(int)
+		if !ok || rulesetID == 0 {
+			return fmt.Errorf("ruleset %q delete change is missing ruleset ID", rulesetName)
+		}
+		_, err := p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/%s/rulesets/%d", owner, name, rulesetID), "--method", "DELETE")
+		return wrapError(err, owner+"/"+name, "ruleset:"+rulesetName)
+	}
 
 	var rs *manifest.Ruleset
 	for i := range repo.Spec.Rulesets {

--- a/internal/repository/apply_test.go
+++ b/internal/repository/apply_test.go
@@ -556,6 +556,42 @@ func TestApplyBranchProtection(t *testing.T) {
 	}
 }
 
+func TestApplyBranchProtection_Delete(t *testing.T) {
+	mock := &gh.MockRunner{}
+	proc := NewProcessor(mock, nil)
+	repo := newTestRepo("myorg", "myrepo")
+
+	changes := []Change{
+		{
+			Type:     ChangeDelete,
+			Resource: "BranchProtection[main]",
+			Name:     "myorg/myrepo",
+			Field:    "branch_protection",
+			OldValue: "main",
+		},
+	}
+
+	results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("unexpected error: %v", results[0].Err)
+	}
+	found := false
+	for _, call := range mock.Called {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "repos/myorg/myrepo/branches/main/protection") &&
+			strings.Contains(joined, "DELETE") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected DELETE to branch protection endpoint, got calls: %v", mock.Called)
+	}
+}
+
 func TestBuildBranchProtectionPayload(t *testing.T) {
 	reviews := 2
 	dismissStale := true
@@ -780,6 +816,43 @@ func TestApplyRuleset_Update(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected PUT to rulesets/42 endpoint, got calls: %v", mock.Called)
+	}
+}
+
+func TestApplyRuleset_Delete(t *testing.T) {
+	mock := &gh.MockRunner{}
+	proc := NewProcessor(mock, nil)
+	repo := newTestRepo("myorg", "myrepo")
+
+	changes := []Change{
+		{
+			Type:     ChangeDelete,
+			Resource: "Ruleset[old-ruleset]",
+			Name:     "myorg/myrepo",
+			Field:    "ruleset",
+			OldValue: 42,
+		},
+	}
+
+	results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("unexpected error: %v", results[0].Err)
+	}
+
+	found := false
+	for _, call := range mock.Called {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "repos/myorg/myrepo/rulesets/42") &&
+			strings.Contains(joined, "DELETE") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected DELETE to rulesets/42 endpoint, got calls: %v", mock.Called)
 	}
 }
 

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -232,8 +232,10 @@ func diffMergeStrategy(name string, desired *manifest.Repository, current *Curre
 
 func diffBranchProtection(name string, desired *manifest.Repository, current *CurrentState) []Change {
 	var changes []Change
+	desiredPatterns := make(map[string]struct{}, len(desired.Spec.BranchProtection))
 
 	for _, dbp := range desired.Spec.BranchProtection {
+		desiredPatterns[dbp.Pattern] = struct{}{}
 		cbp, exists := current.BranchProtection[dbp.Pattern]
 		resource := fmt.Sprintf("%s[%s]", manifest.ResourceBranchProtection, dbp.Pattern)
 
@@ -316,13 +318,32 @@ func diffBranchProtection(name string, desired *manifest.Repository, current *Cu
 		}
 	}
 
+	if manifest.BranchProtectionReconcileMode(desired.Reconcile) == manifest.CollectionReconcileMirror {
+		for pattern, cbp := range current.BranchProtection {
+			if _, ok := desiredPatterns[pattern]; ok {
+				continue
+			}
+			changes = append(changes, Change{
+				Type:     ChangeDelete,
+				Resource: fmt.Sprintf("%s[%s]", manifest.ResourceBranchProtection, pattern),
+				Name:     name,
+				Field:    "branch_protection",
+				OldValue: pattern,
+				NewValue: "not declared; reconcile.branch_protection=mirror",
+				Children: bpDeleteChildren(cbp),
+			})
+		}
+	}
+
 	return changes
 }
 
 func diffRulesets(ctx context.Context, name string, desired *manifest.Repository, current *CurrentState, resolver *manifest.Resolver) []Change {
 	var changes []Change
+	desiredNames := make(map[string]struct{}, len(desired.Spec.Rulesets))
 
 	for _, drs := range desired.Spec.Rulesets {
+		desiredNames[drs.Name] = struct{}{}
 		crs, exists := current.Rulesets[drs.Name]
 		resource := fmt.Sprintf("%s[%s]", manifest.ResourceRuleset, drs.Name)
 
@@ -462,6 +483,23 @@ func diffRulesets(ctx context.Context, name string, desired *manifest.Repository
 		}
 	}
 
+	if manifest.RulesetsReconcileMode(desired.Reconcile) == manifest.CollectionReconcileMirror {
+		for rulesetName, crs := range current.Rulesets {
+			if _, ok := desiredNames[rulesetName]; ok {
+				continue
+			}
+			changes = append(changes, Change{
+				Type:     ChangeDelete,
+				Resource: fmt.Sprintf("%s[%s]", manifest.ResourceRuleset, rulesetName),
+				Name:     name,
+				Field:    "ruleset",
+				OldValue: crs.ID,
+				NewValue: "not declared; reconcile.rulesets=mirror",
+				Children: rsDeleteChildren(crs),
+			})
+		}
+	}
+
 	return changes
 }
 
@@ -541,6 +579,81 @@ func rulesetStatusChecksEqual(ctx context.Context, desired []manifest.RulesetSta
 		}
 	}
 	return true
+}
+
+// bpDeleteChildren builds display-only children showing the current values of
+// a branch protection rule that is about to be deleted. applyChange must not
+// expand these children into separate API calls.
+func bpDeleteChildren(cbp *CurrentBranchProtection) []Change {
+	children := []Change{
+		{Type: ChangeDelete, Field: "required_reviews", OldValue: cbp.RequiredReviews},
+		{Type: ChangeDelete, Field: "dismiss_stale_reviews", OldValue: cbp.DismissStaleReviews},
+		{Type: ChangeDelete, Field: "require_code_owner_reviews", OldValue: cbp.RequireCodeOwnerReviews},
+		{Type: ChangeDelete, Field: "enforce_admins", OldValue: cbp.EnforceAdmins},
+		{Type: ChangeDelete, Field: "allow_force_pushes", OldValue: cbp.AllowForcePushes},
+		{Type: ChangeDelete, Field: "allow_deletions", OldValue: cbp.AllowDeletions},
+	}
+	if cbp.RequireStatusChecks != nil {
+		children = append(children, Change{
+			Type:     ChangeDelete,
+			Field:    "require_status_checks.strict",
+			OldValue: cbp.RequireStatusChecks.Strict,
+		})
+		if len(cbp.RequireStatusChecks.Contexts) > 0 {
+			children = append(children, Change{
+				Type:     ChangeDelete,
+				Field:    "require_status_checks.contexts",
+				OldValue: cbp.RequireStatusChecks.Contexts,
+			})
+		}
+	}
+	return children
+}
+
+// rsDeleteChildren builds display-only children showing the current values of
+// a ruleset that is about to be deleted. applyChange must not expand these
+// children into separate API calls.
+func rsDeleteChildren(rs *CurrentRuleset) []Change {
+	children := []Change{
+		{Type: ChangeDelete, Field: "target", OldValue: rs.Target},
+		{Type: ChangeDelete, Field: "enforcement", OldValue: rs.Enforcement},
+	}
+	if len(rs.BypassActors) > 0 {
+		children = append(children, Change{
+			Type:     ChangeDelete,
+			Field:    "bypass_actors",
+			OldValue: fmt.Sprintf("%d actors", len(rs.BypassActors)),
+		})
+	}
+	if rs.Conditions != nil && rs.Conditions.RefName != nil {
+		children = append(children, Change{
+			Type:     ChangeDelete,
+			Field:    "conditions",
+			OldValue: formatConditions(rs.Conditions.RefName.Include, rs.Conditions.RefName.Exclude),
+		})
+	}
+	if rs.Rules.NonFastForward {
+		children = append(children, Change{Type: ChangeDelete, Field: "rules.non_fast_forward", OldValue: true})
+	}
+	if rs.Rules.Deletion {
+		children = append(children, Change{Type: ChangeDelete, Field: "rules.deletion", OldValue: true})
+	}
+	if rs.Rules.Creation {
+		children = append(children, Change{Type: ChangeDelete, Field: "rules.creation", OldValue: true})
+	}
+	if rs.Rules.RequiredLinearHistory {
+		children = append(children, Change{Type: ChangeDelete, Field: "rules.required_linear_history", OldValue: true})
+	}
+	if rs.Rules.RequiredSignatures {
+		children = append(children, Change{Type: ChangeDelete, Field: "rules.required_signatures", OldValue: true})
+	}
+	if rs.Rules.PullRequest != nil {
+		children = append(children, Change{Type: ChangeDelete, Field: "rules.pull_request", OldValue: "enabled"})
+	}
+	if rs.Rules.RequiredStatusChecks != nil {
+		children = append(children, Change{Type: ChangeDelete, Field: "rules.required_status_checks", OldValue: "enabled"})
+	}
+	return children
 }
 
 func statusCheckContexts(checks []CurrentRulesetStatusCheck) []string {

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -318,7 +318,7 @@ func diffBranchProtection(name string, desired *manifest.Repository, current *Cu
 		}
 	}
 
-	if manifest.BranchProtectionReconcileMode(desired.Reconcile) == manifest.CollectionReconcileMirror {
+	if manifest.BranchProtectionReconcileMode(desired.Reconcile) == manifest.CollectionReconcileAuthoritative {
 		for pattern, cbp := range current.BranchProtection {
 			if _, ok := desiredPatterns[pattern]; ok {
 				continue
@@ -329,7 +329,7 @@ func diffBranchProtection(name string, desired *manifest.Repository, current *Cu
 				Name:     name,
 				Field:    "branch_protection",
 				OldValue: pattern,
-				NewValue: "not declared; reconcile.branch_protection=mirror",
+				NewValue: "not declared; reconcile.branch_protection=authoritative",
 				Children: bpDeleteChildren(cbp),
 			})
 		}
@@ -483,7 +483,7 @@ func diffRulesets(ctx context.Context, name string, desired *manifest.Repository
 		}
 	}
 
-	if manifest.RulesetsReconcileMode(desired.Reconcile) == manifest.CollectionReconcileMirror {
+	if manifest.RulesetsReconcileMode(desired.Reconcile) == manifest.CollectionReconcileAuthoritative {
 		for rulesetName, crs := range current.Rulesets {
 			if _, ok := desiredNames[rulesetName]; ok {
 				continue
@@ -494,7 +494,7 @@ func diffRulesets(ctx context.Context, name string, desired *manifest.Repository
 				Name:     name,
 				Field:    "ruleset",
 				OldValue: crs.ID,
-				NewValue: "not declared; reconcile.rulesets=mirror",
+				NewValue: "not declared; reconcile.rulesets=authoritative",
 				Children: rsDeleteChildren(crs),
 			})
 		}

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -798,9 +798,9 @@ func TestDiff_BranchProtection(t *testing.T) {
 		}
 	})
 
-	t.Run("mirror deletes undeclared branch protection", func(t *testing.T) {
+	t.Run("authoritative deletes undeclared branch protection", func(t *testing.T) {
 		d := baseDesired()
-		mode := manifest.CollectionReconcileMirror
+		mode := manifest.CollectionReconcileAuthoritative
 		d.Reconcile = &manifest.RepositoryReconcile{BranchProtection: &mode}
 		c := baseState()
 		c.BranchProtection["main"] = &CurrentBranchProtection{Pattern: "main"}
@@ -815,7 +815,7 @@ func TestDiff_BranchProtection(t *testing.T) {
 		if changes[0].Resource != "BranchProtection[main]" {
 			t.Fatalf("resource = %q, want BranchProtection[main]", changes[0].Resource)
 		}
-		if changes[0].NewValue != "not declared; reconcile.branch_protection=mirror" {
+		if changes[0].NewValue != "not declared; reconcile.branch_protection=authoritative" {
 			t.Fatalf("delete reason = %v", changes[0].NewValue)
 		}
 		if len(changes[0].Children) == 0 {
@@ -1606,9 +1606,9 @@ func TestDiff_Rulesets_Noop(t *testing.T) {
 	}
 }
 
-func TestDiff_Rulesets_ReconcileMirrorDeletesUndeclared(t *testing.T) {
+func TestDiff_Rulesets_ReconcileAuthoritativeDeletesUndeclared(t *testing.T) {
 	desired := baseDesired()
-	mode := manifest.CollectionReconcileMirror
+	mode := manifest.CollectionReconcileAuthoritative
 	desired.Reconcile = &manifest.RepositoryReconcile{Rulesets: &mode}
 
 	current := baseState()
@@ -1632,7 +1632,7 @@ func TestDiff_Rulesets_ReconcileMirrorDeletesUndeclared(t *testing.T) {
 	if changes[0].OldValue != 42 {
 		t.Fatalf("old value = %v, want ruleset ID 42", changes[0].OldValue)
 	}
-	if changes[0].NewValue != "not declared; reconcile.rulesets=mirror" {
+	if changes[0].NewValue != "not declared; reconcile.rulesets=authoritative" {
 		t.Fatalf("delete reason = %v", changes[0].NewValue)
 	}
 	if len(changes[0].Children) == 0 {

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -787,6 +787,42 @@ func TestDiff_BranchProtection(t *testing.T) {
 		}
 	})
 
+	t.Run("additive leaves undeclared branch protection untouched", func(t *testing.T) {
+		d := baseDesired()
+		c := baseState()
+		c.BranchProtection["main"] = &CurrentBranchProtection{Pattern: "main"}
+
+		changes := diffBranchProtection("org/repo", d, c)
+		if len(changes) != 0 {
+			t.Fatalf("expected no changes, got %d: %v", len(changes), changes)
+		}
+	})
+
+	t.Run("mirror deletes undeclared branch protection", func(t *testing.T) {
+		d := baseDesired()
+		mode := manifest.CollectionReconcileMirror
+		d.Reconcile = &manifest.RepositoryReconcile{BranchProtection: &mode}
+		c := baseState()
+		c.BranchProtection["main"] = &CurrentBranchProtection{Pattern: "main"}
+
+		changes := diffBranchProtection("org/repo", d, c)
+		if len(changes) != 1 {
+			t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
+		}
+		if changes[0].Type != ChangeDelete {
+			t.Fatalf("change type = %q, want %q", changes[0].Type, ChangeDelete)
+		}
+		if changes[0].Resource != "BranchProtection[main]" {
+			t.Fatalf("resource = %q, want BranchProtection[main]", changes[0].Resource)
+		}
+		if changes[0].NewValue != "not declared; reconcile.branch_protection=mirror" {
+			t.Fatalf("delete reason = %v", changes[0].NewValue)
+		}
+		if len(changes[0].Children) == 0 {
+			t.Fatal("expected display-only delete children")
+		}
+	})
+
 	t.Run("update dismiss_stale_reviews", func(t *testing.T) {
 		d := baseDesired()
 		d.Spec.BranchProtection = []manifest.BranchProtection{
@@ -1567,6 +1603,56 @@ func TestDiff_Rulesets_Noop(t *testing.T) {
 	changes := Diff(context.Background(), desired, current)
 	if len(changes) != 0 {
 		t.Errorf("expected no changes, got %d: %v", len(changes), changes)
+	}
+}
+
+func TestDiff_Rulesets_ReconcileMirrorDeletesUndeclared(t *testing.T) {
+	desired := baseDesired()
+	mode := manifest.CollectionReconcileMirror
+	desired.Reconcile = &manifest.RepositoryReconcile{Rulesets: &mode}
+
+	current := baseState()
+	current.Rulesets["old-ruleset"] = &CurrentRuleset{
+		ID:          42,
+		Name:        "old-ruleset",
+		Target:      "branch",
+		Enforcement: "active",
+	}
+
+	changes := Diff(context.Background(), desired, current)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
+	}
+	if changes[0].Type != ChangeDelete {
+		t.Fatalf("change type = %q, want %q", changes[0].Type, ChangeDelete)
+	}
+	if changes[0].Resource != "Ruleset[old-ruleset]" {
+		t.Fatalf("resource = %q, want Ruleset[old-ruleset]", changes[0].Resource)
+	}
+	if changes[0].OldValue != 42 {
+		t.Fatalf("old value = %v, want ruleset ID 42", changes[0].OldValue)
+	}
+	if changes[0].NewValue != "not declared; reconcile.rulesets=mirror" {
+		t.Fatalf("delete reason = %v", changes[0].NewValue)
+	}
+	if len(changes[0].Children) == 0 {
+		t.Fatal("expected display-only delete children")
+	}
+}
+
+func TestDiff_Rulesets_AdditiveLeavesUndeclaredUntouched(t *testing.T) {
+	desired := baseDesired()
+	current := baseState()
+	current.Rulesets["old-ruleset"] = &CurrentRuleset{
+		ID:          42,
+		Name:        "old-ruleset",
+		Target:      "branch",
+		Enforcement: "active",
+	}
+
+	changes := Diff(context.Background(), desired, current)
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes, got %d: %v", len(changes), changes)
 	}
 }
 

--- a/skills/repository-manifest/SKILL.md
+++ b/skills/repository-manifest/SKILL.md
@@ -26,6 +26,8 @@ kind: Repository
 metadata:
   owner: my-org
   name: my-repo
+reconcile:           # optional; controls collection reconciliation
+  rulesets: additive # additive (default) | authoritative
 spec:
   # declare only managed fields
 ```
@@ -50,6 +52,8 @@ metadata:
   owner: my-org
 
 defaults:
+  reconcile:
+    rulesets: authoritative
   spec:
     visibility: public
     features:
@@ -98,6 +102,8 @@ Read [references/repository-set.md](./references/repository-set.md) for the exac
 
 - `actions.enabled` is required when setting any other `actions.*` field
 - `actions.selected_actions` is valid only with `allowed_actions: selected`
+- `reconcile.rulesets: authoritative` and `reconcile.branch_protection: authoritative` delete undeclared remote entries; review `plan` carefully
+- `reconcile` without a corresponding `spec` collection is a parse error
 - `label_sync: mirror` deletes unmanaged labels; review `plan` carefully
 - for `gh infra import --into`, use the dedicated `import-into` skill
 - Repository deletion is not supported

--- a/skills/repository-manifest/references/protection.md
+++ b/skills/repository-manifest/references/protection.md
@@ -1,5 +1,32 @@
 # Protection
 
+## Reconcile
+
+Collections (`rulesets`, `branch_protection`) are additive by default. Use top-level `reconcile` to opt into authoritative mode, which deletes remote entries not declared in YAML.
+
+```yaml
+reconcile:
+  rulesets: authoritative
+  branch_protection: additive
+
+spec:
+  rulesets:
+    - name: protect-main
+      ...
+```
+
+Modes:
+
+- `additive` (default): create/update declared entries; undeclared remote entries are left untouched
+- `authoritative`: YAML is the source of truth; undeclared remote entries are deleted
+
+Rules:
+
+- `reconcile` without the corresponding `spec` collection is a parse error (e.g., `reconcile.rulesets: authoritative` requires `spec.rulesets`)
+- Use `spec.rulesets: []` with `reconcile.rulesets: authoritative` to delete all remote rulesets
+- `rulesets: null` / `rulesets:` (explicit null) is invalid; use `[]` for empty managed collections
+- `plan` output shows delete reason with the reconcile policy (e.g., `not declared; reconcile.rulesets=authoritative`)
+
 ## Rulesets
 
 Prefer `rulesets` for new configurations.

--- a/skills/repository-manifest/references/repository-set.md
+++ b/skills/repository-manifest/references/repository-set.md
@@ -8,14 +8,21 @@ kind: RepositorySet
 metadata:
   owner: my-org
 defaults:
+  reconcile:
+    rulesets: authoritative
   spec:
     visibility: public
     features:
       wiki: false
+    rulesets:
+      - name: protect-main
 repositories:
   - name: repo-a
     spec:
       description: "Repo A"
+  - name: repo-b
+    reconcile:
+      rulesets: additive
 ```
 
 ## Merge Rules
@@ -23,6 +30,7 @@ repositories:
 - Scalars: replaced
 - Lists: replaced entirely
 - Maps: merged by key
+- Reconcile: merged by collection (per-repo overrides individual collections without resetting others)
 
 Examples:
 


### PR DESCRIPTION
## Summary

Introduce a top-level `reconcile` block for Repository and RepositorySet resources, enabling users to choose between additive (default) and authoritative reconciliation modes for `rulesets` and `branch_protection` collections. This implements the design described in ADR-005.

## Background

gh-infra is stateless — it has no state file to track what was previously declared. This means it cannot infer that a resource removed from YAML should be deleted from GitHub. Collections like rulesets and branch protection rules have always been managed additively: gh-infra creates/updates declared entries but never deletes undeclared ones. ADR-003 and ADR-004 explored `field: null` deletion markers but were rejected. A more general reconciliation policy is needed to let users opt into exact-set management where remote entries not listed in YAML are deleted.

The mode name `authoritative` follows established IaC terminology (Terraform's authoritative IAM bindings, Puppet's authoritative catalog) and avoids confusion with Git mirror/repo mirroring.

## Changes

- **ADR-005**: Record the accepted design for collection reconciliation policy with additive/authoritative modes and alternatives considered
- **Schema**: Add `RepositoryReconcile` struct with `branch_protection` and `rulesets` fields; add `Reconcile` field to `Repository`, `RepositorySetDefaults`, and `RepositorySetEntry`
- **Field presence tracking**: Add `BranchProtectionSet` / `RulesetsSet` flags via custom `UnmarshalYAML` on `RepositorySpec`; reject explicit null (`rulesets:` / `rulesets: null`) as invalid
- **Validation**: Reject reconcile policies that target omitted spec collections (e.g., `reconcile.rulesets: authoritative` without `spec.rulesets`)
- **Merge logic**: `mergeReconcile()` merges defaults and per-repo reconcile overrides in RepositorySet; `mergeSpecs()` updated to use `*Set` flags instead of `len() > 0`
- **Diff**: In authoritative mode, generate `ChangeDelete` for remote rulesets/branch-protection rules not declared in YAML, with display-only children showing current values
- **Apply**: Handle `ChangeDelete` for rulesets (`DELETE /repos/{owner}/{repo}/rulesets/{id}`) and branch protection (`DELETE /repos/{owner}/{repo}/branches/{pattern}/protection`); skip child expansion for delete changes
- **Docs**: Update repository, rulesets, branch-protection, and repository-set defaults docs with reconcile mode documentation
- **Skills**: Add reconcile documentation to repository-manifest skill references (protection.md, repository-set.md, SKILL.md)
- **Tests**: Comprehensive test coverage for validation, parsing, reconcile merge, authoritative deletes, additive no-ops, and apply delete operations