### PR TITLE
Detect silent-accept when GitHub API ignores settings

### DIFF
--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/babarot/gh-infra/internal/gh"
+	"github.com/babarot/gh-infra/internal/logger"
 	"github.com/babarot/gh-infra/internal/manifest"
 	"github.com/babarot/gh-infra/internal/parallel"
 )
@@ -374,12 +375,7 @@ func (p *Processor) applyMergeStrategyBatch(ctx context.Context, c Change) Apply
 	fullName := c.Name
 	payload := map[string]any{}
 	for _, child := range c.Children {
-		switch child.Field {
-		case "auto_delete_head_branches":
-			payload["delete_branch_on_merge"] = child.NewValue
-		default:
-			payload[child.Field] = child.NewValue
-		}
+		payload[canonicalAPIField(child.Field)] = child.NewValue
 	}
 
 	body, err := json.Marshal(payload)
@@ -410,11 +406,7 @@ func (p *Processor) applyMergeStrategyBatch(ctx context.Context, c Change) Apply
 			// Skip non-bool fields until jq output normalisation is addressed.
 			continue
 		}
-		apiField := child.Field
-		if child.Field == "auto_delete_head_branches" {
-			apiField = "delete_branch_on_merge"
-		}
-		if verifyErr := p.verifyBoolField(ctx, fullName, apiField, desired); verifyErr != nil {
+		if verifyErr := p.verifyBoolField(ctx, fullName, canonicalAPIField(child.Field), desired); verifyErr != nil {
 			return ApplyResult{Change: c, Err: verifyErr}
 		}
 	}
@@ -1263,6 +1255,13 @@ func wrapError(err error, repo, field string) error {
 	return fmt.Errorf("update %s %s: %w", repo, field, err)
 }
 
+func canonicalAPIField(field string) string {
+	if field == "auto_delete_head_branches" {
+		return "delete_branch_on_merge"
+	}
+	return field
+}
+
 func derefBool(b *bool) bool {
 	if b == nil {
 		return false
@@ -1283,12 +1282,13 @@ func (p *Processor) verifyBoolField(ctx context.Context, fullName, field string,
 		"--jq", "."+field,
 	)
 	if err != nil {
-		// Non-fatal: skip verification on read-back failure.
+		logger.Debug("verification read-back failed, skipping", "repo", fullName, "field", field, "err", err)
 		return nil
 	}
 	actual := strings.TrimSpace(string(out))
 	if actual == "" {
-		// Empty output means the field was absent in the response — skip.
+		// Field absent in response — safe to skip because jq always outputs
+		// "true"/"false" for present booleans, and the caller filters non-bools.
 		return nil
 	}
 	desiredStr := fmt.Sprintf("%v", desired)

--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -392,7 +392,33 @@ func (p *Processor) applyMergeStrategyBatch(ctx context.Context, c Change) Apply
 		"--header", "Content-Type: application/json",
 		"--input", "-",
 	)
-	return ApplyResult{Change: c, Err: wrapError(err, fullName, "merge_strategy")}
+	if err != nil {
+		return ApplyResult{Change: c, Err: wrapError(err, fullName, "merge_strategy")}
+	}
+
+	// Verify that the API actually applied the changes. GitHub silently ignores
+	// some settings (e.g. allow_auto_merge on private repos without branch
+	// protection), returning 200 but not updating the stored value. Only bool
+	// fields are verified for now — string fields have jq quoting differences
+	// that would cause false mismatches.
+	//
+	// Note: new repo creation via applyRepoPatch does not go through this path,
+	// so the verification gap for new repos is accepted for the initial fix.
+	for _, child := range c.Children {
+		desired, ok := child.NewValue.(bool)
+		if !ok {
+			// Skip non-bool fields until jq output normalisation is addressed.
+			continue
+		}
+		apiField := child.Field
+		if child.Field == "auto_delete_head_branches" {
+			apiField = "delete_branch_on_merge"
+		}
+		if verifyErr := p.verifyBoolField(ctx, fullName, apiField, desired); verifyErr != nil {
+			return ApplyResult{Change: c, Err: verifyErr}
+		}
+	}
+	return ApplyResult{Change: c}
 }
 
 func (p *Processor) applyRepoSetting(ctx context.Context, c Change, repo *manifest.Repository) error {
@@ -1242,4 +1268,35 @@ func derefBool(b *bool) bool {
 		return false
 	}
 	return *b
+}
+
+// verifyBoolField reads back a single boolean field from the GitHub repos REST
+// API and compares it to the desired value. Returns an error if the API
+// accepted the PATCH but the field was not updated, indicating a silent-ignore.
+//
+// Verification failure is non-fatal: if the read-back call fails or returns
+// empty output, the error is suppressed. The next plan will surface any real
+// drift.
+func (p *Processor) verifyBoolField(ctx context.Context, fullName, field string, desired bool) error {
+	out, err := p.runner.Run(ctx,
+		"api", fmt.Sprintf("repos/%s", fullName),
+		"--jq", "."+field,
+	)
+	if err != nil {
+		// Non-fatal: skip verification on read-back failure.
+		return nil
+	}
+	actual := strings.TrimSpace(string(out))
+	if actual == "" {
+		// Empty output means the field was absent in the response — skip.
+		return nil
+	}
+	desiredStr := fmt.Sprintf("%v", desired)
+	if actual != desiredStr {
+		return fmt.Errorf(
+			"applied %s=%v but GitHub reports %s=%s (setting may not be supported for this repository configuration)",
+			field, desired, field, actual,
+		)
+	}
+	return nil
 }

