### PR TITLE
Fix FileSet per-repo override source resolution

### DIFF
--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -305,6 +305,16 @@ func parseFileSet(data []byte, path string, resolver *SourceResolver) (*FileSet,
 	}
 	fs.Spec.Files = resolved
 
+	for i, repo := range fs.Spec.Repositories {
+		if len(repo.Overrides) > 0 {
+			resolvedOverrides, err := resolver.ResolveFiles(context.Background(), repo.Overrides, filepath.Dir(path))
+			if err != nil {
+				return nil, nil, fmt.Errorf("%s: resolve overrides for %s: %w", path, repo.Name, err)
+			}
+			fs.Spec.Repositories[i].Overrides = resolvedOverrides
+		}
+	}
+
 	// Collect deprecation warnings
 	warnings := collectFileSetWarnings(fs.Spec)
 

--- a/internal/manifest/source_test.go
+++ b/internal/manifest/source_test.go
@@ -592,6 +592,85 @@ func TestResolveFiles_PatchesPropagated(t *testing.T) {
 	}
 }
 
+func TestParseFileSet_OverrideSourceResolved(t *testing.T) {
+	t.Run("source resolved to content", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "default.yml"), []byte("default-content\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "override.yml"), []byte("override-content\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		yamlContent := `apiVersion: gh-infra/v1
+kind: FileSet
+metadata:
+  owner: testowner
+spec:
+  repositories:
+    - name: repo-a
+      overrides:
+        - path: .github/workflows/ci.yml
+          source: override.yml
+  files:
+    - path: .github/workflows/ci.yml
+      source: default.yml
+  via: push
+  commit_message: "test"
+`
+		if err := os.WriteFile(filepath.Join(dir, "fileset.yaml"), []byte(yamlContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		fs, _, err := parseFileSet([]byte(yamlContent), filepath.Join(dir, "fileset.yaml"), &SourceResolver{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if fs.Spec.Files[0].Content != "default-content\n" {
+			t.Errorf("default content: got %q, want %q", fs.Spec.Files[0].Content, "default-content\n")
+		}
+		if fs.Spec.Repositories[0].Overrides[0].Content != "override-content\n" {
+			t.Errorf("override content: got %q, want %q", fs.Spec.Repositories[0].Overrides[0].Content, "override-content\n")
+		}
+	})
+
+	t.Run("missing override source returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "default.yml"), []byte("default-content\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		yamlContent := `apiVersion: gh-infra/v1
+kind: FileSet
+metadata:
+  owner: testowner
+spec:
+  repositories:
+    - name: repo-a
+      overrides:
+        - path: .github/workflows/ci.yml
+          source: missing.yml
+  files:
+    - path: .github/workflows/ci.yml
+      source: default.yml
+  via: push
+  commit_message: "test"
+`
+		if err := os.WriteFile(filepath.Join(dir, "fileset.yaml"), []byte(yamlContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, err := parseFileSet([]byte(yamlContent), filepath.Join(dir, "fileset.yaml"), &SourceResolver{})
+		if err == nil {
+			t.Fatal("expected error for missing override source")
+		}
+		if !strings.Contains(err.Error(), "resolve overrides") {
+			t.Errorf("error should contain %q, got: %v", "resolve overrides", err)
+		}
+	})
+}
+
 func TestResolveFiles_DuplicatePathError(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Fixes FileSet per-repo override entries with `source:` fields not being resolved to content.

## Background

`parseFileSet()` resolved `Source → Content` for `spec.files` (the default entries) but not for `repositories[].overrides` entries. Because `resolver.ResolveFiles()` was never called on overrides, their `Content` stayed empty. `resolve.go` then fell back to the default file's content for both `plan` and `apply`, silently pushing the wrong file.

## Changes

- Call `resolver.ResolveFiles()` on each repo's `Overrides` slice in `parseFileSet()`, mirroring the existing call for `spec.files`
- Add `TestParseFileSet_OverrideSourceResolved` covering source-resolved-to-content and missing-override-source-returns-error

Closes #151