### PR TITLE
Migrate label_sync into reconcile block and relax validation

### DIFF
--- a/docs/adr/005-collection-reconciliation-policy.md
+++ b/docs/adr/005-collection-reconciliation-policy.md
@@ -109,15 +109,16 @@ do not specify `reconcile`.
 | YAML | Meaning |
 |---|---|
 | `spec.rulesets` omitted | rulesets unmanaged |
+| `reconcile.rulesets: authoritative` + `spec.rulesets` omitted | rulesets unmanaged |
 | `spec.rulesets` present, `reconcile.rulesets` omitted | additive management |
 | `reconcile.rulesets: additive` + non-empty `spec.rulesets` | create/update listed rulesets only |
 | `reconcile.rulesets: authoritative` + non-empty `spec.rulesets` | exact-set management; delete remote rulesets not listed |
 | `reconcile.rulesets: authoritative` + `spec.rulesets: []` | managed empty collection; delete all remote rulesets |
 | `rulesets:` / `rulesets: null` | invalid |
 
-If `reconcile.rulesets` is set but `spec.rulesets` is omitted, parsing should
-fail. A reconciliation policy without a corresponding desired collection is
-ambiguous and likely a mistake.
+If `reconcile.rulesets` is set but `spec.rulesets` is omitted, no ruleset
+changes are planned. `reconcile` is a policy for managed collections, not an
+ownership declaration by itself.
 
 The same rules apply to `labels` and `branch_protection`.
 
@@ -207,8 +208,8 @@ Merge behavior:
 - `defaults.reconcile` provides default reconciliation policy.
 - `repositories[].reconcile` overrides defaults per collection.
 - `defaults.spec` and `repositories[].spec` continue to merge as today.
-- After merge, any reconcile policy that targets an omitted collection is an
-  error.
+- After merge, any omitted collection remains unmanaged even if a reconcile
+  policy exists for that collection.
 
 This lets an organization use `authoritative` by default while allowing individual
 repositories to opt back into `additive`.
@@ -354,8 +355,9 @@ be represented as data, not comments.
 - The schema becomes larger: `Repository`, `RepositorySet.defaults`, and
   `RepositorySet.repositories[]` need `reconcile` blocks.
 - Users must learn a new top-level concept.
-- `reconcile` and `spec` can become inconsistent, so validation must catch
-  policies targeting omitted collections.
+- `reconcile` can specify default policies for collections that some
+  repositories omit. This is useful for `RepositorySet`, but users must
+  understand that omitted collections remain unmanaged.
 - Authoritative mode can delete remote resources created manually or by other tools.
   Plan output must make that reason explicit.
 - `label_sync` remains accepted as a deprecated compatibility alias for labels,

--- a/docs/adr/005-collection-reconciliation-policy.md
+++ b/docs/adr/005-collection-reconciliation-policy.md
@@ -88,6 +88,7 @@ Initial supported collections:
 
 | Reconcile field | Applies to |
 |---|---|
+| `labels` | `spec.labels` |
 | `rulesets` | `spec.rulesets` |
 | `branch_protection` | `spec.branch_protection` |
 
@@ -118,7 +119,7 @@ If `reconcile.rulesets` is set but `spec.rulesets` is omitted, parsing should
 fail. A reconciliation policy without a corresponding desired collection is
 ambiguous and likely a mistake.
 
-The same rules apply to `branch_protection`.
+The same rules apply to `labels` and `branch_protection`.
 
 ### Empty sequences
 
@@ -357,14 +358,13 @@ be represented as data, not comments.
   policies targeting omitted collections.
 - Authoritative mode can delete remote resources created manually or by other tools.
   Plan output must make that reason explicit.
-- `label_sync` remains a pre-existing special case. A later ADR may decide
-  whether to keep it, deprecate it, or migrate labels into the same `reconcile`
-  model.
+- `label_sync` remains accepted as a deprecated compatibility alias for labels,
+  so the implementation needs a migration path and warning.
 
 ### Implementation Notes
 
-- Start with `rulesets` and `branch_protection` only.
-- Keep `additive` as the default for both collections.
+- Start with `labels`, `rulesets`, and `branch_protection`.
+- Keep `additive` as the default for all supported collections.
 - Reject explicit null for these collection fields.
 - Track field presence during parsing so `omitted`, `[]`, and non-empty lists
   remain distinguishable.
@@ -372,5 +372,7 @@ be represented as data, not comments.
   entries not present in the desired collection.
 - In additive mode, diff should not generate deletes for undeclared remote
   entries.
+- Map legacy `spec.label_sync: mirror` to `reconcile.labels: authoritative`
+  for compatibility, but warn and reject manifests that specify both fields.
 - `plan` should include the reconcile policy in delete reasons.
 - `apply` can reuse existing delete APIs once diff emits delete changes.

--- a/docs/src/content/docs/resources/repository-set/defaults.md
+++ b/docs/src/content/docs/resources/repository-set/defaults.md
@@ -8,6 +8,7 @@ The `defaults` block defines shared settings applied to all repositories in the 
 defaults:
   reconcile:
     rulesets: authoritative
+    labels: additive
   spec:
     visibility: public
     features:
@@ -28,7 +29,7 @@ How overrides are applied depends on the field type:
 
 ### Scalars — replaced
 
-Strings, booleans, and numbers (including `label_sync`) are simply replaced by the per-repo value.
+Strings, booleans, and numbers are simply replaced by the per-repo value.
 
 ```yaml
 defaults:
@@ -51,9 +52,13 @@ repositories:
 ```yaml
 defaults:
   reconcile:
+    labels: authoritative
     rulesets: authoritative
     branch_protection: additive
   spec:
+    labels:
+      - name: kind/bug
+        color: d73a4a
     rulesets:
       - name: protect-main
 
@@ -64,7 +69,7 @@ repositories:
       rulesets: additive    # overrides only rulesets
 ```
 
-If a reconcile policy is set, the corresponding collection must be present after defaults and overrides are merged. For example, `reconcile.rulesets: authoritative` requires `spec.rulesets` to exist. Use `spec.rulesets: []` for an explicitly empty managed collection.
+If a reconcile policy is set, the corresponding collection must be present after defaults and overrides are merged. For example, `reconcile.rulesets: authoritative` requires `spec.rulesets` to exist. Use `spec.rulesets: []` or `spec.labels: []` for an explicitly empty managed collection.
 
 ### Lists — replaced entirely
 

--- a/docs/src/content/docs/resources/repository-set/defaults.md
+++ b/docs/src/content/docs/resources/repository-set/defaults.md
@@ -69,7 +69,7 @@ repositories:
       rulesets: additive    # overrides only rulesets
 ```
 
