### PR TITLE
Split Change.Details from Change.Children

### DIFF
--- a/internal/infra/format.go
+++ b/internal/infra/format.go
@@ -303,8 +303,8 @@ func repoChangesToDiffGroups(changes []repository.Change) []ui.DiffGroup {
 				Icon:   groupIcon(g.changes),
 			}
 			for _, c := range g.changes {
-				if len(c.Children) > 0 {
-					for _, child := range c.Children {
+				if len(c.Details) > 0 {
+					for _, child := range c.Details {
 						item := changeToDiffItem(child)
 						item.Field = c.Field + "." + child.Field
 						dg.Items = append(dg.Items, item)
@@ -316,7 +316,7 @@ func repoChangesToDiffGroups(changes []repository.Change) []ui.DiffGroup {
 			result = append(result, dg)
 		} else {
 			c := g.changes[0]
-			if len(c.Children) > 0 {
+			if len(c.Details) > 0 {
 				var icon string
 				switch c.Type {
 				case repository.ChangeCreate:
@@ -328,7 +328,7 @@ func repoChangesToDiffGroups(changes []repository.Change) []ui.DiffGroup {
 				}
 				header := repoChangeGroupHeader(c)
 				dg := ui.DiffGroup{Header: header, Icon: icon}
-				for _, child := range c.Children {
+				for _, child := range c.Details {
 					dg.Items = append(dg.Items, changeToDiffItem(child))
 				}
 				result = append(result, dg)
@@ -387,8 +387,8 @@ func changeToDiffItem(c repository.Change) ui.DiffItem {
 func repoFieldWidth(changes []repository.Change) int {
 	w := 0
 	for _, c := range changes {
-		if len(c.Children) > 0 {
-			for _, child := range c.Children {
+		if len(c.Details) > 0 {
+			for _, child := range c.Details {
 				if len(child.Field) > w {
 					w = len(child.Field)
 				}

--- a/internal/infra/format_test.go
+++ b/internal/infra/format_test.go
@@ -127,7 +127,7 @@ func TestPrintPlan_ChildChanges(t *testing.T) {
 			Type:  repository.ChangeUpdate,
 			Name:  "org/repo",
 			Field: "features",
-			Children: []repository.Change{
+			Details: []repository.Change{
 				{Type: repository.ChangeUpdate, Field: "issues", OldValue: true, NewValue: false},
 				{Type: repository.ChangeUpdate, Field: "wiki", OldValue: false, NewValue: true},
 			},
@@ -229,7 +229,7 @@ func TestRepoFieldWidth_Children(t *testing.T) {
 	changes := []repository.Change{
 		{
 			Field: "features",
-			Children: []repository.Change{
+			Details: []repository.Change{
 				{Field: "short"},
 				{Field: "very_long_child_field_name"},
 			},
@@ -392,7 +392,7 @@ func TestGroupRepoChanges_PreservesOrder(t *testing.T) {
 		{Resource: manifest.ResourceLabel, Field: "bug"},
 		{Resource: manifest.ResourceLabel, Field: "feature"},
 		{Resource: manifest.ResourceMilestone, Field: "v1.0"},
-		{Resource: "Actions", Field: "actions", Children: []repository.Change{{Field: "enabled"}}},
+		{Resource: "Actions", Field: "actions", Details: []repository.Change{{Field: "enabled"}}},
 	}
 	groups := groupRepoChanges(changes)
 	if len(groups) != 4 {
@@ -526,7 +526,7 @@ func TestPrintPlan_GroupedLabelUpdate(t *testing.T) {
 			Resource: manifest.ResourceLabel,
 			Name:     "org/repo",
 			Field:    "bug",
-			Children: []repository.Change{
+			Details: []repository.Change{
 				{Type: repository.ChangeUpdate, Field: "color", OldValue: "d73a4a", NewValue: "FF0000"},
 			},
 		},
@@ -555,7 +555,7 @@ func TestPrintPlan_RulesetAndBranchProtectionHeaders(t *testing.T) {
 			Name:     "org/repo",
 			Field:    "ruleset",
 			NewValue: "main-protection",
-			Children: []repository.Change{
+			Details: []repository.Change{
 				{Type: repository.ChangeUpdate, Field: "enforcement", OldValue: "evaluate", NewValue: "active"},
 			},
 		},
@@ -565,7 +565,7 @@ func TestPrintPlan_RulesetAndBranchProtectionHeaders(t *testing.T) {
 			Name:     "org/repo",
 			Field:    "branch_protection",
 			NewValue: "main",
-			Children: []repository.Change{
+			Details: []repository.Change{
 				{Type: repository.ChangeUpdate, Field: "required_reviews", OldValue: 0, NewValue: 1},
 			},
 		},
@@ -596,7 +596,7 @@ func TestPrintPlan_DeleteRulesetAndBranchProtectionWithChildren(t *testing.T) {
 			Name:     "org/repo",
 			Field:    "ruleset",
 			OldValue: 42,
-			Children: []repository.Change{
+			Details: []repository.Change{
 				{Type: repository.ChangeDelete, Field: "target", OldValue: "branch"},
 				{Type: repository.ChangeDelete, Field: "enforcement", OldValue: "active"},
 			},
@@ -607,7 +607,7 @@ func TestPrintPlan_DeleteRulesetAndBranchProtectionWithChildren(t *testing.T) {
 			Name:     "org/repo",
 			Field:    "branch_protection",
 			OldValue: "main",
-			Children: []repository.Change{
+			Details: []repository.Change{
 				{Type: repository.ChangeDelete, Field: "required_reviews", OldValue: 1},
 				{Type: repository.ChangeDelete, Field: "enforce_admins", OldValue: false},
 			},

--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -139,10 +139,9 @@ func (p *Processor) applyChange(ctx context.Context, c Change, repo *manifest.Re
 		return p.applyMergeStrategyBatch(ctx, c)
 	}
 
-	// Generic: if this change has children, expand and apply each child.
-	// Label and Milestone updates carry children for display (e.g. color, description)
-	// but should be applied as a single API call using the parent's Field (the name/title).
-	if len(c.Children) > 0 && c.Type != ChangeDelete && c.Resource != manifest.ResourceLabel && c.Resource != manifest.ResourceMilestone {
+	// Generic: Children are concrete apply units. Details are display-only plan
+	// information and must not be interpreted as API work.
+	if len(c.Children) > 0 && c.Type != ChangeDelete {
 		for _, child := range c.Children {
 			child.Resource = c.Resource
 			child.Name = c.Name

--- a/internal/repository/apply_test.go
+++ b/internal/repository/apply_test.go
@@ -592,6 +592,40 @@ func TestApplyBranchProtection_Delete(t *testing.T) {
 	}
 }
 
+func TestApplyBranchProtection_ChildrenAreDisplayOnly(t *testing.T) {
+	mock := &gh.MockRunner{}
+	proc := NewProcessor(mock, nil)
+
+	reviews := 2
+	repo := newTestRepo("myorg", "myrepo")
+	repo.Spec.BranchProtection = []manifest.BranchProtection{
+		{Pattern: "main", RequiredReviews: &reviews},
+	}
+
+	changes := []Change{
+		{
+			Type:     ChangeUpdate,
+			Resource: "BranchProtection[main]",
+			Name:     "myorg/myrepo",
+			Field:    "branch_protection",
+			Details: []Change{
+				{Type: ChangeUpdate, Field: "required_reviews", OldValue: 1, NewValue: 2},
+			},
+		},
+	}
+
+	results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("unexpected error: %v", results[0].Err)
+	}
+	if len(mock.Called) != 1 {
+		t.Fatalf("expected parent change to be applied once, got %d calls: %v", len(mock.Called), mock.Called)
+	}
+}
+
 func TestBuildBranchProtectionPayload(t *testing.T) {
 	reviews := 2
 	dismissStale := true
@@ -1178,6 +1212,11 @@ func TestApplyMergeStrategyBatch(t *testing.T) {
 			Resource: "Repository",
 			Name:     "myorg/myrepo",
 			Field:    "merge_strategy",
+			Details: []Change{
+				{Field: "allow_squash_merge", NewValue: true},
+				{Field: "squash_merge_commit_title", NewValue: "PR_TITLE"},
+				{Field: "auto_delete_head_branches", NewValue: true},
+			},
 			Children: []Change{
 				{Field: "allow_squash_merge", NewValue: true},
 				{Field: "squash_merge_commit_title", NewValue: "PR_TITLE"},
@@ -1600,7 +1639,7 @@ func TestApplyLabel_UpdateWithChildren(t *testing.T) {
 			Resource: manifest.ResourceLabel,
 			Name:     "myorg/myrepo",
 			Field:    "enhancement",
-			Children: []Change{
+			Details: []Change{
 				{Type: ChangeUpdate, Field: "color", OldValue: "a2eeef", NewValue: "eeeeee"},
 			},
 		},
@@ -1638,7 +1677,7 @@ func TestApplyMilestone_UpdateWithChildren(t *testing.T) {
 			Resource: manifest.ResourceMilestone,
 			Name:     "myorg/myrepo",
 			Field:    "v1.0",
-			Children: []Change{
+			Details: []Change{
 				{Type: ChangeUpdate, Field: "due_on", OldValue: "2026-05-31", NewValue: "2026-06-01"},
 			},
 		},

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -57,6 +57,27 @@ func appendIfSet[T any](children *[]Change, field string, val *T) {
 	}
 }
 
+type deleteField[T any] struct {
+	Field string
+	Value func(T) (any, bool)
+}
+
+func deleteChildrenFromFields[T any](v T, fields []deleteField[T]) []Change {
+	children := make([]Change, 0, len(fields))
+	for _, field := range fields {
+		value, ok := field.Value(v)
+		if !ok {
+			continue
+		}
+		children = append(children, Change{
+			Type:     ChangeDelete,
+			Field:    field.Field,
+			OldValue: value,
+		})
+	}
+	return children
+}
+
 // group collects child changes and wraps them in a parent Change if non-empty.
 func (dc diffContext) group(field string, childFn func(cc *[]Change)) []Change {
 	var children []Change
@@ -69,6 +90,7 @@ func (dc diffContext) group(field string, childFn func(cc *[]Change)) []Change {
 		Resource: dc.resource,
 		Name:     dc.name,
 		Field:    field,
+		Details:  children,
 		Children: children,
 	}}
 }
@@ -265,7 +287,7 @@ func diffBranchProtection(name string, desired *manifest.Repository, current *Cu
 				Name:     name,
 				Field:    "branch_protection",
 				NewValue: dbp.Pattern,
-				Children: children,
+				Details:  children,
 			})
 			continue
 		}
@@ -313,7 +335,7 @@ func diffBranchProtection(name string, desired *manifest.Repository, current *Cu
 				Name:     name,
 				Field:    "branch_protection",
 				NewValue: dbp.Pattern,
-				Children: fieldChanges,
+				Details:  fieldChanges,
 			})
 		}
 	}
@@ -330,7 +352,7 @@ func diffBranchProtection(name string, desired *manifest.Repository, current *Cu
 				Field:    "branch_protection",
 				OldValue: pattern,
 				NewValue: "not declared; reconcile.branch_protection=authoritative",
-				Children: bpDeleteChildren(cbp),
+				Details:  bpDeleteChildren(cbp),
 			})
 		}
 	}
@@ -384,7 +406,7 @@ func diffRulesets(ctx context.Context, name string, desired *manifest.Repository
 				Name:     name,
 				Field:    "ruleset",
 				NewValue: drs.Name,
-				Children: children,
+				Details:  children,
 			})
 			continue
 		}
@@ -478,7 +500,7 @@ func diffRulesets(ctx context.Context, name string, desired *manifest.Repository
 				Name:     name,
 				Field:    "ruleset",
 				NewValue: drs.Name,
-				Children: fieldChanges,
+				Details:  fieldChanges,
 			})
 		}
 	}
@@ -495,7 +517,7 @@ func diffRulesets(ctx context.Context, name string, desired *manifest.Repository
 				Field:    "ruleset",
 				OldValue: crs.ID,
 				NewValue: "not declared; reconcile.rulesets=authoritative",
-				Children: rsDeleteChildren(crs),
+				Details:  rsDeleteChildren(crs),
 			})
 		}
 	}
@@ -585,75 +607,96 @@ func rulesetStatusChecksEqual(ctx context.Context, desired []manifest.RulesetSta
 // a branch protection rule that is about to be deleted. applyChange must not
 // expand these children into separate API calls.
 func bpDeleteChildren(cbp *CurrentBranchProtection) []Change {
-	children := []Change{
-		{Type: ChangeDelete, Field: "required_reviews", OldValue: cbp.RequiredReviews},
-		{Type: ChangeDelete, Field: "dismiss_stale_reviews", OldValue: cbp.DismissStaleReviews},
-		{Type: ChangeDelete, Field: "require_code_owner_reviews", OldValue: cbp.RequireCodeOwnerReviews},
-		{Type: ChangeDelete, Field: "enforce_admins", OldValue: cbp.EnforceAdmins},
-		{Type: ChangeDelete, Field: "allow_force_pushes", OldValue: cbp.AllowForcePushes},
-		{Type: ChangeDelete, Field: "allow_deletions", OldValue: cbp.AllowDeletions},
-	}
-	if cbp.RequireStatusChecks != nil {
-		children = append(children, Change{
-			Type:     ChangeDelete,
-			Field:    "require_status_checks.strict",
-			OldValue: cbp.RequireStatusChecks.Strict,
-		})
-		if len(cbp.RequireStatusChecks.Contexts) > 0 {
-			children = append(children, Change{
-				Type:     ChangeDelete,
-				Field:    "require_status_checks.contexts",
-				OldValue: cbp.RequireStatusChecks.Contexts,
-			})
-		}
-	}
-	return children
+	return deleteChildrenFromFields(cbp, branchProtectionDeleteFields)
 }
 
 // rsDeleteChildren builds display-only children showing the current values of
 // a ruleset that is about to be deleted. applyChange must not expand these
 // children into separate API calls.
 func rsDeleteChildren(rs *CurrentRuleset) []Change {
-	children := []Change{
-		{Type: ChangeDelete, Field: "target", OldValue: rs.Target},
-		{Type: ChangeDelete, Field: "enforcement", OldValue: rs.Enforcement},
-	}
-	if len(rs.BypassActors) > 0 {
-		children = append(children, Change{
-			Type:     ChangeDelete,
-			Field:    "bypass_actors",
-			OldValue: fmt.Sprintf("%d actors", len(rs.BypassActors)),
-		})
-	}
-	if rs.Conditions != nil && rs.Conditions.RefName != nil {
-		children = append(children, Change{
-			Type:     ChangeDelete,
-			Field:    "conditions",
-			OldValue: formatConditions(rs.Conditions.RefName.Include, rs.Conditions.RefName.Exclude),
-		})
-	}
-	if rs.Rules.NonFastForward {
-		children = append(children, Change{Type: ChangeDelete, Field: "rules.non_fast_forward", OldValue: true})
-	}
-	if rs.Rules.Deletion {
-		children = append(children, Change{Type: ChangeDelete, Field: "rules.deletion", OldValue: true})
-	}
-	if rs.Rules.Creation {
-		children = append(children, Change{Type: ChangeDelete, Field: "rules.creation", OldValue: true})
-	}
-	if rs.Rules.RequiredLinearHistory {
-		children = append(children, Change{Type: ChangeDelete, Field: "rules.required_linear_history", OldValue: true})
-	}
-	if rs.Rules.RequiredSignatures {
-		children = append(children, Change{Type: ChangeDelete, Field: "rules.required_signatures", OldValue: true})
-	}
-	if rs.Rules.PullRequest != nil {
-		children = append(children, Change{Type: ChangeDelete, Field: "rules.pull_request", OldValue: "enabled"})
-	}
-	if rs.Rules.RequiredStatusChecks != nil {
-		children = append(children, Change{Type: ChangeDelete, Field: "rules.required_status_checks", OldValue: "enabled"})
-	}
-	return children
+	return deleteChildrenFromFields(rs, rulesetDeleteFields)
+}
+
+var branchProtectionDeleteFields = []deleteField[*CurrentBranchProtection]{
+	{Field: "required_reviews", Value: func(bp *CurrentBranchProtection) (any, bool) { return bp.RequiredReviews, true }},
+	{Field: "dismiss_stale_reviews", Value: func(bp *CurrentBranchProtection) (any, bool) { return bp.DismissStaleReviews, true }},
+	{Field: "require_code_owner_reviews", Value: func(bp *CurrentBranchProtection) (any, bool) { return bp.RequireCodeOwnerReviews, true }},
+	{Field: "enforce_admins", Value: func(bp *CurrentBranchProtection) (any, bool) { return bp.EnforceAdmins, true }},
+	{Field: "allow_force_pushes", Value: func(bp *CurrentBranchProtection) (any, bool) { return bp.AllowForcePushes, true }},
+	{Field: "allow_deletions", Value: func(bp *CurrentBranchProtection) (any, bool) { return bp.AllowDeletions, true }},
+	{
+		Field: "require_status_checks.strict",
+		Value: func(bp *CurrentBranchProtection) (any, bool) {
+			if bp.RequireStatusChecks == nil {
+				return nil, false
+			}
+			return bp.RequireStatusChecks.Strict, true
+		},
+	},
+	{
+		Field: "require_status_checks.contexts",
+		Value: func(bp *CurrentBranchProtection) (any, bool) {
+			if bp.RequireStatusChecks == nil || len(bp.RequireStatusChecks.Contexts) == 0 {
+				return nil, false
+			}
+			return bp.RequireStatusChecks.Contexts, true
+		},
+	},
+}
+
+var rulesetDeleteFields = []deleteField[*CurrentRuleset]{
+	{Field: "target", Value: func(rs *CurrentRuleset) (any, bool) { return rs.Target, true }},
+	{Field: "enforcement", Value: func(rs *CurrentRuleset) (any, bool) { return rs.Enforcement, true }},
+	{
+		Field: "bypass_actors",
+		Value: func(rs *CurrentRuleset) (any, bool) {
+			if len(rs.BypassActors) == 0 {
+				return nil, false
+			}
+			return fmt.Sprintf("%d actors", len(rs.BypassActors)), true
+		},
+	},
+	{
+		Field: "conditions",
+		Value: func(rs *CurrentRuleset) (any, bool) {
+			if rs.Conditions == nil || rs.Conditions.RefName == nil {
+				return nil, false
+			}
+			return formatConditions(rs.Conditions.RefName.Include, rs.Conditions.RefName.Exclude), true
+		},
+	},
+	{
+		Field: "rules.non_fast_forward",
+		Value: func(rs *CurrentRuleset) (any, bool) { return true, rs.Rules.NonFastForward },
+	},
+	{
+		Field: "rules.deletion",
+		Value: func(rs *CurrentRuleset) (any, bool) { return true, rs.Rules.Deletion },
+	},
+	{
+		Field: "rules.creation",
+		Value: func(rs *CurrentRuleset) (any, bool) { return true, rs.Rules.Creation },
+	},
+	{
+		Field: "rules.required_linear_history",
+		Value: func(rs *CurrentRuleset) (any, bool) { return true, rs.Rules.RequiredLinearHistory },
+	},
+	{
+		Field: "rules.required_signatures",
+		Value: func(rs *CurrentRuleset) (any, bool) { return true, rs.Rules.RequiredSignatures },
+	},
+	{
+		Field: "rules.pull_request",
+		Value: func(rs *CurrentRuleset) (any, bool) {
+			return "enabled", rs.Rules.PullRequest != nil
+		},
+	},
+	{
+		Field: "rules.required_status_checks",
+		Value: func(rs *CurrentRuleset) (any, bool) {
+			return "enabled", rs.Rules.RequiredStatusChecks != nil
+		},
+	},
 }
 
 func statusCheckContexts(checks []CurrentRulesetStatusCheck) []string {
@@ -774,7 +817,7 @@ func diffLabels(name string, desired *manifest.Repository, current *CurrentState
 				Resource: manifest.ResourceLabel,
 				Name:     name,
 				Field:    dl.Name,
-				Children: children,
+				Details:  children,
 			})
 		}
 	}
@@ -857,7 +900,7 @@ func diffMilestones(name string, desired *manifest.Repository, current *CurrentS
 				Resource: manifest.ResourceMilestone,
 				Name:     name,
 				Field:    dm.Title,
-				Children: children,
+				Details:  children,
 			})
 		}
 	}

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -230,12 +230,19 @@ func TestDiff_Features_BoolFlags(t *testing.T) {
 			if parent.Field != "features" {
 				t.Fatalf("expected parent field features, got %q", parent.Field)
 			}
-			if len(parent.Children) != 1 {
-				t.Fatalf("expected 1 child, got %d", len(parent.Children))
+			if len(parent.Details) != 1 {
+				t.Fatalf("expected 1 child, got %d", len(parent.Details))
 			}
-			child := parent.Children[0]
+			if len(parent.Children) != 1 {
+				t.Fatalf("expected 1 apply child, got %d", len(parent.Children))
+			}
+			child := parent.Details[0]
+			applyChild := parent.Children[0]
 			if child.Field != tt.wantField {
 				t.Errorf("expected field %q, got %q", tt.wantField, child.Field)
+			}
+			if applyChild.Field != tt.wantField {
+				t.Errorf("expected apply field %q, got %q", tt.wantField, applyChild.Field)
 			}
 			if child.Type != ChangeUpdate {
 				t.Errorf("expected update, got %q", child.Type)
@@ -318,10 +325,10 @@ func TestDiff_MergeStrategy_BoolFlags(t *testing.T) {
 			if parent.Field != "merge_strategy" {
 				t.Fatalf("expected parent field merge_strategy, got %q", parent.Field)
 			}
-			if len(parent.Children) != 1 {
-				t.Fatalf("expected 1 child, got %d", len(parent.Children))
+			if len(parent.Details) != 1 {
+				t.Fatalf("expected 1 child, got %d", len(parent.Details))
 			}
-			child := parent.Children[0]
+			child := parent.Details[0]
 			if child.Field != tt.wantField {
 				t.Errorf("expected field %q, got %q", tt.wantField, child.Field)
 			}
@@ -530,10 +537,10 @@ func TestDiff_Security(t *testing.T) {
 			if changes[0].Field != "security" {
 				t.Errorf("expected parent field 'security', got %q", changes[0].Field)
 			}
-			if len(changes[0].Children) != 1 {
-				t.Fatalf("expected 1 child, got %d", len(changes[0].Children))
+			if len(changes[0].Details) != 1 {
+				t.Fatalf("expected 1 child, got %d", len(changes[0].Details))
 			}
-			child := changes[0].Children[0]
+			child := changes[0].Details[0]
 			if child.Field != f.field {
 				t.Errorf("expected child field %q, got %q", f.field, child.Field)
 			}
@@ -556,7 +563,7 @@ func TestDiff_Security(t *testing.T) {
 		if len(changes) != 1 {
 			t.Fatalf("expected 1 parent change, got %d", len(changes))
 		}
-		if got := len(changes[0].Children); got != 3 {
+		if got := len(changes[0].Details); got != 3 {
 			t.Errorf("expected 3 children, got %d", got)
 		}
 	})
@@ -588,7 +595,7 @@ func TestDiff_Features_PullRequests(t *testing.T) {
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change, got %d", len(changes))
 	}
-	child := changes[0].Children
+	child := changes[0].Details
 	if len(child) != 1 || child[0].Field != "pull_requests" {
 		t.Errorf("expected pull_requests child change, got %+v", child)
 	}
@@ -610,7 +617,7 @@ func TestDiff_Features_PullRequestsCreation(t *testing.T) {
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change, got %d", len(changes))
 	}
-	child := changes[0].Children
+	child := changes[0].Details
 	if len(child) != 1 || child[0].Field != "pull_requests.creation" {
 		t.Errorf("expected pull_requests.creation child change, got %+v", child)
 	}
@@ -695,10 +702,10 @@ func TestDiff_MergeStrategy_CommitStrings(t *testing.T) {
 			if parent.Field != "merge_strategy" {
 				t.Fatalf("expected parent field merge_strategy, got %q", parent.Field)
 			}
-			if len(parent.Children) != 1 {
-				t.Fatalf("expected 1 child, got %d", len(parent.Children))
+			if len(parent.Details) != 1 {
+				t.Fatalf("expected 1 child, got %d", len(parent.Details))
 			}
-			ch := parent.Children[0]
+			ch := parent.Details[0]
 			if ch.Field != tt.wantField {
 				t.Errorf("expected field %q, got %q", tt.wantField, ch.Field)
 			}
@@ -730,20 +737,20 @@ func TestDiff_BranchProtection(t *testing.T) {
 		if changes[0].Resource != "BranchProtection[main]" {
 			t.Errorf("expected resource BranchProtection[main], got %q", changes[0].Resource)
 		}
-		if len(changes[0].Children) != 2 {
-			t.Fatalf("expected 2 children (pattern + required_reviews), got %d", len(changes[0].Children))
+		if len(changes[0].Details) != 2 {
+			t.Fatalf("expected 2 children (pattern + required_reviews), got %d", len(changes[0].Details))
 		}
-		if changes[0].Children[0].Field != "pattern" {
-			t.Errorf("expected first child field pattern, got %q", changes[0].Children[0].Field)
+		if changes[0].Details[0].Field != "pattern" {
+			t.Errorf("expected first child field pattern, got %q", changes[0].Details[0].Field)
 		}
-		if changes[0].Children[0].NewValue != "main" {
-			t.Errorf("expected pattern value main, got %v", changes[0].Children[0].NewValue)
+		if changes[0].Details[0].NewValue != "main" {
+			t.Errorf("expected pattern value main, got %v", changes[0].Details[0].NewValue)
 		}
-		if changes[0].Children[1].Field != "required_reviews" {
-			t.Errorf("expected second child field required_reviews, got %q", changes[0].Children[1].Field)
+		if changes[0].Details[1].Field != "required_reviews" {
+			t.Errorf("expected second child field required_reviews, got %q", changes[0].Details[1].Field)
 		}
-		if changes[0].Children[1].NewValue != 2 {
-			t.Errorf("expected child new value 2, got %v", changes[0].Children[1].NewValue)
+		if changes[0].Details[1].NewValue != 2 {
+			t.Errorf("expected child new value 2, got %v", changes[0].Details[1].NewValue)
 		}
 	})
 
@@ -757,12 +764,12 @@ func TestDiff_BranchProtection(t *testing.T) {
 		if parent.Field != "branch_protection" {
 			t.Fatalf("expected parent field branch_protection, got %q", parent.Field)
 		}
-		for _, child := range parent.Children {
+		for _, child := range parent.Details {
 			if child.Field == field {
 				return child
 			}
 		}
-		t.Fatalf("child field %q not found in %d children", field, len(parent.Children))
+		t.Fatalf("child field %q not found in %d children", field, len(parent.Details))
 		return Change{}
 	}
 
@@ -818,7 +825,7 @@ func TestDiff_BranchProtection(t *testing.T) {
 		if changes[0].NewValue != "not declared; reconcile.branch_protection=authoritative" {
 			t.Fatalf("delete reason = %v", changes[0].NewValue)
 		}
-		if len(changes[0].Children) == 0 {
+		if len(changes[0].Details) == 0 {
 			t.Fatal("expected display-only delete children")
 		}
 	})
@@ -1143,11 +1150,11 @@ func TestDiff_Labels(t *testing.T) {
 		if changes[0].Type != ChangeUpdate {
 			t.Errorf("expected update, got %q", changes[0].Type)
 		}
-		if len(changes[0].Children) != 1 {
-			t.Fatalf("expected 1 child, got %d", len(changes[0].Children))
+		if len(changes[0].Details) != 1 {
+			t.Fatalf("expected 1 child, got %d", len(changes[0].Details))
 		}
-		if changes[0].Children[0].Field != "color" {
-			t.Errorf("expected child field color, got %q", changes[0].Children[0].Field)
+		if changes[0].Details[0].Field != "color" {
+			t.Errorf("expected child field color, got %q", changes[0].Details[0].Field)
 		}
 	})
 
@@ -1163,11 +1170,11 @@ func TestDiff_Labels(t *testing.T) {
 		if len(changes) != 1 {
 			t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
 		}
-		if len(changes[0].Children) != 1 {
-			t.Fatalf("expected 1 child, got %d", len(changes[0].Children))
+		if len(changes[0].Details) != 1 {
+			t.Fatalf("expected 1 child, got %d", len(changes[0].Details))
 		}
-		if changes[0].Children[0].Field != "description" {
-			t.Errorf("expected child field description, got %q", changes[0].Children[0].Field)
+		if changes[0].Details[0].Field != "description" {
+			t.Errorf("expected child field description, got %q", changes[0].Details[0].Field)
 		}
 	})
 
@@ -1308,8 +1315,8 @@ func TestDiff_Milestones(t *testing.T) {
 		if changes[0].Type != ChangeUpdate {
 			t.Errorf("expected update, got %s", changes[0].Type)
 		}
-		if len(changes[0].Children) != 1 || changes[0].Children[0].Field != "state" {
-			t.Errorf("expected state child change, got %v", changes[0].Children)
+		if len(changes[0].Details) != 1 || changes[0].Details[0].Field != "state" {
+			t.Errorf("expected state child change, got %v", changes[0].Details)
 		}
 	})
 
@@ -1325,8 +1332,8 @@ func TestDiff_Milestones(t *testing.T) {
 		if len(changes) != 1 {
 			t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
 		}
-		if len(changes[0].Children) != 1 || changes[0].Children[0].Field != "due_on" {
-			t.Errorf("expected due_on child change, got %v", changes[0].Children)
+		if len(changes[0].Details) != 1 || changes[0].Details[0].Field != "due_on" {
+			t.Errorf("expected due_on child change, got %v", changes[0].Details)
 		}
 	})
 
@@ -1533,7 +1540,7 @@ func TestStringSliceEqual(t *testing.T) {
 func collectChildFields(changes []Change) map[string]bool {
 	fields := make(map[string]bool)
 	for _, c := range changes {
-		for _, child := range c.Children {
+		for _, child := range c.Details {
 			fields[child.Field] = true
 		}
 	}
@@ -1635,7 +1642,7 @@ func TestDiff_Rulesets_ReconcileAuthoritativeDeletesUndeclared(t *testing.T) {
 	if changes[0].NewValue != "not declared; reconcile.rulesets=authoritative" {
 		t.Fatalf("delete reason = %v", changes[0].NewValue)
 	}
-	if len(changes[0].Children) == 0 {
+	if len(changes[0].Details) == 0 {
 		t.Fatal("expected display-only delete children")
 	}
 }
@@ -1679,7 +1686,7 @@ func TestDiff_Rulesets_UpdateEnforcement(t *testing.T) {
 	}
 	// Verify values
 	for _, c := range changes {
-		for _, child := range c.Children {
+		for _, child := range c.Details {
 			if child.Field == "enforcement" {
 				if child.OldValue != "active" || child.NewValue != "evaluate" {
 					t.Errorf("enforcement: old=%v new=%v", child.OldValue, child.NewValue)
@@ -2043,7 +2050,7 @@ func TestDiffActions_DetectsChanges(t *testing.T) {
 	}
 
 	fields := make(map[string]bool)
-	for _, c := range actionsChange.Children {
+	for _, c := range actionsChange.Details {
 		fields[c.Field] = true
 	}
 
@@ -2096,7 +2103,7 @@ func TestDiffActions_ChildOrder(t *testing.T) {
 
 	// enabled and allowed_actions should appear before selected_actions.*
 	sawSelected := false
-	for _, c := range actionsChange.Children {
+	for _, c := range actionsChange.Details {
 		if c.Field == "enabled" || c.Field == "allowed_actions" {
 			if sawSelected {
 				t.Errorf("field %q appeared after selected_actions.*", c.Field)

--- a/internal/repository/diff_types.go
+++ b/internal/repository/diff_types.go
@@ -11,15 +11,23 @@ const (
 	ChangeNoOp   ChangeType = "noop"
 )
 
-// Change represents a single field-level change.
+// Change represents a single planned change.
 type Change struct {
-	Type     ChangeType
-	Resource string // "Repository", "BranchProtection", "Secret", "Variable"
-	Name     string // "babarot/my-project"
-	Field    string // "description", "topics", etc.
+	Type     ChangeType // create, update, delete, noop
+	Resource string     // "Repository", "BranchProtection", "Secret", "Variable"
+	Name     string     // "babarot/my-project"
+	Field    string     // "description", "topics", etc.
 	OldValue any
 	NewValue any
-	Children []Change // Sub-field details for hierarchical display
+
+	// Details are display-only plan rendering details. They must not be
+	// interpreted as apply units.
+	Details []Change
+
+	// Children are the concrete child changes to apply for grouped
+	// changes. Most resource-level changes should leave this empty and apply
+	// via the parent change.
+	Children []Change
 }
 
 func (c Change) String() string {


### PR DESCRIPTION
## Summary

Refactor the `Change` struct to separate display-only plan information (`Details`) from concrete apply units (`Children`), making the contract between diff and apply explicit.

## Background

Previously, `Change.Children` served a dual purpose: it held sub-field changes for hierarchical plan display (e.g., showing which fields changed within a branch protection rule) and also served as the list of child changes that `applyChange` would expand into separate API calls. This required resource-specific guards in the apply loop — Labels and Milestones had to be exempted from child expansion because their children were display-only, while delete changes also needed special-casing. The overloaded semantics made it easy to introduce bugs when adding new resource types.

## Changes

- **`Change` struct**: Add `Details []Change` field for display-only plan rendering; narrow `Children` to only hold concrete apply units
- **diff.go**: Emit sub-field changes into `Details` for branch protection, rulesets, labels, milestones, and reconcile deletes; `group()` helper now populates both `Details` and `Children` for grouped changes (features, merge_strategy, security, actions)
- **apply.go**: Remove resource-specific guards (Label, Milestone exemptions) from child expansion — `Details` is never expanded, only `Children`
- **format.go**: Read from `Details` instead of `Children` for plan display
- **diff_types.go**: Document the distinction with clear field comments
- **deleteChildrenFromFields**: Extract generic helper using `deleteField[T]` table-driven pattern, replacing imperative `bpDeleteChildren` and `rsDeleteChildren`
- **Tests**: Update all assertions to use `Details` for plan checks; add `TestApplyBranchProtection_ChildrenAreDisplayOnly` to verify that Details-only changes don't trigger API calls