### PR TITLE
fix: address golangci-lint v2.12 govet and modernize issues

### DIFF
--- a/internal/manifest/common.go
+++ b/internal/manifest/common.go
@@ -58,6 +58,4 @@ func (r *ParseResult) Merge(other *ParseResult) {
 }
 
 // Ptr returns a pointer to the given value.
-//
-//go:fix inline
 func Ptr[T any](v T) *T { return new(v) }

--- a/internal/manifest/tagvalidator.go
+++ b/internal/manifest/tagvalidator.go
@@ -31,7 +31,7 @@ func ValidateStruct(prefix string, v any) error {
 // (dot-separated YAML path) for error messages.
 func validateStructRecursive(prefix, structPath string, v any) error {
 	rv := reflect.ValueOf(v)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 	if rv.Kind() != reflect.Struct {
@@ -63,7 +63,7 @@ func validateStructRecursive(prefix, structPath string, v any) error {
 			if err := validateStructRecursive(prefix, fieldPath, fv.Addr().Interface()); err != nil {
 				return err
 			}
-		case reflect.Ptr:
+		case reflect.Pointer:
 			if !fv.IsNil() && fv.Elem().Kind() == reflect.Struct {
 				if err := validateStructRecursive(prefix, fieldPath, fv.Interface()); err != nil {
 					return err
@@ -122,7 +122,7 @@ func validateField(fieldPath string, fv reflect.Value, tag string, parentStruct 
 // Returns an error if a deprecated field and its migration target are both set.
 func MigrateDeprecated(v any) ([]string, error) {
 	rv := reflect.ValueOf(v)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 	if rv.Kind() != reflect.Struct {
@@ -223,7 +223,7 @@ func checkRequired(name string, fv reflect.Value) error {
 		if fv.IsNil() || fv.Len() == 0 {
 			return fmt.Errorf("%s is required", name)
 		}
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if fv.IsNil() {
 			return fmt.Errorf("%s is required", name)
 		}
@@ -237,7 +237,7 @@ func checkOneOf(name string, fv reflect.Value, allowed []string) error {
 	switch fv.Kind() {
 	case reflect.String:
 		val = fv.String()
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if fv.IsNil() {
 			return nil
 		}
@@ -260,7 +260,7 @@ func checkUnique(fieldPath string, fv reflect.Value, keyYAML string) error {
 	}
 	// Resolve yaml name to Go field name from the element type
 	elemType := fv.Type().Elem()
-	if elemType.Kind() == reflect.Ptr {
+	if elemType.Kind() == reflect.Pointer {
 		elemType = elemType.Elem()
 	}
 	sf, ok := goFieldByYAMLName(elemType, keyYAML)
@@ -270,7 +270,7 @@ func checkUnique(fieldPath string, fv reflect.Value, keyYAML string) error {
 	seen := make(map[string]bool)
 	for i := range fv.Len() {
 		elem := fv.Index(i)
-		if elem.Kind() == reflect.Ptr {
+		if elem.Kind() == reflect.Pointer {
 			elem = elem.Elem()
 		}
 		if elem.Kind() != reflect.Struct {
@@ -322,7 +322,7 @@ func checkExclusive(fieldPath string, fv reflect.Value, parent reflect.Value, ot
 // isZero checks if a value is the zero value for its type.
 func isZero(fv reflect.Value) bool {
 	switch fv.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		return fv.IsNil()
 	case reflect.String:
 		return fv.String() == ""

--- a/internal/yamledit/yamledit.go
+++ b/internal/yamledit/yamledit.go
@@ -2,6 +2,7 @@ package yamledit
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -217,8 +218,8 @@ func Delete(data []byte, docIndex int, yamlPath string) ([]byte, error) {
 		return data, nil
 	}
 
-	for i := len(parents) - 1; i >= 0; i-- {
-		if childMap, ok := parents[i].child.(*ast.MappingNode); ok && len(childMap.Values) == 0 {
+	for i, p := range slices.Backward(parents) {
+		if childMap, ok := p.child.(*ast.MappingNode); ok && len(childMap.Values) == 0 {
 			deleteMappingKey(parents[i].node, parents[i].key)
 			continue
 		}


### PR DESCRIPTION
## Summary

Fix lint errors that broke CI on `main` after golangci-lint upgraded to v2.12.1.

## Background

After #148 merged, the `Go / lint` job on `main` started failing because the runner's `latest` golangci-lint resolved to v2.12.1, which ships stricter `govet inline` checks and a `modernize` rule. The build itself is fine; only the linter complains.

Run: https://github.com/babarot/gh-infra/actions/runs/25421251152

Reported issues:

- `internal/importer/repository_test.go` - 3x `govet inline: type parameter inference is not yet supported` against `manifest.Ptr(...)` calls (the function carries `//go:fix inline` but the analyzer cannot inline a generic function).
- `internal/manifest/tagvalidator.go` - 6x `govet inline: Constant reflect.Ptr should be inlined`. `reflect.Ptr` is the legacy alias of `reflect.Pointer`.
- `internal/yamledit/yamledit.go:220` - `modernize: backward loop over slice can be modernized using slices.Backward`.

## Changes

- Drop the `//go:fix inline` directive on `manifest.Ptr`. The function is generic, so the analyzer cannot inline it; removing the directive is the path of least surprise and avoids touching every caller site.
- Replace `reflect.Ptr` with `reflect.Pointer` throughout `internal/manifest/tagvalidator.go`.
- Rewrite the parent cleanup loop in `yamledit.Delete` using `slices.Backward`.