--- a/internal/repository/apply_test.go
+++ b/internal/repository/apply_test.go
@@ -1202,7 +1202,12 @@ func TestApplyRepoPatch_Empty(t *testing.T) {
 }
 
 func TestApplyMergeStrategyBatch(t *testing.T) {
-	mock := &gh.MockRunner{}
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo --jq .allow_squash_merge":     []byte(""),
+			"api repos/myorg/myrepo --jq .delete_branch_on_merge": []byte(""),
+		},
+	}
 	proc := NewProcessor(mock, nil)
 
 	repo := newTestRepo("myorg", "myrepo")
@@ -1699,6 +1704,39 @@ func TestApplyMergeStrategyBatch_SilentAcceptDetected(t *testing.T) {
 	}
 }
 
+func TestApplyMergeStrategyBatch_SilentAcceptDetected_SetFalse(t *testing.T) {
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo --jq .allow_auto_merge": []byte("true\n"),
+		},
+	}
+	proc := NewProcessor(mock, nil)
+
+	changes := []Change{
+		{
+			Type:     ChangeUpdate,
+			Resource: "Repository",
+			Name:     "myorg/myrepo",
+			Field:    "merge_strategy",
+			Children: []Change{
+				{Field: "allow_auto_merge", NewValue: false},
+			},
+		},
+	}
+
+	repo := newTestRepo("myorg", "myrepo")
+	results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err == nil {
+		t.Fatal("expected error for silent-accept when setting false, got nil")
+	}
+	if !strings.Contains(results[0].Err.Error(), "allow_auto_merge") {
+		t.Errorf("expected error mentioning field name, got: %v", results[0].Err)
+	}
+}
+
 func TestApplyMergeStrategyBatch_VerificationPasses(t *testing.T) {
 	// Simulate GitHub accepting and applying the change — read-back returns "true".
 	mock := &gh.MockRunner{
@@ -1786,6 +1824,9 @@ func TestApplyMergeStrategyBatch_DeleteBranchOnMergeFieldTranslation(t *testing.
 
 	repo := newTestRepo("myorg", "myrepo")
 	results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
 	if results[0].Err == nil {
 		t.Fatal("expected error for silent-accept of delete_branch_on_merge, got nil")
 	}

--- a/internal/repository/apply_test.go
+++ b/internal/repository/apply_test.go
@@ -1233,9 +1233,12 @@ func TestApplyMergeStrategyBatch(t *testing.T) {
 		t.Fatalf("unexpected error: %v", results[0].Err)
 	}
 
-	// Should be exactly 1 API call (batched PATCH)
-	if len(mock.Called) != 1 {
-		t.Fatalf("expected 1 gh call, got %d", len(mock.Called))
+	// 1 batched PATCH + 2 post-apply verification reads (one per bool child:
+	// allow_squash_merge and auto_delete_head_branches→delete_branch_on_merge).
+	// squash_merge_commit_title is a string field and is skipped.
+	// Verification reads return empty output (non-fatal), so Err stays nil.
+	if len(mock.Called) != 3 {
+		t.Fatalf("expected 3 gh calls (1 PATCH + 2 verify reads), got %d", len(mock.Called))
 	}
 
 	body := mock.CalledStdin[0]
@@ -1655,6 +1658,139 @@ func TestApplyLabel_UpdateWithChildren(t *testing.T) {
 	call := strings.Join(mock.Called[0], " ")
 	if !strings.Contains(call, "label edit enhancement") {
 		t.Errorf("expected 'label edit enhancement', got: %s", call)
+	}
+}
+
+func TestApplyMergeStrategyBatch_SilentAcceptDetected(t *testing.T) {
+	// Simulate GitHub returning 200 (nil error from PATCH) but not updating
+	// the allow_auto_merge field — the read-back still returns "false".
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo --jq .allow_auto_merge": []byte("false\n"),
+		},
+	}
+	proc := NewProcessor(mock, nil)
+
+	changes := []Change{
+		{
+			Type:     ChangeUpdate,
+			Resource: "Repository",
+			Name:     "myorg/myrepo",
+			Field:    "merge_strategy",
+			Children: []Change{
+				{Field: "allow_auto_merge", NewValue: true},
+			},
+		},
+	}
+
+	repo := newTestRepo("myorg", "myrepo")
+	results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err == nil {
+		t.Fatal("expected error for silent-accept, got nil")
+	}
+	if !strings.Contains(results[0].Err.Error(), "allow_auto_merge") {
+		t.Errorf("expected error mentioning field name, got: %v", results[0].Err)
+	}
+	if !strings.Contains(results[0].Err.Error(), "GitHub reports") {
+		t.Errorf("expected error mentioning read-back, got: %v", results[0].Err)
+	}
+}
+
+func TestApplyMergeStrategyBatch_VerificationPasses(t *testing.T) {
+	// Simulate GitHub accepting and applying the change — read-back returns "true".
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo --jq .allow_auto_merge": []byte("true\n"),
+		},
+	}
+	proc := NewProcessor(mock, nil)
+
+	changes := []Change{
+		{
+			Type:     ChangeUpdate,
+			Resource: "Repository",
+			Name:     "myorg/myrepo",
+			Field:    "merge_strategy",
+			Children: []Change{
+				{Field: "allow_auto_merge", NewValue: true},
+			},
+		},
+	}
+
+	repo := newTestRepo("myorg", "myrepo")
+	results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("unexpected error: %v", results[0].Err)
+	}
+}
+
+func TestApplyMergeStrategyBatch_VerificationReadBackFailure(t *testing.T) {
+	// Simulate the read-back API call failing (e.g. network error).
+	// The apply should still succeed — verification is best-effort.
+	mock := &gh.MockRunner{
+		Errors: map[string]error{
+			"api repos/myorg/myrepo --jq .allow_auto_merge": fmt.Errorf("network error"),
+		},
+	}
+	proc := NewProcessor(mock, nil)
+
+	changes := []Change{
+		{
+			Type:     ChangeUpdate,
+			Resource: "Repository",
+			Name:     "myorg/myrepo",
+			Field:    "merge_strategy",
+			Children: []Change{
+				{Field: "allow_auto_merge", NewValue: true},
+			},
+		},
+	}
+
+	repo := newTestRepo("myorg", "myrepo")
+	results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("verification read-back failure should be non-fatal, got: %v", results[0].Err)
+	}
+}
+
+func TestApplyMergeStrategyBatch_DeleteBranchOnMergeFieldTranslation(t *testing.T) {
+	// auto_delete_head_branches in the Change maps to delete_branch_on_merge
+	// in the GitHub API. The verification call must use the API field name.
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo --jq .delete_branch_on_merge": []byte("false\n"),
+		},
+	}
+	proc := NewProcessor(mock, nil)
+
+	changes := []Change{
+		{
+			Type:     ChangeUpdate,
+			Resource: "Repository",
+			Name:     "myorg/myrepo",
+			Field:    "merge_strategy",
+			Children: []Change{
+				{Field: "auto_delete_head_branches", NewValue: true},
+			},
+		},
+	}
+
+	repo := newTestRepo("myorg", "myrepo")
+	results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+	if results[0].Err == nil {
+		t.Fatal("expected error for silent-accept of delete_branch_on_merge, got nil")
+	}
+	if !strings.Contains(results[0].Err.Error(), "delete_branch_on_merge") {
+		t.Errorf("expected error mentioning API field name, got: %v", results[0].Err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`apply` now reads back boolean fields after a successful PATCH and reports an error when the desired value doesn't match the actual state, catching cases where GitHub silently accepts but ignores a setting.

## Background

`allow_auto_merge` on private repos without branch protection returns HTTP 200 but never takes effect. gh-infra trusted the 200 and reported success, creating a perpetual plan/apply cycle where every run showed the same drift. The root cause is that GitHub's REST API silently ignores certain settings depending on repo configuration — it doesn't error, it just doesn't apply the change.

The fix adds a `verifyBoolField` helper that issues a `GET repos/{fullName}` with a `--jq` filter after each successful `applyMergeStrategyBatch` PATCH. Only boolean-typed child fields are verified (string fields are skipped due to jq output quoting differences). Verification is non-fatal on read-back failure — only a confirmed value mismatch surfaces an error.

The `auto_delete_head_branches` → `delete_branch_on_merge` field name translation is consolidated into a `canonicalAPIField` helper used by both the PATCH payload construction and the verification loop.

## Changes

- Add `verifyBoolField` method on `*Processor` in `apply.go`
- Call verification after successful `applyMergeStrategyBatch` for each boolean child field
- Extract `canonicalAPIField` helper to deduplicate field name translation
- Add debug logging for swallowed verification read-back errors
- Add 5 tests: silent-accept detection (`desired=true` and `desired=false`), successful verification, non-fatal read-back failure, field name translation

Closes #154