### PR TITLE
Merge secrets and variables by key in RepositorySet

### DIFF
--- a/docs/src/content/docs/resources/repository-set/defaults.md
+++ b/docs/src/content/docs/resources/repository-set/defaults.md
@@ -165,7 +165,27 @@ repositories:
       # result: DEPLOY_TOKEN (custom) + SLACK_WEBHOOK (from defaults) + EXTRA_TOKEN (new)
 ```
 
-Variables follow the same merge behavior.
+#### Variables
+
+```yaml
+defaults:
+  spec:
+    variables:
+      - name: APP_ENV
+        value: production
+      - name: REGION
+        value: us-east-1
+
+repositories:
+  - name: my-repo
+    spec:
+      variables:
+        - name: REGION
+          value: eu-west-1           # overrides default REGION
+        - name: EXTRA_VAR
+          value: custom-value        # appended
+      # result: APP_ENV (from defaults) + REGION (custom) + EXTRA_VAR (new)
+```
 
 ### Maps — merged by key
 

--- a/docs/src/content/docs/resources/repository-set/defaults.md
+++ b/docs/src/content/docs/resources/repository-set/defaults.md
@@ -72,6 +72,8 @@ Collections with a natural key field are merged. Entries with the same key are m
 | `labels` | `name` | Entry replaced |
 | `branch_protection` | `pattern` | Fields merged (unspecified fields inherit default) |
 | `rulesets` | `name` | Entry replaced |
+| `secrets` | `name` | Entry replaced |
+| `variables` | `name` | Entry replaced |
 
 #### Labels
 
@@ -138,6 +140,32 @@ repositories:
           target: branch
           enforcement: evaluate   # replaces the entire default ruleset entry
 ```
+
+#### Secrets & Variables
+
+Same-name entries are replaced; new entries are appended; default entries not referenced are inherited.
+
+```yaml
+defaults:
+  spec:
+    secrets:
+      - name: DEPLOY_TOKEN
+        value: "${ENV_DEPLOY_TOKEN}"
+      - name: SLACK_WEBHOOK
+        value: "${ENV_SLACK_WEBHOOK}"
+
+repositories:
+  - name: my-repo
+    spec:
+      secrets:
+        - name: DEPLOY_TOKEN
+          value: "${ENV_CUSTOM_TOKEN}"   # overrides default DEPLOY_TOKEN
+        - name: EXTRA_TOKEN
+          value: "${ENV_EXTRA_TOKEN}"    # appended
+      # result: DEPLOY_TOKEN (custom) + SLACK_WEBHOOK (from defaults) + EXTRA_TOKEN (new)
+```
+
+Variables follow the same merge behavior.
 
 ### Maps — merged by key
 

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -418,11 +418,13 @@ func mergeSpecs(defaults *RepositorySetDefaults, override RepositorySpec) Reposi
 		result.Rulesets = mergeRulesets(result.Rulesets, override.Rulesets)
 		result.RulesetsSet = true
 	}
