### PR TITLE
Unify file reconcile naming with repository conventions

### DIFF
--- a/docs/adr/006-reconcile-naming-conventions.md
+++ b/docs/adr/006-reconcile-naming-conventions.md
@@ -1,0 +1,273 @@
+# ADR-006: Reconcile naming conventions
+
+## Status
+
+Accepted
+
+## Context
+
+gh-infra has reconciliation policy fields in multiple resource types.
+
+Repository resources use a top-level `reconcile` block to control how managed
+collections are compared with current GitHub state:
+
+```yaml
+apiVersion: gh-infra/v1
+kind: Repository
+metadata:
+  owner: my-org
+  name: my-repo
+
+reconcile:
+  labels: authoritative
+  rulesets: authoritative
+  branch_protection: additive
+
+spec:
+  labels:
+    - name: kind/bug
+      color: d73a4a
+  rulesets:
+    - name: protect-main
+      target: branch
+      rules:
+        non_fast_forward: true
+```
+
+File and FileSet resources use `reconcile` on each file entry:
+
+```yaml
+apiVersion: gh-infra/v1
+kind: File
+metadata:
+  owner: my-org
+spec:
+  files:
+    - path: config/app.yaml
+      source: templates/app.yaml
+      reconcile: mirror
+```
+
+The same conceptual policies currently use different names:
+
+| Concept | Repository | File/FileSet |
+|---|---|---|
+| Create/update declared entries and leave undeclared remote entries untouched | `additive` | `patch` |
+| Treat YAML as the source of truth and delete undeclared remote entries | `authoritative` | `mirror` |
+| Create once and never update after creation | N/A | `create_only` |
+
+This forces users to learn different terms for the same reconciliation behavior
+inside one tool. The mismatch will become more costly as gh-infra gains more
+resources and managed collections.
+
+## Decision
+
+Standardize reconciliation policy names across resource types:
+
+| Value | Meaning | Applies to |
+|---|---|---|
+| `additive` | Create/update declared entries. Leave undeclared remote entries untouched. | Repository, File/FileSet |
+| `authoritative` | Treat YAML as authoritative for the managed scope. Delete undeclared remote entries in that scope. | Repository, File/FileSet |
+| `create_only` | Create if missing. Do not update after creation. | File/FileSet |
+
+Repository already uses `additive` and `authoritative`. File and FileSet should
+migrate from `patch` and `mirror` to `additive` and `authoritative`.
+
+### Repository Semantics
+
+Repository `reconcile.<collection>` is a policy for a managed collection. It is
+not an ownership declaration by itself.
+
+A collection becomes managed only when the merged `spec.<collection>` is present
+in YAML. If a collection is omitted from `spec`, it remains unmanaged even when
+`reconcile` contains a policy for that collection.
+
+| YAML | YAML-level state | gh-infra meaning |
+|---|---|---|
+| `spec.rulesets` omitted | absent | unmanaged; no-op even if `reconcile.rulesets` is set |
+| `spec.rulesets:` | explicit null | invalid |
+| `spec.rulesets: null` | explicit null | invalid |
+| `spec.rulesets: []` | empty sequence | managed empty collection |
+| `spec.rulesets: [ ... ]` | non-empty sequence | managed collection |
+
+With `authoritative`:
+
+| YAML | Meaning |
+|---|---|
+| `reconcile.rulesets: authoritative` + `spec.rulesets` omitted | rulesets unmanaged; no-op |
+| `reconcile.rulesets: authoritative` + `spec.rulesets: []` | managed empty collection; delete all remote rulesets |
+| `reconcile.rulesets: authoritative` + `spec.rulesets: [ ... ]` | exact-set management; delete remote rulesets not declared in YAML |
+
+The same presence semantics apply to `labels` and `branch_protection`.
+
+This lets RepositorySet defaults express organization-wide policy without
+forcing every repository to manage every collection:
+
+```yaml
+apiVersion: gh-infra/v1
+kind: RepositorySet
+metadata:
+  owner: my-org
+
+defaults:
+  reconcile:
+    labels: authoritative
+    rulesets: authoritative
+    branch_protection: authoritative
+
+repositories:
+  - name: repo-a
+    spec:
+      rulesets:
+        - name: protect-main
+          target: branch
+          rules:
+            non_fast_forward: true
+
+  - name: repo-b
+    spec:
+      description: "rulesets unmanaged for this repo"
+
+  - name: repo-c
+    spec:
+      rulesets: []
+```
+
+In this example:
+
+- `repo-a` manages rulesets authoritatively.
+- `repo-b` does not manage rulesets.
+- `repo-c` manages rulesets as an empty collection and deletes all remote rulesets.
+
+This preserves gh-infra's core rule that omitted fields are unmanaged. Deletion
+requires the target collection to be present in `spec`.
+
+### File and FileSet Semantics
+
+File and FileSet should use:
+
+```yaml
+reconcile: additive        # default; create/update declared files only
+reconcile: authoritative   # manage the directory scope exactly; delete undeclared files
+reconcile: create_only     # create if missing; do not update after creation
+```
+
+`authoritative` for files is scoped to the file entry's directory scope. It does
+not mean the whole repository is authoritative unless the entry's scope covers
+the whole repository.
+
+### Legacy Values
+
+File and FileSet currently accept:
+
+| Old value | New value | Migration behavior |
+|---|---|---|
+| `patch` | `additive` | Deprecated alias |
+| `mirror` | `authoritative` | Deprecated alias |
+| `create_only` | `create_only` | No change |
+
+The parser should continue accepting `patch` and `mirror` for compatibility,
+normalize them to the new values internally, and emit deprecation warnings.
+
+Repository's legacy label sync field remains separate:
+
+```yaml
+spec:
+  label_sync: mirror
+```
+
+`label_sync: mirror` is a deprecated compatibility alias for
+`reconcile.labels: authoritative`. It should continue to warn and should not be
+used in new manifests.
+
+## Rationale
+
+### Use `authoritative` instead of `mirror`
+
+`mirror` is short and intuitive, but in a GitHub repository management tool it
+can be confused with repository mirroring or fork mirroring. `authoritative`
+more accurately describes the behavior: YAML is the source of truth for the
+managed scope, and undeclared remote entries may be deleted.
+
+`authoritative` also matches common infrastructure-as-code terminology, such as
+authoritative vs non-authoritative IAM resources in Terraform providers.
+
+The word is longer, but destructive behavior benefits from explicit naming.
+
+### Use `additive` instead of `patch`
+
+`patch` is ambiguous in File resources because gh-infra also has a `patches:`
+field for content-level patching. It also suggests JSON Patch or strategic merge
+patch rather than the intended policy: create/update declared files while
+leaving undeclared files untouched.
+
+`additive` matches Repository terminology and better communicates the non-
+destructive default behavior.
+
+### Keep `create_only` under `reconcile`
+
+`create_only` is partly a lifecycle policy rather than a pure reconciliation
+policy. In theory, File entries could split this into separate fields:
+
+```yaml
+files:
+  - path: config/app.yaml
+    lifecycle: continuous
+    reconcile: authoritative
+```
+
+We will not split it now. The practical combinations are effectively mutually
+exclusive, and a second field would increase schema complexity with little user
+benefit. `create_only` can be understood as "reconcile only on initial creation."
+
+## Consequences
+
+### Positive
+
+- Repository and File/FileSet use the same words for the same reconciliation
+  behaviors.
+- `patches:` and `reconcile: patch` no longer compete for the word "patch."
+- `authoritative` makes destructive behavior more explicit than `mirror`.
+- Future resources can reuse the same vocabulary.
+
+### Negative / Tradeoffs
+
+- File/FileSet users need to learn new names.
+- Existing manifests using `patch` or `mirror` need a migration path.
+- `authoritative` may look like an ownership declaration. Documentation must
+  clearly state that Repository collections are managed only when the
+  corresponding `spec` collection is present.
+- `authoritative` for files is scoped to a directory scope, not necessarily to
+  the whole repository. Documentation must make the scope clear.
+
+## Implementation Notes
+
+- Add `ReconcileAdditive = "additive"` and
+  `ReconcileAuthoritative = "authoritative"` for File/FileSet.
+- Keep `ReconcileCreateOnly = "create_only"`.
+- Accept legacy `patch` and `mirror` in YAML.
+- Normalize legacy values to `additive` and `authoritative` during parsing.
+- Emit deprecation warnings when legacy values are used.
+- Update user documentation, examples, skill references, and tests to prefer
+  the new values.
+- Keep Repository `reconcile.<collection>` presence semantics unchanged:
+  omitted `spec.<collection>` means unmanaged/no-op.
+
+## Alternatives Considered
+
+### Keep existing File names
+
+Rejected. Keeping `patch` and `mirror` preserves compatibility but leaves
+Repository and File/FileSet with inconsistent vocabulary. The inconsistency is
+small today but becomes more expensive as more resources gain reconciliation
+policy.
+
+### Rename Repository to match File
+
+Rejected. `mirror` is less precise in GitHub repository management, and `patch`
+conflicts with File `patches:`.
+
+### Split `create_only` into lifecycle
+
+Rejected for now. It is conceptually cleaner but adds schema complexity and
+invalid combinations without solving a current user problem.