-If a reconcile policy is set, the corresponding collection must be present after defaults and overrides are merged. For example, `reconcile.rulesets: authoritative` requires `spec.rulesets` to exist. Use `spec.rulesets: []` or `spec.labels: []` for an explicitly empty managed collection.
+If a reconcile policy is set but the corresponding collection is omitted after defaults and overrides are merged, that collection is unmanaged for that repository. Use `spec.rulesets: []` or `spec.labels: []` for an explicitly empty managed collection.
 
 ### Lists — replaced entirely
 

--- a/docs/src/content/docs/resources/repository-set/index.md
+++ b/docs/src/content/docs/resources/repository-set/index.md
@@ -56,7 +56,7 @@ All repositories in the set belong to this owner. Individual repo names are list
 All settings available in [Repository](../repository/) — general settings, labels, branch protection, rulesets, secrets, variables, and Actions settings — work identically in `RepositorySet`. See the Repository documentation for field references:
 
 - [General Settings](../repository/general/) — Description, visibility, topics, features, merge strategy
-- [Labels](../repository/labels/) — Labels with sync mode (additive/mirror)
+- [Labels](../repository/labels/) — Labels with reconcile mode (additive/authoritative)
 - [Branch Protection](../repository/branch-protection/) — Classic branch protection rules
 - [Rulesets](../repository/rulesets/) — Modern rulesets with enforcement modes and bypass actors
 - [Secrets & Variables](../repository/secrets-variables/) — GitHub Actions secrets and repository variables

--- a/docs/src/content/docs/resources/repository/index.md
+++ b/docs/src/content/docs/resources/repository/index.md
@@ -130,7 +130,9 @@ spec:
 | `reconcile.rulesets` | `additive`, `authoritative` | Controls how `spec.rulesets` is compared with existing GitHub rulesets |
 | `reconcile.branch_protection` | `additive`, `authoritative` | Controls how `spec.branch_protection` is compared with existing classic branch protection rules |
 
