### PR TITLE
Update internals docs for GraphQL createCommitOnBranch mutation

### DIFF
--- a/docs/src/content/docs/internals/concurrency.md
+++ b/docs/src/content/docs/internals/concurrency.md
@@ -145,18 +145,11 @@ flowchart TB
         direction TB
         subgraph ga["worker: repo-A (direct push)"]
             direction TB
-            a1[get HEAD SHA] --> a2[create blob file-1]
-            a2 --> a3[create blob file-2]
-            a3 --> a4[create tree]
-            a4 --> a5[create commit]
-            a5 --> a6[update ref]
+            a1[get HEAD SHA] --> a2[createCommitOnBranch]
         end
         subgraph gb["worker: repo-B (pull request)"]
             direction TB
-            b1[get HEAD SHA] --> b2[create blob file-1]
-            b2 --> b3[create tree]
-            b3 --> b4[create commit]
-            b4 --> b5[create pull request]
+            b1[get HEAD SHA] --> b2[create branch] --> b3[createCommitOnBranch] --> b4[open pull request]
         end
     end
     pool --> flat["Flatten results in order"]
@@ -166,13 +159,10 @@ flowchart TB
 
 - Changes are grouped by target repo using `groupChangesByTarget()`
 - **Repos run in parallel** — bounded by worker pool (max 10)
-- **Within each repo, all operations are sequential** — Git Data API requires:
+- **Within each repo, all operations are sequential** — the GraphQL `createCommitOnBranch` mutation requires:
   1. Get HEAD SHA (base commit)
-  2. Create blobs for each file
-  3. Create tree referencing the blobs
-  4. Create commit pointing to the tree
-  5. Update ref (direct push) or create pull request
-- A single commit bundles all file changes for one repo
+  2. Send mutation with all file additions/deletions (direct push), or create branch first then send mutation and open PR (pull request)
+- A single verified commit bundles all file changes for one repo
 - Spinner display shows per-repo progress
 
 ### Import — `importMultipleRepos`
@@ -270,7 +260,7 @@ Assuming 1 protected branch, 1 ruleset per repo:
 | 20 | ~38 | ~131 |
 
 :::caution
-These estimates cover the **plan phase only**. An `apply` run executes the plan fetch first, then makes additional API calls to mutate state (create/update settings, Git Data API for file commits, etc.). Budget accordingly.
+These estimates cover the **plan phase only**. An `apply` run executes the plan fetch first, then makes additional API calls to mutate state (create/update settings, GraphQL commit mutation for file commits, etc.). Budget accordingly.
 :::
 
 ### Strategies for Large-Scale Usage
@@ -290,4 +280,4 @@ If you manage hundreds of repositories and approach the 5,000/hr limit:
 | Plan output rendering | Must be sequential for readable terminal output |
 | Confirm prompt | Blocks on user input |
 | Settings within a repo | API ordering dependencies (create → configure) |
-| Git Data API within a repo | Each step depends on the previous (HEAD → blob → tree → commit → ref) |
+| GraphQL commit within a repo | Mutation requires HEAD SHA; for PRs the branch must be created first |

--- a/docs/src/content/docs/internals/git-api.md
+++ b/docs/src/content/docs/internals/git-api.md
@@ -1,33 +1,33 @@
 ---
-title: Git Data API vs Contents API
+title: GraphQL Commit API vs Contents API
 sidebar:
   order: 4
 ---
 
 gh-infra uses two different GitHub APIs to write files, depending on the repository state.
 
-## Git Data API (default)
+## GraphQL `createCommitOnBranch` (default)
 
-For repositories with at least one commit, gh-infra uses the **Git Data API**. This API operates on Git's low-level objects (blobs, trees, commits, refs), which means **all file changes are bundled into a single atomic commit** regardless of how many files are modified.
+For repositories with at least one commit, gh-infra uses the **GraphQL `createCommitOnBranch` mutation**. This mutation commits all file additions and deletions atomically in a single API call, and GitHub automatically marks the resulting commit as **Verified** — no local GPG or SSH signing is required.
 
 The process:
 
-1. Create a **blob** for each file's content
-2. Create a **tree** containing all blobs (deletions use SHA=null)
-3. Create a **commit** pointing to that tree
-4. Update the default branch **ref** to the new commit (`via: push`), or create a new branch and open a PR (`via: pull_request`)
+1. Get the HEAD SHA of the default branch
+2. Send a `createCommitOnBranch` mutation with all file changes (additions as base64-encoded content, deletions by path)
+3. For `via: push` — the mutation targets the default branch directly
+4. For `via: pull_request` — gh-infra creates a branch first, then the mutation targets that branch, and a PR is opened
 
-This applies to both `push` and `pull_request` — changes are always a single commit.
+All file changes are bundled into a single atomic, verified commit regardless of how many files are modified. This applies to both `push` and `pull_request` delivery methods.
 
 ## Contents API (empty repository fallback)
 
-Repositories with **no commits** (e.g. freshly created) cannot use the Git Data API because there is no existing HEAD to use as the `base_tree`. In this case, gh-infra automatically falls back to the **Contents API**.
+Repositories with **no commits** (e.g. freshly created) cannot use the GraphQL mutation because there is no existing HEAD. In this case, gh-infra automatically falls back to the **Contents API**.
 
 The Contents API can only operate on one file per request, so **each file becomes a separate commit**. The `via` setting is ignored — all files are pushed directly to the default branch.
 
 ```
-# Normal repository (Git Data API)
-commit abc123: "chore: sync files via gh-infra"
+# Normal repository (GraphQL createCommitOnBranch)
+commit abc123 ✓: "chore: sync files via gh-infra"
   - .github/CODEOWNERS       (created)
   - .github/workflows/ci.yml (created)
   - LICENSE                   (created)
@@ -38,4 +38,4 @@ commit def456: "chore: sync files: .github/workflows/ci.yml"
 commit 789ghi: "chore: sync files: LICENSE"
 ```
 
-This fallback is automatic — no user configuration is needed. After the first files are committed, all subsequent `apply` runs use the Git Data API as normal.
+This fallback is automatic — no user configuration is needed. After the first files are committed, all subsequent `apply` runs use the GraphQL mutation as normal.

--- a/docs/src/content/docs/resources/file/delivery.md
+++ b/docs/src/content/docs/resources/file/delivery.md
@@ -48,4 +48,4 @@ If a pull request already exists for the branch, gh-infra updates it instead of 
 
 ## Empty repositories
 
-For repositories with no commits yet, gh-infra falls back to the Contents API regardless of the `via` setting. Each file becomes a separate commit. See [Git Data API vs Contents API](/internals/git-api/) for details.
+For repositories with no commits yet, gh-infra falls back to the Contents API regardless of the `via` setting. Each file becomes a separate commit. See [GraphQL Commit API vs Contents API](/internals/git-api/) for details.


### PR DESCRIPTION
## Summary

Update internal documentation to reflect the switch from Git Data API to GraphQL `createCommitOnBranch` mutation (PR #139).

## Background

PR #139 replaced the 4-step Git Data API flow (blob → tree → commit → ref update) with a single GraphQL `createCommitOnBranch` mutation that produces verified commits. The internal docs still described the old flow.

## Changes

- **`internals/git-api.md`**: Rewrite to describe the GraphQL mutation flow; note that commits are automatically Verified; rename page title
- **`internals/concurrency.md`**: Update Mermaid diagram (simplified flow), sequential operation table, and API budget note
- **`resources/file/delivery.md`**: Update cross-reference link text