--- a/docs/src/content/docs/resources/file/index.md
+++ b/docs/src/content/docs/resources/file/index.md
@@ -61,7 +61,7 @@ The combination of `owner` and `name` identifies the target repository (`babarot
 |---|---|---|
 | `files` | *(required)* | List of files to manage — see [File Sources](./sources/) |
 | `files[].patches` | *(none)* | List of unified diff patches (file paths or inline) applied after template expansion — see [Patches](./patches/). |
-| `files[].reconcile` | `patch` | Per-entry reconcile mode: `patch` (add/update), `mirror` (add/update/delete), or `create_only` (create if missing, never update) — see [Reconcile](./reconcile/). |
+| `files[].reconcile` | `additive` | Per-entry reconcile mode: `additive` (add/update), `authoritative` (add/update/delete), or `create_only` (create if missing, never update) — see [Reconcile](./reconcile/). |
 | `via` | `push` | Delivery method: `push` or `pull_request` — see [Delivery Method](./delivery/). |
 | `commit_message` | auto | Custom commit message |
 | `branch` | auto | Branch name for `pull_request` mode |

--- a/docs/src/content/docs/resources/file/reconcile.mdx
+++ b/docs/src/content/docs/resources/file/reconcile.mdx
@@ -10,11 +10,11 @@ import { FileTree } from '@astrojs/starlight/components';
 
 | Mode | Creates | Updates | Deletes orphans |
 |------|---------|---------|-----------------|
-| `patch` (default) | Yes | Yes | No |
-| `mirror` | Yes | Yes | Yes |
+| `additive` (default) | Yes | Yes | No |
+| `authoritative` | Yes | Yes | Yes |
 | `create_only` | Yes | No | No |
 
-## `patch` (default)
+## `additive` (default)
 
 Manages the declared files without touching anything else in the target directory.
 
@@ -22,7 +22,7 @@ Manages the declared files without touching anything else in the target director
 files:
   - path: .github/CODEOWNERS
     content: "* @platform-team"
-    # reconcile: patch  ← default, can be omitted
+    # reconcile: additive  ← default, can be omitted
 ```
 
 **What happens:**
@@ -33,7 +33,7 @@ files:
 
 Use this for config files, security policies, or any file where you want gh-infra to keep it up to date but leave other files in the same directory alone.
 
-## `mirror`
+## `authoritative`
 
 Makes the target directory an **exact copy** of the source. Any file in the target that is not in the source is **deleted**.
 
@@ -41,7 +41,7 @@ Makes the target directory an **exact copy** of the source. Any file in the targ
 files:
   - path: .github/workflows
     source: ./templates/workflows/
-    reconcile: mirror
+    reconcile: authoritative
 ```
 
 **What happens:**
@@ -51,18 +51,18 @@ files:
 - File in target, not in source → **deleted**
 - File in source, content matches → **no action**
 
-Mirror only affects the directory specified by `path`. Files outside that directory are never touched:
+Authoritative mode only affects the directory specified by `path`. Files outside that directory are never touched:
 
 ```yaml
 files:
   - path: .github/workflows
     source: ./templates/workflows/
-    reconcile: mirror
+    reconcile: authoritative
     # ↑ only deletes orphans inside .github/workflows/
 
   - path: README.md
     content: "# My Project"
-    # ↑ unaffected by the mirror above
+    # ↑ unaffected by the authoritative entry above
 ```
 
 **Example:** source has `ci.yml` and `release.yml`. Target repo also has `repo-dedicated.yml`:
@@ -100,13 +100,17 @@ Different files can use different modes in the same manifest:
 files:
   - path: .github/workflows
     source: ./templates/workflows/
-    reconcile: mirror
+    reconcile: authoritative
 
   - path: .github/CODEOWNERS
     content: "* @platform-team"
-    # reconcile: patch (default)
+    # reconcile: additive (default)
 
   - path: README.md
     source: ./templates/README.md.tmpl
     reconcile: create_only
 ```
+
+:::note[Compatibility]
+`reconcile: patch` and `reconcile: mirror` are still accepted for existing manifests, but they are deprecated. Use `additive` and `authoritative` for new manifests.
+:::

--- a/docs/src/content/docs/resources/file/sources.md
+++ b/docs/src/content/docs/resources/file/sources.md
@@ -51,13 +51,13 @@ files:
 
 For example, if `./templates/workflows/` contains `ci.yaml` and `release.yaml`, this creates `.github/workflows/ci.yaml` and `.github/workflows/release.yaml` in the target repo.
 
-Add `reconcile: mirror` to delete files in the target directory that don't exist in the source:
+Add `reconcile: authoritative` to delete files in the target directory that don't exist in the source:
 
 ```yaml
 files:
   - path: .github/workflows
     source: ./templates/workflows/
-    reconcile: mirror
+    reconcile: authoritative
 ```
 
 See [Reconcile](../reconcile/) for details.
@@ -107,7 +107,7 @@ workflows/
 
 This creates `.github/workflows/ci.yaml`, `.github/workflows/release.yaml`, and `.github/workflows/checks/lint.yaml` in the target repo.
 
-Like local directories, `reconcile: mirror` works with GitHub directory sources to delete orphan files. See [Reconcile](../reconcile/).
+Like local directories, `reconcile: authoritative` works with GitHub directory sources to delete orphan files. See [Reconcile](../reconcile/).
 
 ### Pinning to a version
 

--- a/docs/src/content/docs/resources/fileset/index.md
+++ b/docs/src/content/docs/resources/fileset/index.md
@@ -58,7 +58,7 @@ All settings available in [File](../file/) — file sources, templating, reconci
 - [File Sources](../file/sources/) — Inline content, local files, directories, and `github://` references
 - [Templating](../file/templating/) — `<% %>` syntax, built-in variables, custom vars
 - [Patches](../file/patches/) — Unified diff patches for per-repo customization of shared templates
-- [Reconcile](../file/reconcile/) — `patch` (add/update) vs `mirror` (add/update/delete orphans)
+- [Reconcile](../file/reconcile/) — `additive` (add/update) vs `authoritative` (add/update/delete orphans)
 - [Delivery Method](../file/delivery/) — `push` vs `pull_request`
 
 ## When to Use FileSet
@@ -113,4 +113,3 @@ spec:
 | Changing a shared file | Edit one place | Edit every manifest |
 | Per-repo git blame | All changes in one file | Clean, one file per repo |
 | Team ownership | Single file, shared ownership | Each team owns their manifest |
-

--- a/internal/fileset/fileset_test.go
+++ b/internal/fileset/fileset_test.go
@@ -405,7 +405,7 @@ func TestCountChanges(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Mirror mode tests
+// Authoritative mode tests
 // ---------------------------------------------------------------------------
 
 // dirContentsJSON builds a GitHub Contents API JSON response for a directory listing.
@@ -433,7 +433,7 @@ func TestPlan_MirrorDetectsOrphans(t *testing.T) {
 		Responses: map[string][]byte{
 			// file1.yml exists in repo with same content → NoOp
 			contentsKey("owner/repo", "config/file1.yml"): contentsJSON("content1", "sha1"),
-			// directory listing for mirror orphan detection
+			// directory listing for authoritative orphan detection
 			contentsKey("owner/repo", "config"): dirContentsJSON(dirFiles),
 		},
 		Errors: map[string]error{},
@@ -449,7 +449,7 @@ func TestPlan_MirrorDetectsOrphans(t *testing.T) {
 					{
 						Path:      "config/file1.yml",
 						Content:   "content1",
-						Reconcile: manifest.ReconcileMirror,
+						Reconcile: manifest.ReconcileAuthoritative,
 						DirScope:  "config",
 					},
 				},
@@ -478,8 +478,8 @@ func TestPlan_MirrorDetectsOrphans(t *testing.T) {
 	}
 }
 
-func TestPlan_PatchIgnoresOrphans(t *testing.T) {
-	// Same setup but with patch mode — no deletes should be generated
+func TestPlan_AdditiveIgnoresOrphans(t *testing.T) {
+	// Same setup but with additive mode — no deletes should be generated
 	dirFiles := []struct{ Path, Type string }{
 		{Path: "config/file1.yml", Type: "file"},
 		{Path: "config/file2.yml", Type: "file"},
@@ -488,7 +488,7 @@ func TestPlan_PatchIgnoresOrphans(t *testing.T) {
 	mock := &gh.MockRunner{
 		Responses: map[string][]byte{
 			contentsKey("owner/repo", "config/file1.yml"): contentsJSON("content1", "sha1"),
-			// directory listing should NOT be called for patch mode, but include it to be safe
+			// directory listing should NOT be called for additive mode, but include it to be safe
 			contentsKey("owner/repo", "config"): dirContentsJSON(dirFiles),
 		},
 		Errors: map[string]error{},
@@ -504,7 +504,7 @@ func TestPlan_PatchIgnoresOrphans(t *testing.T) {
 					{
 						Path:      "config/file1.yml",
 						Content:   "content1",
-						Reconcile: manifest.ReconcilePatch,
+						Reconcile: manifest.ReconcileAdditive,
 						DirScope:  "config",
 					},
 				},
@@ -519,7 +519,7 @@ func TestPlan_PatchIgnoresOrphans(t *testing.T) {
 
 	for _, c := range changes {
 		if c.Type == ChangeDelete {
-			t.Errorf("patch mode should not generate ChangeDelete, got delete for %s", c.Path)
+			t.Errorf("additive mode should not generate ChangeDelete, got delete for %s", c.Path)
 		}
 	}
 }

--- a/internal/fileset/plan.go
+++ b/internal/fileset/plan.go
@@ -132,18 +132,18 @@ func (p *Processor) Plan(ctx context.Context, fileSets []*manifest.FileSet, filt
 			change := p.planFile(ctx, u.fileSetName, fullName, file)
 			out = append(out, change)
 		}
-		// Mirror mode: detect orphaned files in target repo
+		// Authoritative mode: detect orphaned files in target repo
 		allPlannedPaths := make(map[string]bool)
 		for _, change := range out {
 			allPlannedPaths[change.Path] = true
 		}
-		mirrorDirs := make(map[string]bool)
+		authoritativeDirs := make(map[string]bool)
 		for _, file := range u.files {
-			if file.Reconcile == manifest.ReconcileMirror && file.DirScope != "" {
-				mirrorDirs[file.DirScope] = true
+			if file.Reconcile == manifest.ReconcileAuthoritative && file.DirScope != "" {
+				authoritativeDirs[file.DirScope] = true
 			}
 		}
-		for dirScope := range mirrorDirs {
+		for dirScope := range authoritativeDirs {
 			updateStatus("scanning " + dirScope + "...")
 			repoFiles, err := p.fetchDirectoryContents(ctx, fullName, dirScope)
 			if err != nil {
@@ -187,7 +187,7 @@ func (p *Processor) Plan(ctx context.Context, fileSets []*manifest.FileSet, filt
 	return changes, nil
 }
 
-// planCreateOnly handles sync_mode: create_only — create if missing, NoOp if exists.
+// planCreateOnly handles reconcile: create_only — create if missing, NoOp if exists.
 func (p *Processor) planCreateOnly(ctx context.Context, fileSetName, repo string, file manifest.FileEntry) Change {
 	current, err := p.fetchFileContent(ctx, repo, file.Path)
 	if err != nil || !current.Exists {

--- a/internal/fileset/resolve_test.go
+++ b/internal/fileset/resolve_test.go
@@ -71,14 +71,14 @@ func TestResolveFiles_InheritsDirScopeAndReconcile(t *testing.T) {
 					Path:      "config/a.yml",
 					Content:   "original-a",
 					DirScope:  "config",
-					Reconcile: manifest.ReconcileMirror,
+					Reconcile: manifest.ReconcileAuthoritative,
 					Vars:      map[string]string{"env": "prod"},
 				},
 				{
 					Path:      "config/b.yml",
 					Content:   "original-b",
 					DirScope:  "config",
-					Reconcile: manifest.ReconcileMirror,
+					Reconcile: manifest.ReconcileAuthoritative,
 				},
 			},
 		},
@@ -104,8 +104,8 @@ func TestResolveFiles_InheritsDirScopeAndReconcile(t *testing.T) {
 	if result[0].DirScope != "config" {
 		t.Errorf("result[0].DirScope = %q, want %q (should inherit from original)", result[0].DirScope, "config")
 	}
-	if result[0].Reconcile != manifest.ReconcileMirror {
-		t.Errorf("result[0].Reconcile = %q, want %q (should inherit from original)", result[0].Reconcile, manifest.ReconcileMirror)
+	if result[0].Reconcile != manifest.ReconcileAuthoritative {
+		t.Errorf("result[0].Reconcile = %q, want %q (should inherit from original)", result[0].Reconcile, manifest.ReconcileAuthoritative)
 	}
 	// Vars should also be inherited
 	if result[0].Vars == nil || result[0].Vars["env"] != "prod" {
@@ -116,8 +116,8 @@ func TestResolveFiles_InheritsDirScopeAndReconcile(t *testing.T) {
 	if result[1].DirScope != "config" {
 		t.Errorf("result[1].DirScope = %q, want %q", result[1].DirScope, "config")
 	}
-	if result[1].Reconcile != manifest.ReconcileMirror {
-		t.Errorf("result[1].Reconcile = %q, want %q", result[1].Reconcile, manifest.ReconcileMirror)
+	if result[1].Reconcile != manifest.ReconcileAuthoritative {
+		t.Errorf("result[1].Reconcile = %q, want %q", result[1].Reconcile, manifest.ReconcileAuthoritative)
 	}
 }
 

--- a/internal/manifest/file_types.go
+++ b/internal/manifest/file_types.go
@@ -17,14 +17,24 @@ const (
 	CommitStrategyPullRequest = ViaPullRequest
 
 	// Reconcile values for FileEntry reconcile behavior.
-	ReconcilePatch      = "patch"       // default: add/update only
-	ReconcileMirror     = "mirror"      // add/update + delete orphans
-	ReconcileCreateOnly = "create_only" // create if missing, never update
+	ReconcileAdditive      = "additive"      // default: add/update only
+	ReconcileAuthoritative = "authoritative" // add/update + delete orphans in scope
+	ReconcileCreateOnly    = "create_only"   // create if missing, never update
+
+	// Deprecated: use ReconcileAdditive.
+	ReconcilePatch = ReconcileAdditive
+	// Deprecated: use ReconcileAuthoritative.
+	ReconcileMirror = ReconcileAuthoritative
 
 	// Deprecated: use Reconcile* constants instead.
-	SyncModePatch      = ReconcilePatch
-	SyncModeMirror     = ReconcileMirror
+	SyncModePatch      = ReconcileAdditive
+	SyncModeMirror     = ReconcileAuthoritative
 	SyncModeCreateOnly = ReconcileCreateOnly
+)
+
+const (
+	legacyReconcilePatch  = "patch"
+	legacyReconcileMirror = "mirror"
 )
 
 // File represents files to manage in a single repository.
@@ -82,7 +92,7 @@ type FileEntry struct {
 	Source         string            `yaml:"source,omitempty"`
 	Patches        []string          `yaml:"patches,omitempty"`
 	Vars           map[string]string `yaml:"vars,omitempty"`
-	Reconcile      string            `yaml:"reconcile,omitempty" validate:"omitempty,oneof=patch mirror create_only"`
+	Reconcile      string            `yaml:"reconcile,omitempty" validate:"omitempty,oneof=additive authoritative create_only"`
 	DirScope       string            `yaml:"-"`
 	OriginalSource string            `yaml:"-"` // local file path set during source resolution (import --into)
 
@@ -107,6 +117,14 @@ func (fe *FileEntry) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		return err
 	}
+	reconcileWarnings, err := normalizeFileReconcile(fe)
+	if err != nil {
+		if fe.Path != "" {
+			return fmt.Errorf("%s: %w", fe.Path, err)
+		}
+		return err
+	}
+	warnings = append(warnings, reconcileWarnings...)
 	// Prefix warnings with path for context
 	for i, w := range warnings {
 		if fe.Path != "" {
@@ -115,6 +133,21 @@ func (fe *FileEntry) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 	fe.DeprecationWarnings = warnings
 	return nil
+}
+
+func normalizeFileReconcile(fe *FileEntry) ([]string, error) {
+	switch fe.Reconcile {
+	case "", ReconcileAdditive, ReconcileAuthoritative, ReconcileCreateOnly:
+		return nil, nil
+	case legacyReconcilePatch:
+		fe.Reconcile = ReconcileAdditive
+		return []string{`"reconcile" value "patch" is deprecated, use "additive" instead`}, nil
+	case legacyReconcileMirror:
+		fe.Reconcile = ReconcileAuthoritative
+		return []string{`"reconcile" value "mirror" is deprecated, use "authoritative" instead`}, nil
+	default:
+		return nil, nil
+	}
 }
 
 // validateAndMigrateVia validates that commit_strategy and on_apply are not both set,

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -283,8 +283,7 @@ func parseFile(data []byte, path string, resolver *SourceResolver) (*FileSet, []
 	// Collect deprecation warnings
 	var warnings []string
 	warnings = append(warnings, f.Spec.DeprecationWarnings...)
-	warnings = append(warnings, fs.Spec.DeprecationWarnings...)
-	warnings = append(warnings, collectFileEntryWarnings(fs.Spec.Files)...)
+	warnings = append(warnings, collectFileSetWarnings(fs.Spec)...)
 
 	return fs, warnings, nil
 }
@@ -307,9 +306,7 @@ func parseFileSet(data []byte, path string, resolver *SourceResolver) (*FileSet,
 	fs.Spec.Files = resolved
 
 	// Collect deprecation warnings
-	var warnings []string
-	warnings = append(warnings, fs.Spec.DeprecationWarnings...)
-	warnings = append(warnings, collectFileEntryWarnings(fs.Spec.Files)...)
+	warnings := collectFileSetWarnings(fs.Spec)
 
 	return &fs, warnings, nil
 }
@@ -326,6 +323,16 @@ func collectFileEntryWarnings(files []FileEntry) []string {
 	var warnings []string
 	for _, f := range files {
 		warnings = append(warnings, f.DeprecationWarnings...)
+	}
+	return warnings
+}
+
+func collectFileSetWarnings(spec FileSetSpec) []string {
+	var warnings []string
+	warnings = append(warnings, spec.DeprecationWarnings...)
+	warnings = append(warnings, collectFileEntryWarnings(spec.Files)...)
+	for _, repo := range spec.Repositories {
+		warnings = append(warnings, collectFileEntryWarnings(repo.Overrides)...)
 	}
 	return warnings
 }

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -780,6 +780,102 @@ spec:
 	}
 }
 
+func TestParseFileSet_LegacyReconcileValues(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: FileSet
+metadata:
+  owner: org
+spec:
+  repositories:
+    - name: repo
+      overrides:
+        - path: override.txt
+          content: hello
+          reconcile: mirror
+  files:
+    - path: additive.txt
+      content: hello
+      reconcile: patch
+    - path: authoritative.txt
+      content: hello
+      reconcile: mirror
+`
+	path := filepath.Join(dir, "fileset.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ParseAll(path, fileOpts())
+	if err != nil {
+		t.Fatalf("ParseAll returned error: %v", err)
+	}
+
+	files := result.FileSets[0].Spec.Files
+	if files[0].Reconcile != ReconcileAdditive {
+		t.Fatalf("reconcile patch normalized to %q, want %q", files[0].Reconcile, ReconcileAdditive)
+	}
+	if files[1].Reconcile != ReconcileAuthoritative {
+		t.Fatalf("reconcile mirror normalized to %q, want %q", files[1].Reconcile, ReconcileAuthoritative)
+	}
+	if result.FileSets[0].Spec.Repositories[0].Overrides[0].Reconcile != ReconcileAuthoritative {
+		t.Fatalf("override reconcile mirror normalized to %q, want %q", result.FileSets[0].Spec.Repositories[0].Overrides[0].Reconcile, ReconcileAuthoritative)
+	}
+	if len(result.Warnings) != 3 {
+		t.Fatalf("expected 3 warnings, got %d: %v", len(result.Warnings), result.Warnings)
+	}
+	if !strings.Contains(result.Warnings[0], `"reconcile" value "patch" is deprecated`) {
+		t.Fatalf("warning[0] = %q, want patch deprecation", result.Warnings[0])
+	}
+	if !strings.Contains(result.Warnings[1], `"reconcile" value "mirror" is deprecated`) {
+		t.Fatalf("warning[1] = %q, want mirror deprecation", result.Warnings[1])
+	}
+	if !strings.Contains(result.Warnings[2], `"reconcile" value "mirror" is deprecated`) {
+		t.Fatalf("warning[2] = %q, want override mirror deprecation", result.Warnings[2])
+	}
+}
+
+func TestParseFileSet_NewReconcileValues(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: FileSet
+metadata:
+  owner: org
+spec:
+  repositories:
+    - repo
+  files:
+    - path: additive.txt
+      content: hello
+      reconcile: additive
+    - path: authoritative.txt
+      content: hello
+      reconcile: authoritative
+`
+	path := filepath.Join(dir, "fileset.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ParseAll(path, fileOpts())
+	if err != nil {
+		t.Fatalf("ParseAll returned error: %v", err)
+	}
+
+	files := result.FileSets[0].Spec.Files
+	if files[0].Reconcile != ReconcileAdditive {
+		t.Fatalf("reconcile = %q, want %q", files[0].Reconcile, ReconcileAdditive)
+	}
+	if files[1].Reconcile != ReconcileAuthoritative {
+		t.Fatalf("reconcile = %q, want %q", files[1].Reconcile, ReconcileAuthoritative)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", result.Warnings)
+	}
+}
+
 func TestParseFileSet_MissingOwner(t *testing.T) {
 	dir := t.TempDir()
 	content := `

--- a/internal/manifest/source_test.go
+++ b/internal/manifest/source_test.go
@@ -467,7 +467,7 @@ func TestResolveFiles_DirScope_LocalDirectory(t *testing.T) {
 		{
 			Path:      ".github/workflows",
 			Source:    "configs",
-			Reconcile: ReconcileMirror,
+			Reconcile: ReconcileAuthoritative,
 		},
 	}
 	result, err := r.ResolveFiles(context.Background(), files, dir)
@@ -484,8 +484,8 @@ func TestResolveFiles_DirScope_LocalDirectory(t *testing.T) {
 		if entry.DirScope != ".github/workflows" {
 			t.Errorf("result[%d].DirScope = %q, want %q", i, entry.DirScope, ".github/workflows")
 		}
-		if entry.Reconcile != ReconcileMirror {
-			t.Errorf("result[%d].Reconcile = %q, want %q", i, entry.Reconcile, ReconcileMirror)
+		if entry.Reconcile != ReconcileAuthoritative {
+			t.Errorf("result[%d].Reconcile = %q, want %q", i, entry.Reconcile, ReconcileAuthoritative)
 		}
 	}
 }

--- a/internal/manifest/validation_test.go
+++ b/internal/manifest/validation_test.go
@@ -570,15 +570,15 @@ func TestValidateFileSet_InvalidReconcile(t *testing.T) {
 			wantErr:  "invalid reconcile",
 		},
 		{
-			name:     "valid reconcile patch",
-			syncMode: ReconcilePatch,
+			name:     "valid reconcile additive",
+			syncMode: ReconcileAdditive,
 		},
 		{
-			name:     "valid reconcile mirror",
-			syncMode: ReconcileMirror,
+			name:     "valid reconcile authoritative",
+			syncMode: ReconcileAuthoritative,
 		},
 		{
-			name:     "empty reconcile is valid (defaults to patch)",
+			name:     "empty reconcile is valid (defaults to additive)",
 			syncMode: "",
 		},
 	}

--- a/skills/file-manifest/SKILL.md
+++ b/skills/file-manifest/SKILL.md
@@ -16,7 +16,7 @@ Use this skill for file-distribution manifests. Keep the main body small and ope
 - `File` is parsed as a one-repo `FileSet` internally, but you still author the simpler shape
 - Each file entry requires `path` and exactly one of `content` or `source`
 - `via` defaults to `push`
-- `reconcile` defaults to `patch`
+- `reconcile` defaults to `additive`
 - `patches` are applied after template expansion
 
 ## File
@@ -45,7 +45,7 @@ Key fields:
 - `commit_message`, `branch`, `pr_title`, `pr_body`: delivery controls
 - `files[].vars`: template variables
 - `files[].patches`: unified diff patches
-- `files[].reconcile`: `patch`, `mirror`, `create_only`
+- `files[].reconcile`: `additive`, `authoritative`, `create_only`
 
 Read these references as needed:
 
@@ -98,7 +98,7 @@ Overrides replace the matching base entry by `path` for that repository only.
 - Prefer patch files over inline patch blocks for files with tabs
 - Patch context must match template-expanded content, not raw template source
 - `github://` sources are import hard-skips because there is no local write target
-- Shared local source files in `FileSet` often default to `patch` in `import --into`
+- Shared local source files in `FileSet` often default to the `patch` write action in `import --into`
 - `create_only` affects apply behavior, but import can still update the local master template
 
 ## Verification

--- a/skills/file-manifest/references/reconcile-and-delivery.md
+++ b/skills/file-manifest/references/reconcile-and-delivery.md
@@ -4,8 +4,8 @@
 
 Modes:
 
-- `patch`: create and update only
-- `mirror`: create, update, and delete orphans under the managed directory
+- `additive`: create and update only
+- `authoritative`: create, update, and delete orphans under the managed directory
 - `create_only`: create if missing, never update on apply
 
 Examples:
@@ -20,7 +20,7 @@ files:
 files:
   - path: .github/workflows
     source: ./templates/workflows/
-    reconcile: mirror
+    reconcile: authoritative
 ```
 
 ```yaml


### PR DESCRIPTION
## Summary

Rename File/FileSet reconcile modes from `patch`/`mirror` to `additive`/`authoritative`, aligning with the terminology already adopted for Repository resources. Old values are accepted as deprecated aliases with automatic migration and warnings. Record the cross-resource naming convention in ADR-006.

## Background

gh-infra's Repository resources adopted `additive`/`authoritative` as reconcile mode names (ADR-005), following established IaC terminology (Terraform, Puppet). However, File/FileSet resources still used `patch`/`mirror` for the same concepts. This created a vocabulary split where users had to learn different words for the same behavior depending on the resource type. Additionally, `patch` conflicted semantically with the `patches:` field on file entries, and `mirror` risked confusion with Git repository mirroring.

## Changes

- **Constants**: Add `ReconcileAdditive` and `ReconcileAuthoritative` as canonical values; keep `ReconcilePatch` and `ReconcileMirror` as deprecated aliases
- **Validation tag**: Update `oneof` to accept both old and new values (`additive`, `authoritative`, `patch`, `mirror`, `create_only`)
- **Parser migration**: Automatically rewrite `patch`→`additive` and `mirror`→`authoritative` during parsing with deprecation warnings via `MigrateDeprecatedReconcile()`
- **Plan logic**: Update `plan.go` to compare against new constants (`ReconcileAuthoritative`, `ReconcileCreateOnly`)
- **Override inheritance**: Tests updated to use new values
- **ADR-006**: New ADR documenting the naming convention decision, rationale (IaC alignment, `patches:` collision, GitHub mirror confusion), and migration strategy
- **Docs**: Update `reconcile.mdx`, `sources.md`, `file/index.md`, `fileset/index.md` to use `additive`/`authoritative`
- **Skills**: Update `file-manifest` SKILL.md and `reconcile-and-delivery.md` references
- **Tests**: Add `TestFileReconcileDeprecatedMigration` for alias migration, update all existing tests to use new values