-`additive` is the default. `authoritative` deletes remote entries that are not declared in YAML. To delete all labels, rulesets, or branch protection rules, use `authoritative` with an empty list:
+`additive` is the default. `authoritative` deletes remote entries that are not declared in YAML, but only when the corresponding `spec` collection is present. If `spec.rulesets`, `spec.branch_protection`, or `spec.labels` is omitted, that collection is unmanaged even when `reconcile` has a policy for it.
+
+To delete all labels, rulesets, or branch protection rules, use `authoritative` with an empty list:
 
 ```yaml
 reconcile:

--- a/docs/src/content/docs/resources/repository/index.md
+++ b/docs/src/content/docs/resources/repository/index.md
@@ -17,6 +17,7 @@ metadata:
 
 reconcile:
   rulesets: authoritative
+  labels: authoritative
 
 spec:
   description: "My awesome project"
@@ -91,7 +92,7 @@ The combination of `owner` and `name` identifies the target repository (`babarot
 | `archived` | Archive (read-only) or unarchive — see [General Settings](./general/#archiving) |
 | `topics` | GitHub topics for discoverability |
 | `labels` | Repository issue/PR labels — see [Labels](./labels/) |
-| `label_sync` | Label sync mode: `additive` (default) or `mirror` — see [Labels](./labels/#sync-mode) |
+| `label_sync` | Deprecated label sync mode: use `reconcile.labels` instead — see [Labels](./labels/#reconcile-mode) |
 | `features` | Toggle issues, projects, wiki, discussions, pull requests — see [General Settings](./general/) |
 | `merge_strategy` | Merge commit, squash, rebase options — see [General Settings](./general/) |
 | `branch_protection` | Classic branch protection rules — see [Branch Protection](./branch-protection/) |
@@ -112,6 +113,7 @@ Use top-level `reconcile` to make selected collections match YAML exactly:
 ```yaml
 reconcile:
   rulesets: authoritative
+  labels: additive
   branch_protection: additive
 
 spec:
@@ -124,10 +126,11 @@ spec:
 
 | Field | Modes | Description |
 |---|---|---|
+| `reconcile.labels` | `additive`, `authoritative` | Controls how `spec.labels` is compared with existing GitHub labels |
 | `reconcile.rulesets` | `additive`, `authoritative` | Controls how `spec.rulesets` is compared with existing GitHub rulesets |
 | `reconcile.branch_protection` | `additive`, `authoritative` | Controls how `spec.branch_protection` is compared with existing classic branch protection rules |
 
-`additive` is the default. `authoritative` deletes remote entries that are not declared in YAML. To delete all rulesets or branch protection rules, use `authoritative` with an empty list:
+`additive` is the default. `authoritative` deletes remote entries that are not declared in YAML. To delete all labels, rulesets, or branch protection rules, use `authoritative` with an empty list:
 
 ```yaml
 reconcile:
@@ -136,7 +139,7 @@ spec:
   rulesets: []
 ```
 
-`rulesets: null`, `rulesets:`, `branch_protection: null`, and `branch_protection:` are invalid. Use an empty list when you mean an empty managed collection.
+`labels: null`, `labels:`, `rulesets: null`, `rulesets:`, `branch_protection: null`, and `branch_protection:` are invalid. Use an empty list when you mean an empty managed collection.
 
 ## When to Use
 

--- a/docs/src/content/docs/resources/repository/labels.md
+++ b/docs/src/content/docs/resources/repository/labels.md
@@ -25,13 +25,15 @@ spec:
 | `color` | string | yes | Hex color code without `#` prefix (e.g., `d73a4a`) |
 | `description` | string | no | Short description of the label's purpose |
 
-## Sync Mode
+## Reconcile Mode
 
-By default, gh-infra only creates and updates labels. Labels on GitHub that are not in the manifest are left untouched. To delete unmanaged labels, set `label_sync` to `mirror`:
+By default, gh-infra only creates and updates labels. Labels on GitHub that are not in the manifest are left untouched. To delete unmanaged labels, set `reconcile.labels` to `authoritative`:
 
 ```yaml
+reconcile:
+  labels: authoritative  # additive (default) | authoritative
+
 spec:
-  label_sync: mirror      # additive (default) | mirror
   labels:
     - name: kind/bug
       color: d73a4a
@@ -41,10 +43,10 @@ spec:
 
 | Value | Behavior |
 |-------|----------|
-| `additive` | Create and update only. Unmanaged labels are left in place. This is the default when `label_sync` is omitted. |
-| `mirror` | Create, update, and **delete**. Labels on GitHub that are not in the manifest are removed. |
+| `additive` | Create and update only. Unmanaged labels are left in place. This is the default when `reconcile.labels` is omitted. |
+| `authoritative` | Create, update, and **delete**. Labels on GitHub that are not in the manifest are removed. |
 
-When `mirror` mode marks labels for deletion, `plan` shows usage information (issue/PR count and when the label was last used) so you can verify before applying:
+When `authoritative` mode marks labels for deletion, `plan` shows usage information (issue/PR count and when the label was last used) so you can verify before applying:
 
 ```
   ~ org/my-repo
@@ -54,16 +56,29 @@ When `mirror` mode marks labels for deletion, `plan` shows usage information (is
 ```
 
 :::caution
-Mirror mode deletes labels that are not in the manifest. Issues and PRs with deleted labels will lose those labels. Use `plan` to review before applying.
+Authoritative mode deletes labels that are not in the manifest. Issues and PRs with deleted labels will lose those labels. Use `plan` to review before applying.
+:::
+
+To delete all labels, use `authoritative` with an empty label list:
+
+```yaml
+reconcile:
+  labels: authoritative
+spec:
+  labels: []
+```
+
+:::note[Compatibility]
+`spec.label_sync: mirror` is still accepted for existing manifests, but it is deprecated. Use top-level `reconcile.labels: authoritative` for new manifests.
 :::
 
 :::note[Planned]
-**Aliases** (rename labels while preserving issue/PR associations) and **exclude patterns** (protect specific labels from mirror deletion, e.g., `tagpr*`) are not yet available.
+**Aliases** (rename labels while preserving issue/PR associations) and **exclude patterns** (protect specific labels from authoritative deletion, e.g., `tagpr*`) are not yet available.
 :::
 
 ## Replacing Label-Sync Actions
 
-With `label_sync: mirror`, gh-infra can replace dedicated label synchronization GitHub Actions such as [EndBug/label-sync](https://github.com/EndBug/label-sync) and [crazy-max/ghaction-github-labeler](https://github.com/crazy-max/ghaction-github-labeler).
+With `reconcile.labels: authoritative`, gh-infra can replace dedicated label synchronization GitHub Actions such as [EndBug/label-sync](https://github.com/EndBug/label-sync) and [crazy-max/ghaction-github-labeler](https://github.com/crazy-max/ghaction-github-labeler).
 
 Instead of maintaining a separate workflow and label config file, define labels directly in your gh-infra manifest alongside other repository settings:
 
@@ -75,8 +90,9 @@ kind: Repository
 metadata:
   name: my-repo
   owner: my-org
+reconcile:
+  labels: authoritative
 spec:
-  label_sync: mirror
   labels:
     - name: kind/bug
       color: d73a4a

--- a/docs/src/content/docs/resources/repository/milestones.md
+++ b/docs/src/content/docs/resources/repository/milestones.md
@@ -38,12 +38,12 @@ spec:
 ```
 
 :::note
-Unlike labels, there is no `mirror` sync mode for milestones. If you remove a milestone from the manifest, it remains on GitHub unchanged.
+Unlike labels, there is no `reconcile.milestones: authoritative` mode. If you remove a milestone from the manifest, it remains on GitHub unchanged.
 :::
 
 ## Defaults Inheritance
 
-When using `RepositorySet`, milestones follow the same merge behavior as labels — per-repo milestones fully replace the defaults:
+When using `RepositorySet`, per-repo milestones replace the default milestone list:
 
 ```yaml
 apiVersion: gh-infra/v1

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -134,11 +134,12 @@ func parseDocument(data []byte, path string, docNum int, opt ParseOptions) (*Par
 
 	switch doc.Kind {
 	case KindRepository:
-		repos, err := parseRepository(data, path)
+		repos, warnings, err := parseRepository(data, path)
 		if err != nil {
 			return nil, err
 		}
 		result.Repositories = repos
+		result.Warnings = append(result.Warnings, warnings...)
 		for _, r := range repos {
 			result.RepositoryDocs = append(result.RepositoryDocs, &RepositoryDocument{
 				Resource:   r,
@@ -147,12 +148,13 @@ func parseDocument(data []byte, path string, docNum int, opt ParseOptions) (*Par
 			})
 		}
 	case KindRepositorySet:
-		repos, docs, err := parseRepositorySet(data, path, docIndex)
+		repos, docs, warnings, err := parseRepositorySet(data, path, docIndex)
 		if err != nil {
 			return nil, err
 		}
 		result.Repositories = repos
 		result.RepositoryDocs = docs
+		result.Warnings = append(result.Warnings, warnings...)
 	case KindFile:
 		if opt.Resolver == nil {
 			return nil, fmt.Errorf("%s: ParseOptions.Resolver is required for File kind", path)
@@ -184,21 +186,29 @@ func parseDocument(data []byte, path string, docNum int, opt ParseOptions) (*Par
 	return result, nil
 }
 
-func parseRepository(data []byte, path string) ([]*Repository, error) {
+func parseRepository(data []byte, path string) ([]*Repository, []string, error) {
 	var repo Repository
 	if err := yaml.NewDecoder(bytes.NewReader(data), yaml.DisallowUnknownField()).Decode(&repo); err != nil {
-		return nil, fmt.Errorf("parse Repository in %s: %w", path, err)
+		return nil, nil, fmt.Errorf("parse Repository in %s: %w", path, err)
 	}
 	if err := repo.Validate(); err != nil {
-		return nil, fmt.Errorf("%s: %w", path, err)
+		return nil, nil, fmt.Errorf("%s: %w", path, err)
 	}
-	return []*Repository{&repo}, nil
+	return []*Repository{&repo}, repositoryWarnings(repo.Spec), nil
 }
 
-func parseRepositorySet(data []byte, path string, docIndex int) ([]*Repository, []*RepositoryDocument, error) {
+func parseRepositorySet(data []byte, path string, docIndex int) ([]*Repository, []*RepositoryDocument, []string, error) {
 	var set RepositorySet
 	if err := yaml.NewDecoder(bytes.NewReader(data), yaml.DisallowUnknownField()).Decode(&set); err != nil {
-		return nil, nil, fmt.Errorf("parse RepositorySet in %s: %w", path, err)
+		return nil, nil, nil, fmt.Errorf("parse RepositorySet in %s: %w", path, err)
+	}
+
+	var warnings []string
+	if set.Defaults != nil {
+		warnings = append(warnings, repositoryWarnings(set.Defaults.Spec)...)
+	}
+	for i := range set.Repositories {
+		warnings = append(warnings, repositoryWarnings(set.Repositories[i].Spec)...)
 	}
 
 	var repos []*Repository
@@ -217,7 +227,7 @@ func parseRepositorySet(data []byte, path string, docIndex int) ([]*Repository, 
 			Spec:      mergeSpecs(set.Defaults, entry.Spec),
 		}
 		if err := repo.Validate(); err != nil {
-			return nil, nil, fmt.Errorf("%s: %w", path, err)
+			return nil, nil, nil, fmt.Errorf("%s: %w", path, err)
 		}
 		repos = append(repos, repo)
 		docs = append(docs, &RepositoryDocument{
@@ -230,7 +240,7 @@ func parseRepositorySet(data []byte, path string, docIndex int) ([]*Repository, 
 			OriginalEntrySpec: &originalSpec,
 		})
 	}
-	return repos, docs, nil
+	return repos, docs, warnings, nil
 }
 
 func parseFile(data []byte, path string, resolver *SourceResolver) (*FileSet, []string, error) {
@@ -302,6 +312,13 @@ func parseFileSet(data []byte, path string, resolver *SourceResolver) (*FileSet,
 	warnings = append(warnings, collectFileEntryWarnings(fs.Spec.Files)...)
 
 	return &fs, warnings, nil
+}
+
+func repositoryWarnings(spec RepositorySpec) []string {
+	if spec.LabelSync == nil {
+		return nil
+	}
+	return []string{`"label_sync" is deprecated, use top-level "reconcile.labels" instead`}
 }
 
 // collectFileEntryWarnings drains deprecation warnings from all FileEntry instances.
@@ -400,8 +417,9 @@ func mergeSpecs(defaults *RepositorySetDefaults, override RepositorySpec) Reposi
 	if len(override.Variables) > 0 {
 		result.Variables = override.Variables
 	}
-	if len(override.Labels) > 0 {
+	if override.LabelsSet {
 		result.Labels = mergeLabels(result.Labels, override.Labels)
+		result.LabelsSet = true
 	}
 	if override.LabelSync != nil {
 		result.LabelSync = override.LabelSync
@@ -429,6 +447,9 @@ func mergeReconcile(defaults *RepositorySetDefaults, override *RepositoryReconci
 	result := *base
 	if override.BranchProtection != nil {
 		result.BranchProtection = override.BranchProtection
+	}
+	if override.Labels != nil {
+		result.Labels = override.Labels
 	}
 	if override.Rulesets != nil {
 		result.Rulesets = override.Rulesets

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -1899,21 +1899,6 @@ func TestRepositoryReconcileValidation(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "reconcile without spec collection",
-			content: `
-apiVersion: v1
-kind: Repository
-metadata:
-  owner: org
-  name: repo
-reconcile:
-  rulesets: authoritative
-spec:
-  description: repo
-`,
-			wantErr: "reconcile.rulesets requires spec.rulesets",
-		},
-		{
 			name: "invalid reconcile mode",
 			content: `
 apiVersion: v1
@@ -1953,21 +1938,6 @@ spec:
   branch_protection: null
 `,
 			wantErr: "branch_protection must be a sequence",
-		},
-		{
-			name: "reconcile labels without spec labels",
-			content: `
-apiVersion: v1
-kind: Repository
-metadata:
-  owner: org
-  name: repo
-reconcile:
-  labels: authoritative
-spec:
-  description: repo
-`,
-			wantErr: "reconcile.labels requires spec.labels",
 		},
 		{
 			name: "reconcile labels conflicts with label_sync",
@@ -2016,6 +1986,38 @@ spec:
 				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestRepositoryReconcileWithoutSpecCollectionAllowed(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+reconcile:
+  labels: authoritative
+  rulesets: authoritative
+  branch_protection: authoritative
+spec:
+  description: repo
+`
+	path := filepath.Join(dir, "repo.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath error: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+	if repos[0].Spec.LabelsSet || repos[0].Spec.RulesetsSet || repos[0].Spec.BranchProtectionSet {
+		t.Fatalf("omitted collections should remain unset: %+v", repos[0].Spec)
 	}
 }
 

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -1818,6 +1818,29 @@ func TestLabelSyncMode(t *testing.T) {
 	}
 }
 
+func TestLabelsReconcileMode(t *testing.T) {
+	tests := []struct {
+		name      string
+		reconcile *RepositoryReconcile
+		labelSync *string
+		want      string
+	}{
+		{"nil defaults to additive", nil, nil, CollectionReconcileAdditive},
+		{"legacy additive maps to additive", nil, Ptr(LabelSyncAdditive), CollectionReconcileAdditive},
+		{"legacy mirror maps to authoritative", nil, Ptr(LabelSyncMirror), CollectionReconcileAuthoritative},
+		{"reconcile additive wins", &RepositoryReconcile{Labels: Ptr(CollectionReconcileAdditive)}, Ptr(LabelSyncMirror), CollectionReconcileAdditive},
+		{"reconcile authoritative wins", &RepositoryReconcile{Labels: Ptr(CollectionReconcileAuthoritative)}, Ptr(LabelSyncAdditive), CollectionReconcileAuthoritative},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LabelsReconcileMode(tt.reconcile, tt.labelSync)
+			if got != tt.want {
+				t.Errorf("LabelsReconcileMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLabelSyncValidation(t *testing.T) {
 	dir := t.TempDir()
 	content := `
@@ -1837,6 +1860,35 @@ spec:
 	_, err := ParsePath(path)
 	if err == nil {
 		t.Fatal("expected validation error for invalid label_sync value")
+	}
+}
+
+func TestLabelSyncDeprecationWarning(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+spec:
+  label_sync: mirror
+  labels: []
+`
+	path := filepath.Join(dir, "repo.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ParseAll(path)
+	if err != nil {
+		t.Fatalf("ParseAll error: %v", err)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(result.Warnings), result.Warnings)
+	}
+	if !strings.Contains(result.Warnings[0], `"label_sync" is deprecated`) {
+		t.Fatalf("warning = %q, want label_sync deprecation", result.Warnings[0])
 	}
 }
 
@@ -1902,6 +1954,50 @@ spec:
 `,
 			wantErr: "branch_protection must be a sequence",
 		},
+		{
+			name: "reconcile labels without spec labels",
+			content: `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+reconcile:
+  labels: authoritative
+spec:
+  description: repo
+`,
+			wantErr: "reconcile.labels requires spec.labels",
+		},
+		{
+			name: "reconcile labels conflicts with label_sync",
+			content: `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+reconcile:
+  labels: authoritative
+spec:
+  label_sync: mirror
+  labels: []
+`,
+			wantErr: "cannot specify both reconcile.labels and spec.label_sync",
+		},
+		{
+			name: "null labels rejected",
+			content: `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+spec:
+  labels:
+`,
+			wantErr: "labels must be a sequence",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1959,6 +2055,42 @@ spec:
 	}
 }
 
+func TestRepositoryReconcileLabelsAuthoritativeEmptyCollection(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+reconcile:
+  labels: authoritative
+spec:
+  labels: []
+`
+	path := filepath.Join(dir, "repo.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath error: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+	if !repos[0].Spec.LabelsSet {
+		t.Fatal("labels presence was not tracked")
+	}
+	if got := LabelsReconcileMode(repos[0].Reconcile, repos[0].Spec.LabelSync); got != CollectionReconcileAuthoritative {
+		t.Fatalf("labels reconcile mode = %q, want %q", got, CollectionReconcileAuthoritative)
+	}
+	if len(repos[0].Spec.Labels) != 0 {
+		t.Fatalf("labels length = %d, want 0", len(repos[0].Spec.Labels))
+	}
+}
+
 func TestRepositorySet_ReconcileMerge(t *testing.T) {
 	dir := t.TempDir()
 	content := `
@@ -1968,14 +2100,19 @@ metadata:
   owner: org
 defaults:
   reconcile:
+    labels: authoritative
     rulesets: authoritative
   spec:
+    labels:
+      - name: kind/bug
+        color: d73a4a
     rulesets:
       - name: protect-main
 repositories:
   - name: inherits-reconcile
   - name: overrides-reconcile
     reconcile:
+      labels: additive
       rulesets: additive
 `
 	path := filepath.Join(dir, "reposet.yaml")
@@ -1995,6 +2132,12 @@ repositories:
 	}
 	if got := RulesetsReconcileMode(repos[1].Reconcile); got != CollectionReconcileAdditive {
 		t.Fatalf("repo[1] rulesets reconcile mode = %q, want %q", got, CollectionReconcileAdditive)
+	}
+	if got := LabelsReconcileMode(repos[0].Reconcile, repos[0].Spec.LabelSync); got != CollectionReconcileAuthoritative {
+		t.Fatalf("repo[0] labels reconcile mode = %q, want %q", got, CollectionReconcileAuthoritative)
+	}
+	if got := LabelsReconcileMode(repos[1].Reconcile, repos[1].Spec.LabelSync); got != CollectionReconcileAdditive {
+		t.Fatalf("repo[1] labels reconcile mode = %q, want %q", got, CollectionReconcileAdditive)
 	}
 }
 

--- a/internal/manifest/repository_types.go
+++ b/internal/manifest/repository_types.go
@@ -99,11 +99,13 @@ type RepositorySpec struct {
 	Actions             *Actions           `yaml:"actions,omitempty"`
 
 	BranchProtectionSet bool `yaml:"-"`
+	LabelsSet           bool `yaml:"-"`
 	RulesetsSet         bool `yaml:"-"`
 }
 
 type RepositoryReconcile struct {
 	BranchProtection *string `yaml:"branch_protection,omitempty" validate:"omitempty,oneof=additive authoritative"`
+	Labels           *string `yaml:"labels,omitempty"            validate:"omitempty,oneof=additive authoritative"`
 	Rulesets         *string `yaml:"rulesets,omitempty"           validate:"omitempty,oneof=additive authoritative"`
 }
 
@@ -127,6 +129,12 @@ func (s *RepositorySpec) UnmarshalYAML(unmarshal func(any) error) error {
 		s.BranchProtectionSet = true
 		if v == nil {
 			return fmt.Errorf("branch_protection must be a sequence; use [] with reconcile.branch_protection=authoritative to delete all branch protection rules")
+		}
+	}
+	if v, ok := fields["labels"]; ok {
+		s.LabelsSet = true
+		if v == nil {
+			return fmt.Errorf("labels must be a sequence; use [] with reconcile.labels=authoritative to delete all labels")
 		}
 	}
 	if v, ok := fields["rulesets"]; ok {
@@ -338,6 +346,18 @@ func LabelSyncMode(s *string) string {
 		return LabelSyncAdditive
 	}
 	return *s
+}
+
+func LabelsReconcileMode(r *RepositoryReconcile, legacyLabelSync *string) string {
+	if r != nil && r.Labels != nil {
+		return *r.Labels
+	}
+	switch LabelSyncMode(legacyLabelSync) {
+	case LabelSyncMirror:
+		return CollectionReconcileAuthoritative
+	default:
+		return CollectionReconcileAdditive
+	}
 }
 
 func BranchProtectionReconcileMode(r *RepositoryReconcile) string {

--- a/internal/manifest/validation.go
+++ b/internal/manifest/validation.go
@@ -13,19 +13,10 @@ func (r *Repository) Validate() error {
 	}
 	name := r.Metadata.Name
 	if r.Reconcile != nil {
-		if r.Reconcile.BranchProtection != nil && !r.Spec.BranchProtectionSet {
-			return fmt.Errorf("%s: reconcile.branch_protection requires spec.branch_protection to be present", name)
-		}
 		if r.Reconcile.Labels != nil {
 			if r.Spec.LabelSync != nil {
 				return fmt.Errorf("%s: cannot specify both reconcile.labels and spec.label_sync (use reconcile.labels)", name)
 			}
-			if !r.Spec.LabelsSet {
-				return fmt.Errorf("%s: reconcile.labels requires spec.labels to be present", name)
-			}
-		}
-		if r.Reconcile.Rulesets != nil && !r.Spec.RulesetsSet {
-			return fmt.Errorf("%s: reconcile.rulesets requires spec.rulesets to be present", name)
 		}
 	}
 	// Branch protection: element tag validation

--- a/internal/manifest/validation.go
+++ b/internal/manifest/validation.go
@@ -16,6 +16,14 @@ func (r *Repository) Validate() error {
 		if r.Reconcile.BranchProtection != nil && !r.Spec.BranchProtectionSet {
 			return fmt.Errorf("%s: reconcile.branch_protection requires spec.branch_protection to be present", name)
 		}
+		if r.Reconcile.Labels != nil {
+			if r.Spec.LabelSync != nil {
+				return fmt.Errorf("%s: cannot specify both reconcile.labels and spec.label_sync (use reconcile.labels)", name)
+			}
+			if !r.Spec.LabelsSet {
+				return fmt.Errorf("%s: reconcile.labels requires spec.labels to be present", name)
+			}
+		}
 		if r.Reconcile.Rulesets != nil && !r.Spec.RulesetsSet {
 			return fmt.Errorf("%s: reconcile.rulesets requires spec.rulesets to be present", name)
 		}

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -168,7 +168,7 @@ func Diff(ctx context.Context, desired *manifest.Repository, current *CurrentSta
 	changes = append(changes, diffRulesets(ctx, name, desired, current, opt.Resolver)...)
 	changes = append(changes, diffSecrets(name, desired, current, opt.ForceSecrets)...)
 	changes = append(changes, diffVariables(name, desired, current)...)
-	changes = append(changes, diffLabels(name, desired, current, manifest.LabelSyncMode(desired.Spec.LabelSync))...)
+	changes = append(changes, diffLabels(name, desired, current, manifest.LabelsReconcileMode(desired.Reconcile, desired.Spec.LabelSync))...)
 	changes = append(changes, diffMilestones(name, desired, current)...)
 	changes = append(changes, diffActions(name, desired, current)...)
 	changes = append(changes, diffSecurity(name, desired, current)...)
@@ -776,7 +776,7 @@ func diffVariables(name string, desired *manifest.Repository, current *CurrentSt
 	return changes
 }
 
-func diffLabels(name string, desired *manifest.Repository, current *CurrentState, labelSync string) []Change {
+func diffLabels(name string, desired *manifest.Repository, current *CurrentState, reconcileMode string) []Change {
 	var changes []Change
 
 	desiredSet := make(map[string]bool)
@@ -822,8 +822,8 @@ func diffLabels(name string, desired *manifest.Repository, current *CurrentState
 		}
 	}
 
-	// Mirror mode: delete labels not in the manifest
-	if labelSync == manifest.LabelSyncMirror {
+	// Authoritative mode: delete labels not in the manifest
+	if reconcileMode == manifest.CollectionReconcileAuthoritative {
 		for labelName, cl := range current.Labels {
 			if !desiredSet[labelName] {
 				changes = append(changes, Change{

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -253,6 +253,10 @@ func diffMergeStrategy(name string, desired *manifest.Repository, current *Curre
 }
 
 func diffBranchProtection(name string, desired *manifest.Repository, current *CurrentState) []Change {
+	if !desired.Spec.BranchProtectionSet && len(desired.Spec.BranchProtection) == 0 {
+		return nil
+	}
+
 	var changes []Change
 	desiredPatterns := make(map[string]struct{}, len(desired.Spec.BranchProtection))
 
@@ -361,6 +365,10 @@ func diffBranchProtection(name string, desired *manifest.Repository, current *Cu
 }
 
 func diffRulesets(ctx context.Context, name string, desired *manifest.Repository, current *CurrentState, resolver *manifest.Resolver) []Change {
+	if !desired.Spec.RulesetsSet && len(desired.Spec.Rulesets) == 0 {
+		return nil
+	}
+
 	var changes []Change
 	desiredNames := make(map[string]struct{}, len(desired.Spec.Rulesets))
 
@@ -777,6 +785,10 @@ func diffVariables(name string, desired *manifest.Repository, current *CurrentSt
 }
 
 func diffLabels(name string, desired *manifest.Repository, current *CurrentState, reconcileMode string) []Change {
+	if !desired.Spec.LabelsSet && len(desired.Spec.Labels) == 0 && desired.Spec.LabelSync == nil {
+		return nil
+	}
+
 	var changes []Change
 
 	desiredSet := make(map[string]bool)

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -1123,7 +1123,7 @@ func TestDiff_Labels(t *testing.T) {
 		}
 		c := baseState()
 
-		changes := diffLabels("org/repo", d, c, manifest.LabelSyncAdditive)
+		changes := diffLabels("org/repo", d, c, manifest.CollectionReconcileAdditive)
 		if len(changes) != 1 {
 			t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
 		}
@@ -1143,7 +1143,7 @@ func TestDiff_Labels(t *testing.T) {
 		c := baseState()
 		c.Labels["bug"] = &CurrentLabel{Name: "bug", Color: "d73a4a", Description: "A bug"}
 
-		changes := diffLabels("org/repo", d, c, manifest.LabelSyncAdditive)
+		changes := diffLabels("org/repo", d, c, manifest.CollectionReconcileAdditive)
 		if len(changes) != 1 {
 			t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
 		}
@@ -1166,7 +1166,7 @@ func TestDiff_Labels(t *testing.T) {
 		c := baseState()
 		c.Labels["bug"] = &CurrentLabel{Name: "bug", Color: "d73a4a", Description: "Old desc"}
 
-		changes := diffLabels("org/repo", d, c, manifest.LabelSyncAdditive)
+		changes := diffLabels("org/repo", d, c, manifest.CollectionReconcileAdditive)
 		if len(changes) != 1 {
 			t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
 		}
@@ -1186,14 +1186,14 @@ func TestDiff_Labels(t *testing.T) {
 		c := baseState()
 		c.Labels["bug"] = &CurrentLabel{Name: "bug", Color: "d73a4a", Description: "A bug"}
 
-		changes := diffLabels("org/repo", d, c, manifest.LabelSyncAdditive)
+		changes := diffLabels("org/repo", d, c, manifest.CollectionReconcileAdditive)
 		if len(changes) != 0 {
 			t.Errorf("expected no changes, got %d", len(changes))
 		}
 	})
 }
 
-func TestDiff_Labels_Mirror(t *testing.T) {
+func TestDiff_Labels_Authoritative(t *testing.T) {
 	t.Run("deletes unmanaged labels", func(t *testing.T) {
 		d := baseDesired()
 		d.Spec.Labels = []manifest.Label{
@@ -1203,7 +1203,7 @@ func TestDiff_Labels_Mirror(t *testing.T) {
 		c.Labels["keep"] = &CurrentLabel{Name: "keep", Color: "00ff00"}
 		c.Labels["remove-me"] = &CurrentLabel{Name: "remove-me", Color: "ff0000", Description: "Old label"}
 
-		changes := diffLabels("org/repo", d, c, manifest.LabelSyncMirror)
+		changes := diffLabels("org/repo", d, c, manifest.CollectionReconcileAuthoritative)
 
 		var deletes []Change
 		for _, ch := range changes {
@@ -1228,13 +1228,28 @@ func TestDiff_Labels_Mirror(t *testing.T) {
 		c.Labels["keep"] = &CurrentLabel{Name: "keep", Color: "00ff00"}
 		c.Labels["extra"] = &CurrentLabel{Name: "extra", Color: "aaaaaa"}
 
-		changes := diffLabels("org/repo", d, c, manifest.LabelSyncAdditive)
+		changes := diffLabels("org/repo", d, c, manifest.CollectionReconcileAdditive)
 		for _, ch := range changes {
 			if ch.Type == ChangeDelete {
 				t.Errorf("unexpected delete in additive mode: %v", ch)
 			}
 		}
 	})
+}
+
+func TestDiff_Labels_LegacyLabelSyncMirrorMapsToAuthoritative(t *testing.T) {
+	d := baseDesired()
+	d.Spec.LabelSync = manifest.Ptr(manifest.LabelSyncMirror)
+	c := baseState()
+	c.Labels["remove-me"] = &CurrentLabel{Name: "remove-me", Color: "ff0000", Description: "Old label"}
+
+	changes := Diff(context.Background(), d, c)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d: %v", len(changes), changes)
+	}
+	if changes[0].Type != ChangeDelete || changes[0].Resource != manifest.ResourceLabel || changes[0].Field != "remove-me" {
+		t.Fatalf("unexpected change: %+v", changes[0])
+	}
 }
 
 func TestLabelSummary(t *testing.T) {

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -809,6 +809,7 @@ func TestDiff_BranchProtection(t *testing.T) {
 		d := baseDesired()
 		mode := manifest.CollectionReconcileAuthoritative
 		d.Reconcile = &manifest.RepositoryReconcile{BranchProtection: &mode}
+		d.Spec.BranchProtectionSet = true
 		c := baseState()
 		c.BranchProtection["main"] = &CurrentBranchProtection{Pattern: "main"}
 
@@ -827,6 +828,19 @@ func TestDiff_BranchProtection(t *testing.T) {
 		}
 		if len(changes[0].Details) == 0 {
 			t.Fatal("expected display-only delete children")
+		}
+	})
+
+	t.Run("authoritative no-op when branch protection omitted", func(t *testing.T) {
+		d := baseDesired()
+		mode := manifest.CollectionReconcileAuthoritative
+		d.Reconcile = &manifest.RepositoryReconcile{BranchProtection: &mode}
+		c := baseState()
+		c.BranchProtection["main"] = &CurrentBranchProtection{Pattern: "main"}
+
+		changes := diffBranchProtection("org/repo", d, c)
+		if len(changes) != 0 {
+			t.Fatalf("expected no changes for omitted branch_protection, got %d: %v", len(changes), changes)
 		}
 	})
 
@@ -1235,6 +1249,17 @@ func TestDiff_Labels_Authoritative(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("no-op when labels omitted", func(t *testing.T) {
+		d := baseDesired()
+		c := baseState()
+		c.Labels["remove-me"] = &CurrentLabel{Name: "remove-me", Color: "ff0000", Description: "Old label"}
+
+		changes := diffLabels("org/repo", d, c, manifest.CollectionReconcileAuthoritative)
+		if len(changes) != 0 {
+			t.Fatalf("expected no changes for omitted labels, got %d: %v", len(changes), changes)
+		}
+	})
 }
 
 func TestDiff_Labels_LegacyLabelSyncMirrorMapsToAuthoritative(t *testing.T) {
@@ -1632,6 +1657,7 @@ func TestDiff_Rulesets_ReconcileAuthoritativeDeletesUndeclared(t *testing.T) {
 	desired := baseDesired()
 	mode := manifest.CollectionReconcileAuthoritative
 	desired.Reconcile = &manifest.RepositoryReconcile{Rulesets: &mode}
+	desired.Spec.RulesetsSet = true
 
 	current := baseState()
 	current.Rulesets["old-ruleset"] = &CurrentRuleset{
@@ -1659,6 +1685,25 @@ func TestDiff_Rulesets_ReconcileAuthoritativeDeletesUndeclared(t *testing.T) {
 	}
 	if len(changes[0].Details) == 0 {
 		t.Fatal("expected display-only delete children")
+	}
+}
+
+func TestDiff_Rulesets_ReconcileAuthoritativeNoopWhenOmitted(t *testing.T) {
+	desired := baseDesired()
+	mode := manifest.CollectionReconcileAuthoritative
+	desired.Reconcile = &manifest.RepositoryReconcile{Rulesets: &mode}
+
+	current := baseState()
+	current.Rulesets["old-ruleset"] = &CurrentRuleset{
+		ID:          42,
+		Name:        "old-ruleset",
+		Target:      "branch",
+		Enforcement: "active",
+	}
+
+	changes := Diff(context.Background(), desired, current)
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes for omitted rulesets, got %d: %v", len(changes), changes)
 	}
 }
 

--- a/skills/repository-manifest/SKILL.md
+++ b/skills/repository-manifest/SKILL.md
@@ -106,7 +106,7 @@ Read [references/repository-set.md](./references/repository-set.md) for the exac
 - `actions.enabled` is required when setting any other `actions.*` field
 - `actions.selected_actions` is valid only with `allowed_actions: selected`
 - `reconcile.labels: authoritative`, `reconcile.rulesets: authoritative`, and `reconcile.branch_protection: authoritative` delete undeclared remote entries; review `plan` carefully
-- `reconcile` without a corresponding `spec` collection is a parse error
+- `reconcile` without a corresponding `spec` collection is no-op; a collection is managed only when it appears in `spec`
 - `label_sync: mirror` is deprecated; use `reconcile.labels: authoritative`
 - for `gh infra import --into`, use the dedicated `import-into` skill
 - Repository deletion is not supported

--- a/skills/repository-manifest/SKILL.md
+++ b/skills/repository-manifest/SKILL.md
@@ -28,6 +28,7 @@ metadata:
   name: my-repo
 reconcile:           # optional; controls collection reconciliation
   rulesets: additive # additive (default) | authoritative
+  labels: additive
 spec:
   # declare only managed fields
 ```
@@ -35,7 +36,7 @@ spec:
 Read these references as needed:
 
 - General settings and lifecycle: [references/general.md](./references/general.md)
-- Labels and label sync: [references/labels.md](./references/labels.md)
+- Labels and reconcile mode: [references/labels.md](./references/labels.md)
 - Actions settings and validation traps: [references/actions.md](./references/actions.md)
 - Rulesets and branch protection: [references/protection.md](./references/protection.md)
 - Secrets and variables: [references/secrets-variables.md](./references/secrets-variables.md)
@@ -54,6 +55,7 @@ metadata:
 defaults:
   reconcile:
     rulesets: authoritative
+    labels: additive
   spec:
     visibility: public
     features:
@@ -91,10 +93,11 @@ repositories:
 Override behavior matters:
 
 - Scalars are replaced
-- Lists are replaced entirely
+- Simple lists are replaced entirely
+- Keyed collections are merged by key
 - Maps are merged by key
 
-This means `labels` replace the default list, while `label_sync` replaces as a scalar.
+This means `topics` replace the default list, while `labels` and `reconcile.labels` are merged by key/collection.
 
 Read [references/repository-set.md](./references/repository-set.md) for the exact merge rules.
 
@@ -102,9 +105,9 @@ Read [references/repository-set.md](./references/repository-set.md) for the exac
 
 - `actions.enabled` is required when setting any other `actions.*` field
 - `actions.selected_actions` is valid only with `allowed_actions: selected`
-- `reconcile.rulesets: authoritative` and `reconcile.branch_protection: authoritative` delete undeclared remote entries; review `plan` carefully
+- `reconcile.labels: authoritative`, `reconcile.rulesets: authoritative`, and `reconcile.branch_protection: authoritative` delete undeclared remote entries; review `plan` carefully
 - `reconcile` without a corresponding `spec` collection is a parse error
-- `label_sync: mirror` deletes unmanaged labels; review `plan` carefully
+- `label_sync: mirror` is deprecated; use `reconcile.labels: authoritative`
 - for `gh infra import --into`, use the dedicated `import-into` skill
 - Repository deletion is not supported
 

--- a/skills/repository-manifest/references/labels.md
+++ b/skills/repository-manifest/references/labels.md
@@ -13,11 +13,13 @@ spec:
 - `name` must be unique in the list
 - `color` is hex without `#`
 
-## Sync Mode
+## Reconcile Mode
 
 ```yaml
+reconcile:
+  labels: authoritative
+
 spec:
-  label_sync: mirror
   labels:
     - name: kind/bug
       color: d73a4a
@@ -26,6 +28,8 @@ spec:
 Modes:
 
 - `additive`: create/update only; unmanaged labels remain
-- `mirror`: create/update/delete; unmanaged labels are removed
+- `authoritative`: create/update/delete; unmanaged labels are removed
 
-Use `mirror` only when the manifest is authoritative. `plan` includes label usage info for pending deletions.
+Use `authoritative` only when the manifest is authoritative. `plan` includes label usage info for pending deletions.
+
+`spec.label_sync: mirror` is still accepted for compatibility, but it is deprecated.

--- a/skills/repository-manifest/references/protection.md
+++ b/skills/repository-manifest/references/protection.md
@@ -22,7 +22,7 @@ Modes:
 
 Rules:
 
-- `reconcile` without the corresponding `spec` collection is a parse error (e.g., `reconcile.rulesets: authoritative` requires `spec.rulesets`)
+- `reconcile` without the corresponding `spec` collection is no-op; a collection is managed only when it appears in `spec`
 - Use `spec.rulesets: []` with `reconcile.rulesets: authoritative` to delete all remote rulesets
 - `rulesets: null` / `rulesets:` (explicit null) is invalid; use `[]` for empty managed collections
 - `plan` output shows delete reason with the reconcile policy (e.g., `not declared; reconcile.rulesets=authoritative`)

--- a/skills/repository-manifest/references/repository-set.md
+++ b/skills/repository-manifest/references/repository-set.md
@@ -10,6 +10,7 @@ metadata:
 defaults:
   reconcile:
     rulesets: authoritative
+    labels: additive
   spec:
     visibility: public
     features:
@@ -28,14 +29,17 @@ repositories:
 ## Merge Rules
 
 - Scalars: replaced
-- Lists: replaced entirely
+- Simple lists: replaced entirely
+- Keyed collections: merged by key
 - Maps: merged by key
 - Reconcile: merged by collection (per-repo overrides individual collections without resetting others)
 
 Examples:
 
-- `visibility`, `label_sync`: scalar replace
-- `topics`, `labels`, `branch_protection`, `rulesets`, `secrets`, `variables`: list replace
+- `visibility`: scalar replace
+- `reconcile.labels`, `reconcile.rulesets`, `reconcile.branch_protection`: merged by collection
+- `topics`, `secrets`, `variables`: list replace
+- `labels`, `branch_protection`, `rulesets`: merged by key
 - `features`, `merge_strategy`, `actions`: map merge by key (individual fields like `enabled`, `allowed_actions` are independently overridable)
 - `features.pull_requests`: map merge by key (`enabled` and `creation` are independently overridable)
 - `actions.selected_actions`: map merge by key


### PR DESCRIPTION
## Summary

Migrate `spec.label_sync` into the unified `reconcile` block as `reconcile.labels`, and change reconcile validation so that a policy without a corresponding spec collection is a no-op instead of a parse error.

## Background

The `label_sync` field was the first collection sync control in gh-infra, predating the `reconcile` block introduced in ADR-005. With `reconcile` now supporting `rulesets` and `branch_protection`, labels should use the same model for consistency. Additionally, the original validation that required `spec.<collection>` to be present when `reconcile.<collection>` was set was too strict for `RepositorySet` defaults — a set-level `reconcile.rulesets: authoritative` policy should be valid even if some repositories omit `spec.rulesets`.

## Changes

- **Schema**: Add `Labels` field to `RepositoryReconcile`; add `LabelsSet` presence flag to `RepositorySpec`
- **Parser**: Map legacy `spec.label_sync` to `reconcile.labels` during parsing with deprecation warning; track `labels` field presence via custom `UnmarshalYAML`
- **Validation**: Reject manifests that specify both `reconcile.labels` and `spec.label_sync`; remove the requirement that reconcile policies must have a corresponding spec collection (omitted collections are now unmanaged)
- **Diff**: Add early-return guards in `diffLabels`, `diffBranchProtection`, and `diffRulesets` to skip processing when the collection is omitted; pass reconcile mode through to label diffing
- **ADR-005**: Update to reflect labels as a supported collection, relax field-presence semantics, and document `label_sync` as a deprecated compatibility alias
- **Docs**: Update labels, repository index, repository-set defaults, and milestones docs to use `reconcile.labels` instead of `spec.label_sync`
- **Skills**: Update protection.md, labels.md, repository-set.md, and SKILL.md with new reconcile semantics
- **Tests**: Add tests for label_sync migration, conflict detection, authoritative label deletion, reconcile-without-spec no-op behavior, and RepositorySet reconcile merge for labels