-	if len(override.Secrets) > 0 {
-		result.Secrets = override.Secrets
+	if override.SecretsSet {
+		result.Secrets = mergeSecrets(result.Secrets, override.Secrets)
+		result.SecretsSet = true
 	}
-	if len(override.Variables) > 0 {
-		result.Variables = override.Variables
+	if override.VariablesSet {
+		result.Variables = mergeVariables(result.Variables, override.Variables)
+		result.VariablesSet = true
 	}
 	if override.LabelsSet {
 		result.Labels = mergeLabels(result.Labels, override.Labels)
@@ -704,6 +706,62 @@ func mergeRulesets(base, override []Ruleset) []Ruleset {
 		} else {
 			index[rs.Name] = len(result)
 			result = append(result, rs)
+		}
+	}
+	return result
+}
+
+// mergeSecrets merges two secret slices by name. Override secrets take precedence
+// for entries with the same name; new secrets are appended.
+func mergeSecrets(base, override []Secret) []Secret {
+	if len(base) == 0 {
+		return override
+	}
+	if len(override) == 0 {
+		return base
+	}
+
+	index := make(map[string]int, len(base))
+	result := make([]Secret, len(base))
+	copy(result, base)
+	for i, s := range result {
+		index[s.Name] = i
+	}
+
+	for _, s := range override {
+		if i, ok := index[s.Name]; ok {
+			result[i] = s
+		} else {
+			index[s.Name] = len(result)
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// mergeVariables merges two variable slices by name. Override variables take precedence
+// for entries with the same name; new variables are appended.
+func mergeVariables(base, override []Variable) []Variable {
+	if len(base) == 0 {
+		return override
+	}
+	if len(override) == 0 {
+		return base
+	}
+
+	index := make(map[string]int, len(base))
+	result := make([]Variable, len(base))
+	copy(result, base)
+	for i, v := range result {
+		index[v.Name] = i
+	}
+
+	for _, v := range override {
+		if i, ok := index[v.Name]; ok {
+			result[i] = v
+		} else {
+			index[v.Name] = len(result)
+			result = append(result, v)
 		}
 	}
 	return result

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -2313,3 +2313,206 @@ spec:
 		t.Fatal("expected validation error for invalid milestone state value")
 	}
 }
+
+func TestRepositorySet_SecretsMerge(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: RepositorySet
+metadata:
+  owner: org
+defaults:
+  spec:
+    secrets:
+      - name: DEPLOY_TOKEN
+        value: "${ENV_DEPLOY_TOKEN}"
+      - name: SLACK_WEBHOOK
+        value: "${ENV_SLACK_WEBHOOK}"
+repositories:
+  - name: inherits-secrets
+    spec:
+      description: "inherits default secrets"
+  - name: adds-secret
+    spec:
+      secrets:
+        - name: EXTRA_TOKEN
+          value: "${ENV_EXTRA_TOKEN}"
+  - name: overrides-secret
+    spec:
+      secrets:
+        - name: DEPLOY_TOKEN
+          value: "${ENV_CUSTOM_TOKEN}"
+`
+	path := filepath.Join(dir, "secrets.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath error: %v", err)
+	}
+	if len(repos) != 3 {
+		t.Fatalf("expected 3 repos, got %d", len(repos))
+	}
+
+	// inherits-secrets: should have both default secrets
+	if len(repos[0].Spec.Secrets) != 2 {
+		t.Errorf("inherits-secrets: expected 2 secrets, got %d", len(repos[0].Spec.Secrets))
+	}
+
+	// adds-secret: should have defaults + new secret (3 total)
+	if len(repos[1].Spec.Secrets) != 3 {
+		t.Fatalf("adds-secret: expected 3 secrets, got %d", len(repos[1].Spec.Secrets))
+	}
+	secretNames := make(map[string]bool)
+	for _, s := range repos[1].Spec.Secrets {
+		secretNames[s.Name] = true
+	}
+	for _, want := range []string{"DEPLOY_TOKEN", "SLACK_WEBHOOK", "EXTRA_TOKEN"} {
+		if !secretNames[want] {
+			t.Errorf("adds-secret: missing secret %q", want)
+		}
+	}
+
+	// overrides-secret: DEPLOY_TOKEN replaced, SLACK_WEBHOOK inherited (2 total)
+	if len(repos[2].Spec.Secrets) != 2 {
+		t.Fatalf("overrides-secret: expected 2 secrets, got %d", len(repos[2].Spec.Secrets))
+	}
+	// verify DEPLOY_TOKEN was overridden
+	for _, s := range repos[2].Spec.Secrets {
+		if s.Name == "DEPLOY_TOKEN" && s.Value != "${ENV_CUSTOM_TOKEN}" {
+			t.Errorf("overrides-secret: DEPLOY_TOKEN value = %q, want ${ENV_CUSTOM_TOKEN}", s.Value)
+		}
+	}
+}
+
+func TestRepositorySet_VariablesMerge(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: RepositorySet
+metadata:
+  owner: org
+defaults:
+  spec:
+    variables:
+      - name: APP_ENV
+        value: production
+      - name: REGION
+        value: us-east-1
+repositories:
+  - name: inherits-variables
+    spec:
+      description: "inherits default variables"
+  - name: adds-variable
+    spec:
+      variables:
+        - name: EXTRA_VAR
+          value: custom-value
+  - name: overrides-variable
+    spec:
+      variables:
+        - name: REGION
+          value: eu-west-1
+`
+	path := filepath.Join(dir, "variables.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath error: %v", err)
+	}
+	if len(repos) != 3 {
+		t.Fatalf("expected 3 repos, got %d", len(repos))
+	}
+
+	// inherits-variables: should have both default variables
+	if len(repos[0].Spec.Variables) != 2 {
+		t.Errorf("inherits-variables: expected 2 variables, got %d", len(repos[0].Spec.Variables))
+	}
+
+	// adds-variable: defaults + new variable (3 total)
+	if len(repos[1].Spec.Variables) != 3 {
+		t.Fatalf("adds-variable: expected 3 variables, got %d", len(repos[1].Spec.Variables))
+	}
+	varNames := make(map[string]bool)
+	for _, v := range repos[1].Spec.Variables {
+		varNames[v.Name] = true
+	}
+	for _, want := range []string{"APP_ENV", "REGION", "EXTRA_VAR"} {
+		if !varNames[want] {
+			t.Errorf("adds-variable: missing variable %q", want)
+		}
+	}
+
+	// overrides-variable: REGION replaced (eu-west-1), APP_ENV inherited (2 total)
+	if len(repos[2].Spec.Variables) != 2 {
+		t.Fatalf("overrides-variable: expected 2 variables, got %d", len(repos[2].Spec.Variables))
+	}
+	for _, v := range repos[2].Spec.Variables {
+		if v.Name == "REGION" && v.Value != "eu-west-1" {
+			t.Errorf("overrides-variable: REGION value = %q, want eu-west-1", v.Value)
+		}
+		if v.Name == "APP_ENV" && v.Value != "production" {
+			t.Errorf("overrides-variable: APP_ENV value = %q, want production (inherited)", v.Value)
+		}
+	}
+}
+
+func TestRepositorySet_SecretsMerge_OverrideByName(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: RepositorySet
+metadata:
+  owner: org
+defaults:
+  spec:
+    secrets:
+      - name: DEFAULT_SECRET_A
+        value: value-a
+      - name: DEFAULT_SECRET_B
+        value: value-b
+repositories:
+  - name: repo-a
+    spec:
+      secrets:
+        - name: DEFAULT_SECRET_A
+          value: overridden-a
+        - name: NEW_SECRET
+          value: new-value
+`
+	path := filepath.Join(dir, "secrets.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath error: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+
+	secrets := repos[0].Spec.Secrets
+	if len(secrets) != 3 {
+		t.Fatalf("expected 3 secrets, got %d", len(secrets))
+	}
+
+	// DEFAULT_SECRET_A overridden (value changed)
+	if secrets[0].Name != "DEFAULT_SECRET_A" || secrets[0].Value != "overridden-a" {
+		t.Errorf("DEFAULT_SECRET_A not overridden: got name=%q value=%q", secrets[0].Name, secrets[0].Value)
+	}
+	// DEFAULT_SECRET_B inherited from defaults
+	if secrets[1].Name != "DEFAULT_SECRET_B" || secrets[1].Value != "value-b" {
+		t.Errorf("DEFAULT_SECRET_B not inherited: got %+v", secrets[1])
+	}
+	// NEW_SECRET appended
+	if secrets[2].Name != "NEW_SECRET" || secrets[2].Value != "new-value" {
+		t.Errorf("NEW_SECRET not appended: got %+v", secrets[2])
+	}
+}

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -2052,6 +2052,32 @@ spec:
 			wantErr: "cannot specify both reconcile.labels and spec.label_sync",
 		},
 		{
+			name: "null secrets rejected",
+			content: `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+spec:
+  secrets:
+`,
+			wantErr: "secrets must be a sequence",
+		},
+		{
+			name: "null variables rejected",
+			content: `
+apiVersion: v1
+kind: Repository
+metadata:
+  owner: org
+  name: repo
+spec:
+  variables:
+`,
+			wantErr: "variables must be a sequence",
+		},
+		{
 			name: "null labels rejected",
 			content: `
 apiVersion: v1
@@ -2365,13 +2391,22 @@ repositories:
 	if len(repos[1].Spec.Secrets) != 3 {
 		t.Fatalf("adds-secret: expected 3 secrets, got %d", len(repos[1].Spec.Secrets))
 	}
-	secretNames := make(map[string]bool)
 	for _, s := range repos[1].Spec.Secrets {
-		secretNames[s.Name] = true
-	}
-	for _, want := range []string{"DEPLOY_TOKEN", "SLACK_WEBHOOK", "EXTRA_TOKEN"} {
-		if !secretNames[want] {
-			t.Errorf("adds-secret: missing secret %q", want)
+		switch s.Name {
+		case "DEPLOY_TOKEN":
+			if s.Value != "${ENV_DEPLOY_TOKEN}" {
+				t.Errorf("adds-secret: DEPLOY_TOKEN value = %q, want ${ENV_DEPLOY_TOKEN} (inherited)", s.Value)
+			}
+		case "SLACK_WEBHOOK":
+			if s.Value != "${ENV_SLACK_WEBHOOK}" {
+				t.Errorf("adds-secret: SLACK_WEBHOOK value = %q, want ${ENV_SLACK_WEBHOOK} (inherited)", s.Value)
+			}
+		case "EXTRA_TOKEN":
+			if s.Value != "${ENV_EXTRA_TOKEN}" {
+				t.Errorf("adds-secret: EXTRA_TOKEN value = %q, want ${ENV_EXTRA_TOKEN}", s.Value)
+			}
+		default:
+			t.Errorf("adds-secret: unexpected secret %q", s.Name)
 		}
 	}
 
@@ -2379,10 +2414,18 @@ repositories:
 	if len(repos[2].Spec.Secrets) != 2 {
 		t.Fatalf("overrides-secret: expected 2 secrets, got %d", len(repos[2].Spec.Secrets))
 	}
-	// verify DEPLOY_TOKEN was overridden
 	for _, s := range repos[2].Spec.Secrets {
-		if s.Name == "DEPLOY_TOKEN" && s.Value != "${ENV_CUSTOM_TOKEN}" {
-			t.Errorf("overrides-secret: DEPLOY_TOKEN value = %q, want ${ENV_CUSTOM_TOKEN}", s.Value)
+		switch s.Name {
+		case "DEPLOY_TOKEN":
+			if s.Value != "${ENV_CUSTOM_TOKEN}" {
+				t.Errorf("overrides-secret: DEPLOY_TOKEN value = %q, want ${ENV_CUSTOM_TOKEN}", s.Value)
+			}
+		case "SLACK_WEBHOOK":
+			if s.Value != "${ENV_SLACK_WEBHOOK}" {
+				t.Errorf("overrides-secret: SLACK_WEBHOOK value = %q, want ${ENV_SLACK_WEBHOOK} (inherited)", s.Value)
+			}
+		default:
+			t.Errorf("overrides-secret: unexpected secret %q", s.Name)
 		}
 	}
 }
@@ -2459,6 +2502,58 @@ repositories:
 		if v.Name == "APP_ENV" && v.Value != "production" {
 			t.Errorf("overrides-variable: APP_ENV value = %q, want production (inherited)", v.Value)
 		}
+	}
+}
+
+func TestRepositorySet_VariablesMerge_OverrideByName(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+apiVersion: v1
+kind: RepositorySet
+metadata:
+  owner: org
+defaults:
+  spec:
+    variables:
+      - name: DEFAULT_VAR_A
+        value: value-a
+      - name: DEFAULT_VAR_B
+        value: value-b
+repositories:
+  - name: repo-a
+    spec:
+      variables:
+        - name: DEFAULT_VAR_A
+          value: overridden-a
+        - name: NEW_VAR
+          value: new-value
+`
+	path := filepath.Join(dir, "variables.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath error: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+
+	vars := repos[0].Spec.Variables
+	if len(vars) != 3 {
+		t.Fatalf("expected 3 variables, got %d", len(vars))
+	}
+
+	if vars[0].Name != "DEFAULT_VAR_A" || vars[0].Value != "overridden-a" {
+		t.Errorf("DEFAULT_VAR_A not overridden: got name=%q value=%q", vars[0].Name, vars[0].Value)
+	}
+	if vars[1].Name != "DEFAULT_VAR_B" || vars[1].Value != "value-b" {
+		t.Errorf("DEFAULT_VAR_B not inherited: got %+v", vars[1])
+	}
+	if vars[2].Name != "NEW_VAR" || vars[2].Value != "new-value" {
+		t.Errorf("NEW_VAR not appended: got %+v", vars[2])
 	}
 }
 

--- a/internal/manifest/repository_types.go
+++ b/internal/manifest/repository_types.go
@@ -101,6 +101,8 @@ type RepositorySpec struct {
 	BranchProtectionSet bool `yaml:"-"`
 	LabelsSet           bool `yaml:"-"`
 	RulesetsSet         bool `yaml:"-"`
+	SecretsSet          bool `yaml:"-"`
+	VariablesSet        bool `yaml:"-"`
 }
 
 type RepositoryReconcile struct {
@@ -141,6 +143,18 @@ func (s *RepositorySpec) UnmarshalYAML(unmarshal func(any) error) error {
 		s.RulesetsSet = true
 		if v == nil {
 			return fmt.Errorf("rulesets must be a sequence; use [] with reconcile.rulesets=authoritative to delete all rulesets")
+		}
+	}
+	if v, ok := fields["secrets"]; ok {
+		s.SecretsSet = true
+		if v == nil {
+			return fmt.Errorf("secrets must be a sequence; use [] to declare an empty secrets list")
+		}
+	}
+	if v, ok := fields["variables"]; ok {
+		s.VariablesSet = true
+		if v == nil {
+			return fmt.Errorf("variables must be a sequence; use [] to declare an empty variables list")
 		}
 	}
 

--- a/internal/manifest/repository_types.go
+++ b/internal/manifest/repository_types.go
@@ -148,13 +148,13 @@ func (s *RepositorySpec) UnmarshalYAML(unmarshal func(any) error) error {
 	if v, ok := fields["secrets"]; ok {
 		s.SecretsSet = true
 		if v == nil {
-			return fmt.Errorf("secrets must be a sequence; use [] to declare an empty secrets list")
+			return fmt.Errorf("secrets must be a sequence; use [] to inherit no secrets from defaults")
 		}
 	}
 	if v, ok := fields["variables"]; ok {
 		s.VariablesSet = true
 		if v == nil {
-			return fmt.Errorf("variables must be a sequence; use [] to declare an empty variables list")
+			return fmt.Errorf("variables must be a sequence; use [] to inherit no variables from defaults")
 		}
 	}
 


### PR DESCRIPTION
## Summary

Per-repo `secrets:` and `variables:` overrides currently replace the entire defaults list, forcing repos that need one extra secret to re-declare all shared secrets. This aligns both collections with the existing merge-by-key pattern used by `labels` and `rulesets` — same-name entries are replaced, new entries appended, unmentioned defaults inherited.

## Background

The six collection types in RepositorySet have two merge strategies: list-replace (overrides replace the entire list) and merge-by-key (entries are matched by a natural key field). `labels`, `branch_protection`, and `rulesets` already use merge-by-key. `secrets` and `variables` were the only named collections still using list-replace, despite having a natural `name` key. This inconsistency made RepositorySet defaults less useful for the most common case — sharing secrets across repos while allowing per-repo additions.

The implementation follows the exact sentinel-field + merge-function pattern established by `mergeLabels` and `mergeRulesets`: `SecretsSet`/`VariablesSet` booleans tracked in `UnmarshalYAML`, dedicated `mergeSecrets`/`mergeVariables` functions using a `map[string]int` index, and sentinel-gated calls in `mergeSpecs`. ADR-005's additive-by-default philosophy applies — secrets and variables already behave additively at the API level (gh-infra never deletes unlisted entries).

## Changes

- Add `SecretsSet`/`VariablesSet` sentinel fields to `RepositorySpec`, tracked in `UnmarshalYAML` with null guards
- Add `mergeSecrets()` and `mergeVariables()` merge-by-key functions in `parser.go`
- Replace list-replace logic in `mergeSpecs()` with sentinel-gated merge calls
- Add 6 test cases: inherit defaults, add new entry, override existing by name (with ordering verification for both secrets and variables), and null-rejection validation for both collection types
- Update `defaults.md` with new table rows and example YAML for both secrets and variables
- Improve null-guard error messages to describe the effect (`"inherit no secrets from defaults"`) rather than the syntax