### PR TITLE
Add `--diff` flag to plan for inline FileSet diffs

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -35,7 +35,7 @@ func newPlanCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&repo, "repo", "r", "", "Target specific repository only")
 	cmd.Flags().BoolVar(&ci, "ci", false, "Exit with code 1 if changes are detected")
 	cmd.Flags().BoolVar(&failOnUnknown, "fail-on-unknown", false, "Error on YAML files with unknown Kind")
-	cmd.Flags().BoolVar(&showDiff, "diff", false, "Show unified diff for each file change")
+	cmd.Flags().BoolVar(&showDiff, "diff", false, "Show unified diff for FileSet file changes (prints full content)")
 
 	return cmd
 }

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -16,6 +16,7 @@ func newPlanCmd() *cobra.Command {
 		repo          string
 		ci            bool
 		failOnUnknown bool
+		showDiff      bool
 	)
 
 	cmd := &cobra.Command{
@@ -26,6 +27,7 @@ func newPlanCmd() *cobra.Command {
 				FilterRepo:    repo,
 				CI:            ci,
 				FailOnUnknown: failOnUnknown,
+				ShowDiff:      showDiff,
 			})
 		},
 	}
@@ -33,6 +35,7 @@ func newPlanCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&repo, "repo", "r", "", "Target specific repository only")
 	cmd.Flags().BoolVar(&ci, "ci", false, "Exit with code 1 if changes are detected")
 	cmd.Flags().BoolVar(&failOnUnknown, "fail-on-unknown", false, "Error on YAML files with unknown Kind")
+	cmd.Flags().BoolVar(&showDiff, "diff", false, "Show unified diff for each file change")
 
 	return cmd
 }
@@ -41,6 +44,7 @@ type planCommandOptions struct {
 	FilterRepo    string
 	CI            bool
 	FailOnUnknown bool
+	ShowDiff      bool
 }
 
 func runPlan(paths []string, opts planCommandOptions) error {
@@ -53,6 +57,7 @@ func runPlan(paths []string, opts planCommandOptions) error {
 		FilterRepo:    opts.FilterRepo,
 		FailOnUnknown: opts.FailOnUnknown,
 		DryRun:        true,
+		ShowDiff:      opts.ShowDiff,
 	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	charm.land/log/v2 v2.0.0
 	github.com/avast/retry-go/v4 v4.7.0
 	github.com/bluekeyes/go-gitdiff v0.8.1
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/goccy/go-yaml v1.19.2
 	github.com/pmezard/go-difflib v1.0.0
@@ -20,7 +21,6 @@ require (
 require (
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect

--- a/internal/infra/format.go
+++ b/internal/infra/format.go
@@ -12,7 +12,7 @@ import (
 
 // printPlan prints repository and fileset changes grouped by repo name.
 // FileSet changes for a repo are displayed after its repository changes.
-func printPlan(p ui.Printer, repoChanges []repository.Change, fileChanges []fileset.Change) {
+func printPlan(p ui.Printer, repoChanges []repository.Change, fileChanges []fileset.Change, showDiff bool) {
 	// Build ordered list of unique repo names (preserving appearance order)
 	seen := make(map[string]bool)
 	var repoNames []string
@@ -102,12 +102,43 @@ func printPlan(p ui.Printer, repoChanges []repository.Change, fileChanges []file
 			for _, c := range fChanges {
 				added, removed := fileset.DiffStat(c.Current, c.Desired)
 				p.PrintFileChange(fileChangeToItem(c, added, removed))
+				if showDiff {
+					printFileDiff(p, c)
+				}
 			}
 		}
 
 		p.GroupEnd()
 		p.SetColumnWidth(0)
 	}
+}
+
+// printFileDiff emits a colored unified diff block for a single file change.
+// For creates, it diffs empty string against desired content.
+// For deletes, it diffs current content against empty string.
+// For updates, it diffs current against desired.
+// Output is written to stdout at IndentSub indent, matching the file change line above it.
+func printFileDiff(p ui.Printer, c fileset.Change) {
+	var current, desired string
+	switch c.Type {
+	case fileset.ChangeCreate:
+		current = ""
+		desired = c.Desired
+	case fileset.ChangeUpdate:
+		current = c.Current
+		desired = c.Desired
+	case fileset.ChangeDelete:
+		current = c.Current
+		desired = ""
+	default:
+		return
+	}
+	diff := ui.GenerateDiff(current, desired, c.Path)
+	if diff == "" {
+		return
+	}
+	lines := strings.Split(strings.TrimRight(diff, "\n"), "\n")
+	p.PrintDiffBlock(lines)
 }
 
 // printApplyResults prints apply results grouped by repo name,

--- a/internal/infra/format.go
+++ b/internal/infra/format.go
@@ -113,11 +113,13 @@ func printPlan(p ui.Printer, repoChanges []repository.Change, fileChanges []file
 	}
 }
 
+const maxDiffLines = 500
+
 // printFileDiff emits a colored unified diff block for a single file change.
 // For creates, it diffs empty string against desired content.
 // For deletes, it diffs current content against empty string.
 // For updates, it diffs current against desired.
-// Output is written to stdout at IndentSub indent, matching the file change line above it.
+// Output is capped at maxDiffLines to prevent terminal flooding.
 func printFileDiff(p ui.Printer, c fileset.Change) {
 	var current, desired string
 	switch c.Type {
@@ -137,8 +139,7 @@ func printFileDiff(p ui.Printer, c fileset.Change) {
 	if diff == "" {
 		return
 	}
-	lines := strings.Split(strings.TrimRight(diff, "\n"), "\n")
-	p.PrintDiffBlock(lines)
+	p.PrintDiffBlock(ui.TruncateDiff(diff, maxDiffLines))
 }
 
 // printApplyResults prints apply results grouped by repo name,

--- a/internal/infra/format_test.go
+++ b/internal/infra/format_test.go
@@ -29,7 +29,7 @@ func TestPrintPlan_RepoChanges(t *testing.T) {
 		{Type: repository.ChangeCreate, Name: "org/repo", Field: "homepage", NewValue: "https://example.com"},
 	}
 
-	printPlan(p, repoChanges, nil)
+	printPlan(p, repoChanges, nil, false)
 	out := buf.String()
 
 	if !strings.Contains(out, "org/repo") {
@@ -52,7 +52,7 @@ func TestPrintPlan_FileChanges(t *testing.T) {
 		{Type: fileset.ChangeUpdate, Target: "org/repo", Path: ".github/lint.yml", Current: "old\n", Desired: "new\n", Via: "push"},
 	}
 
-	printPlan(p, nil, fileChanges)
+	printPlan(p, nil, fileChanges, false)
 	out := buf.String()
 
 	if !strings.Contains(out, "org/repo") {
@@ -77,7 +77,7 @@ func TestPrintPlan_Mixed(t *testing.T) {
 		{Type: fileset.ChangeCreate, Target: "org/repo", Path: "README.md"},
 	}
 
-	printPlan(p, repoChanges, fileChanges)
+	printPlan(p, repoChanges, fileChanges, false)
 	out := buf.String()
 
 	// Both repo and file changes should appear under same repo group
@@ -100,7 +100,7 @@ func TestPrintPlan_AllNoOp(t *testing.T) {
 		{Type: fileset.ChangeNoOp, Target: "org/repo"},
 	}
 
-	printPlan(p, repoChanges, fileChanges)
+	printPlan(p, repoChanges, fileChanges, false)
 
 	if buf.Len() != 0 {
 		t.Errorf("expected empty output for all no-op, got:\n%s", buf.String())
@@ -111,7 +111,7 @@ func TestPrintPlan_Empty(t *testing.T) {
 	var buf bytes.Buffer
 	p := ui.NewStandardPrinterWith(&buf, &buf)
 
-	printPlan(p, nil, nil)
+	printPlan(p, nil, nil, false)
 
 	if buf.Len() != 0 {
 		t.Errorf("expected empty output for nil changes, got:\n%s", buf.String())
@@ -134,7 +134,7 @@ func TestPrintPlan_ChildChanges(t *testing.T) {
 		},
 	}
 
-	printPlan(p, repoChanges, nil)
+	printPlan(p, repoChanges, nil, false)
 	out := buf.String()
 
 	if !strings.Contains(out, "features") {
@@ -488,7 +488,7 @@ func TestPrintPlan_GroupedLabelsAndMilestones(t *testing.T) {
 		{Type: repository.ChangeCreate, Resource: manifest.ResourceMilestone, Name: "org/repo", Field: "v1.0", NewValue: "open"},
 	}
 
-	printPlan(p, repoChanges, nil)
+	printPlan(p, repoChanges, nil, false)
 	out := buf.String()
 
 	if !strings.Contains(out, "labels") {
@@ -532,7 +532,7 @@ func TestPrintPlan_GroupedLabelUpdate(t *testing.T) {
 		},
 	}
 
-	printPlan(p, repoChanges, nil)
+	printPlan(p, repoChanges, nil, false)
 	out := buf.String()
 
 	if !strings.Contains(out, "labels") {
@@ -571,7 +571,7 @@ func TestPrintPlan_RulesetAndBranchProtectionHeaders(t *testing.T) {
 		},
 	}
 
-	printPlan(p, repoChanges, nil)
+	printPlan(p, repoChanges, nil, false)
 	out := buf.String()
 
 	if !strings.Contains(out, `ruleset "main-protection"`) {
@@ -614,7 +614,7 @@ func TestPrintPlan_DeleteRulesetAndBranchProtectionWithChildren(t *testing.T) {
 		},
 	}
 
-	printPlan(p, repoChanges, nil)
+	printPlan(p, repoChanges, nil, false)
 	out := buf.String()
 
 	for _, want := range []string{
@@ -631,5 +631,94 @@ func TestPrintPlan_DeleteRulesetAndBranchProtectionWithChildren(t *testing.T) {
 	}
 	if strings.Contains(out, "branch_protection      main") {
 		t.Errorf("expected grouped branch protection delete, got flat output:\n%s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// printPlan with ShowDiff
+// ---------------------------------------------------------------------------
+
+func TestPrintPlan_ShowDiff_Update(t *testing.T) {
+	var buf bytes.Buffer
+	p := ui.NewStandardPrinterWith(&buf, &buf)
+
+	fileChanges := []fileset.Change{
+		{
+			Type:    fileset.ChangeUpdate,
+			Target:  "org/repo",
+			Path:    ".github/ci.yml",
+			Current: "old line\n",
+			Desired: "new line\n",
+		},
+	}
+
+	printPlan(p, nil, fileChanges, true)
+	out := buf.String()
+
+	// Diff block should appear for update change
+	if !strings.Contains(out, "-old line") {
+		t.Errorf("expected removed line in diff output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "+new line") {
+		t.Errorf("expected added line in diff output, got:\n%s", out)
+	}
+}
+
+func TestPrintPlan_ShowDiff_Create(t *testing.T) {
+	var buf bytes.Buffer
+	p := ui.NewStandardPrinterWith(&buf, &buf)
+
+	fileChanges := []fileset.Change{
+		{
+			Type:    fileset.ChangeCreate,
+			Target:  "org/repo",
+			Path:    "README.md",
+			Desired: "# Hello\n",
+		},
+	}
+
+	printPlan(p, nil, fileChanges, true)
+	out := buf.String()
+
+	if !strings.Contains(out, "+# Hello") {
+		t.Errorf("expected added content in diff output for create, got:\n%s", out)
+	}
+}
+
+func TestPrintPlan_ShowDiff_False(t *testing.T) {
+	var buf bytes.Buffer
+	p := ui.NewStandardPrinterWith(&buf, &buf)
+
+	fileChanges := []fileset.Change{
+		{
+			Type:    fileset.ChangeUpdate,
+			Target:  "org/repo",
+			Path:    ".github/ci.yml",
+			Current: "old line\n",
+			Desired: "new line\n",
+		},
+	}
+
+	printPlan(p, nil, fileChanges, false)
+	out := buf.String()
+
+	// No diff block when showDiff=false
+	if strings.Contains(out, "-old line") || strings.Contains(out, "+new line") {
+		t.Errorf("expected no diff output when showDiff=false, got:\n%s", out)
+	}
+	// But the file change line itself still appears
+	if !strings.Contains(out, ".github/ci.yml") {
+		t.Errorf("expected file path in output, got:\n%s", out)
+	}
+}
+
+func TestPrintFileDiff_NoOp(t *testing.T) {
+	var buf bytes.Buffer
+	p := ui.NewStandardPrinterWith(&buf, &buf)
+	// NoOp changes should produce no output
+	c := fileset.Change{Type: fileset.ChangeNoOp, Path: "a.txt"}
+	printFileDiff(p, c)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for NoOp, got: %q", buf.String())
 	}
 }

--- a/internal/infra/format_test.go
+++ b/internal/infra/format_test.go
@@ -683,6 +683,15 @@ func TestPrintPlan_ShowDiff_Create(t *testing.T) {
 	if !strings.Contains(out, "+# Hello") {
 		t.Errorf("expected added content in diff output for create, got:\n%s", out)
 	}
+	if !strings.Contains(out, "--- README.md (current)") {
+		t.Errorf("expected file header '---' in diff output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "+++ README.md (desired)") {
+		t.Errorf("expected file header '+++' in diff output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "@@") {
+		t.Errorf("expected hunk header '@@' in diff output, got:\n%s", out)
+	}
 }
 
 func TestPrintPlan_ShowDiff_False(t *testing.T) {
@@ -715,10 +724,131 @@ func TestPrintPlan_ShowDiff_False(t *testing.T) {
 func TestPrintFileDiff_NoOp(t *testing.T) {
 	var buf bytes.Buffer
 	p := ui.NewStandardPrinterWith(&buf, &buf)
-	// NoOp changes should produce no output
 	c := fileset.Change{Type: fileset.ChangeNoOp, Path: "a.txt"}
 	printFileDiff(p, c)
 	if buf.Len() != 0 {
 		t.Errorf("expected no output for NoOp, got: %q", buf.String())
+	}
+}
+
+func TestPrintPlan_ShowDiff_Delete(t *testing.T) {
+	var buf bytes.Buffer
+	p := ui.NewStandardPrinterWith(&buf, &buf)
+
+	fileChanges := []fileset.Change{
+		{
+			Type:    fileset.ChangeDelete,
+			Target:  "org/repo",
+			Path:    "old-config.yml",
+			Current: "removed content\n",
+		},
+	}
+
+	printPlan(p, nil, fileChanges, true)
+	out := buf.String()
+
+	if !strings.Contains(out, "-removed content") {
+		t.Errorf("expected removed line in diff output for delete, got:\n%s", out)
+	}
+}
+
+func TestPrintFileDiff_IdenticalContent(t *testing.T) {
+	var buf bytes.Buffer
+	p := ui.NewStandardPrinterWith(&buf, &buf)
+	c := fileset.Change{
+		Type:    fileset.ChangeUpdate,
+		Path:    "same.yml",
+		Current: "same content\n",
+		Desired: "same content\n",
+	}
+	printFileDiff(p, c)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for identical content, got: %q", buf.String())
+	}
+}
+
+func TestPrintPlan_ShowDiff_MultiFile(t *testing.T) {
+	var buf bytes.Buffer
+	p := ui.NewStandardPrinterWith(&buf, &buf)
+
+	fileChanges := []fileset.Change{
+		{
+			Type:    fileset.ChangeUpdate,
+			Target:  "org/repo",
+			Path:    "a.yml",
+			Current: "old-a\n",
+			Desired: "new-a\n",
+			Via:     "push",
+		},
+		{
+			Type:    fileset.ChangeCreate,
+			Target:  "org/repo",
+			Path:    "b.yml",
+			Desired: "content-b\n",
+			Via:     "push",
+		},
+	}
+
+	printPlan(p, nil, fileChanges, true)
+	out := buf.String()
+
+	if !strings.Contains(out, "-old-a") {
+		t.Errorf("expected first file diff, got:\n%s", out)
+	}
+	if !strings.Contains(out, "+new-a") {
+		t.Errorf("expected first file diff, got:\n%s", out)
+	}
+	if !strings.Contains(out, "+content-b") {
+		t.Errorf("expected second file diff, got:\n%s", out)
+	}
+}
+
+func TestPrintPlan_ShowDiff_Truncated(t *testing.T) {
+	var buf bytes.Buffer
+	p := ui.NewStandardPrinterWith(&buf, &buf)
+
+	var content strings.Builder
+	for i := range 600 {
+		fmt.Fprintf(&content, "line %d\n", i)
+	}
+
+	fileChanges := []fileset.Change{
+		{
+			Type:    fileset.ChangeCreate,
+			Target:  "org/repo",
+			Path:    "big-file.txt",
+			Desired: content.String(),
+		},
+	}
+
+	printPlan(p, nil, fileChanges, true)
+	out := buf.String()
+
+	if !strings.Contains(out, "lines truncated") {
+		t.Errorf("expected truncation message for large diff, got:\n%s", out)
+	}
+}
+
+func TestPrintPlan_ShowDiff_NoANSI(t *testing.T) {
+	// Tests run with DisableStyles() via init(), simulating --ci mode.
+	// Verify no ANSI escape sequences leak into output.
+	var buf bytes.Buffer
+	p := ui.NewStandardPrinterWith(&buf, &buf)
+
+	fileChanges := []fileset.Change{
+		{
+			Type:    fileset.ChangeUpdate,
+			Target:  "org/repo",
+			Path:    ".github/ci.yml",
+			Current: "old line\n",
+			Desired: "new line\n",
+		},
+	}
+
+	printPlan(p, nil, fileChanges, true)
+	out := buf.String()
+
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("expected no ANSI escape sequences in CI mode, got:\n%q", out)
 	}
 }

--- a/internal/infra/plan.go
+++ b/internal/infra/plan.go
@@ -21,6 +21,7 @@ type PlanOptions struct {
 	FailOnUnknown bool
 	ForceSecrets  bool // only meaningful when followed by Apply
 	DryRun        bool // true = plan only (skip secret resolution)
+	ShowDiff      bool // emit unified diff for each file change in plan output
 }
 
 // PlanResult holds the outcome of the plan phase.
@@ -206,7 +207,7 @@ func Plan(opts PlanOptions) (*PlanResult, error) {
 	p.Separator()
 	p.Legend(result.Creates > 0, result.Updates > 0, result.Deletes > 0)
 
-	printPlan(p, repoChanges, fileChanges)
+	printPlan(p, repoChanges, fileChanges, opts.ShowDiff)
 
 	parts := []string{
 		fmt.Sprintf("%s to create", ui.Bold.Render(fmt.Sprintf("%d", result.Creates))),

--- a/internal/ui/diffviewer.go
+++ b/internal/ui/diffviewer.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/pmezard/go-difflib/difflib"
 )
 
@@ -40,6 +41,19 @@ func GenerateDiff(current, desired, path string) string {
 		Context:  3,
 	})
 	return expandTabs(diff)
+}
+
+// TruncateDiff caps a unified diff string at maxLines lines.
+// If the diff exceeds the limit, the output is truncated with a summary note.
+// Returns the original diff unchanged if within the limit.
+func TruncateDiff(diff string, maxLines int) string {
+	lines := strings.Split(strings.TrimSuffix(diff, "\n"), "\n")
+	if len(lines) <= maxLines {
+		return diff
+	}
+	lines = append(lines[:maxLines],
+		fmt.Sprintf("... (%d lines truncated)", len(lines)-maxLines))
+	return strings.Join(lines, "\n") + "\n"
 }
 
 // expandTabs replaces tab characters with 4 spaces for consistent terminal rendering.
@@ -398,26 +412,16 @@ func renderDiffIcon(icon string) string {
 	}
 }
 
-// colorDiffLineNoTrunc applies diff coloring without terminal truncation.
-// Used for non-interactive output (plan --diff) where the terminal handles wrapping.
-func colorDiffLineNoTrunc(line string) string {
-	if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
-		return Green.Render(line)
-	}
-	if strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---") {
-		return Red.Render(line)
-	}
-	if strings.HasPrefix(line, "@@") {
-		return Cyan.Render(line)
-	}
-	if strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++") {
-		return Bold.Render(line)
-	}
-	return line
-}
-
+// colorDiffLine applies diff coloring to a single unified-diff line.
+// If maxWidth > 0 the line is truncated to fit; pass 0 to skip truncation.
+// ANSI escape sequences are stripped from the input to prevent terminal injection
+// from file content fetched via the GitHub API.
 func colorDiffLine(line string, maxWidth int) string {
-	display := truncate(line, maxWidth)
+	line = ansi.Strip(line)
+	display := line
+	if maxWidth > 0 {
+		display = truncate(line, maxWidth)
+	}
 	if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
 		return Green.Render(display)
 	}

--- a/internal/ui/diffviewer.go
+++ b/internal/ui/diffviewer.go
@@ -398,6 +398,24 @@ func renderDiffIcon(icon string) string {
 	}
 }
 
+// colorDiffLineNoTrunc applies diff coloring without terminal truncation.
+// Used for non-interactive output (plan --diff) where the terminal handles wrapping.
+func colorDiffLineNoTrunc(line string) string {
+	if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
+		return Green.Render(line)
+	}
+	if strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---") {
+		return Red.Render(line)
+	}
+	if strings.HasPrefix(line, "@@") {
+		return Cyan.Render(line)
+	}
+	if strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++") {
+		return Bold.Render(line)
+	}
+	return line
+}
+
 func colorDiffLine(line string, maxWidth int) string {
 	display := truncate(line, maxWidth)
 	if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {

--- a/internal/ui/diffviewer_test.go
+++ b/internal/ui/diffviewer_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -122,6 +123,106 @@ func TestBuildRightPane_NotSkipped(t *testing.T) {
 	}
 	if !hasDiffMarker {
 		t.Error("non-skipped entry should show unified diff")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// colorDiffLine
+// ---------------------------------------------------------------------------
+
+func TestColorDiffLine(t *testing.T) {
+	DisableStyles()
+
+	tests := []struct {
+		name     string
+		line     string
+		maxWidth int
+		want     string
+	}{
+		{"added line no trunc", "+new content", 0, "+new content"},
+		{"removed line no trunc", "-old content", 0, "-old content"},
+		{"hunk header", "@@ -1,3 +1,4 @@", 0, "@@ -1,3 +1,4 @@"},
+		{"file header plus", "+++ b/file.go", 0, "+++ b/file.go"},
+		{"file header minus", "--- a/file.go", 0, "--- a/file.go"},
+		{"context line", " unchanged", 0, " unchanged"},
+		{"empty string", "", 0, ""},
+		{"added line truncated", "+very long added content here", 10, "+very l..."},
+		{"removed line truncated", "-very long removed content", 10, "-very l..."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := colorDiffLine(tt.line, tt.maxWidth)
+			if got != tt.want {
+				t.Errorf("colorDiffLine(%q, %d) = %q, want %q", tt.line, tt.maxWidth, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestColorDiffLine_StripsANSI(t *testing.T) {
+	DisableStyles()
+
+	line := "+\x1b[2Jmalicious content"
+	got := colorDiffLine(line, 0)
+	if strings.Contains(got, "\x1b") {
+		t.Errorf("expected ANSI sequences stripped, got: %q", got)
+	}
+	if got != "+malicious content" {
+		t.Errorf("expected '+malicious content', got: %q", got)
+	}
+}
+
+func TestColorDiffLine_PrefixNotGreen(t *testing.T) {
+	DisableStyles()
+
+	// "+++ " lines should be treated as file headers, not added lines
+	got := colorDiffLine("+++ b/file.go (desired)", 0)
+	if got != "+++ b/file.go (desired)" {
+		t.Errorf("expected file header unchanged with disabled styles, got: %q", got)
+	}
+
+	// "--- " lines should be treated as file headers, not removed lines
+	got = colorDiffLine("--- a/file.go (current)", 0)
+	if got != "--- a/file.go (current)" {
+		t.Errorf("expected file header unchanged with disabled styles, got: %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TruncateDiff
+// ---------------------------------------------------------------------------
+
+func TestTruncateDiff_UnderLimit(t *testing.T) {
+	diff := "--- a/f\n+++ b/f\n@@ -1 +1 @@\n-old\n+new\n"
+	got := TruncateDiff(diff, 500)
+	if got != diff {
+		t.Errorf("expected unchanged diff, got:\n%s", got)
+	}
+}
+
+func TestTruncateDiff_OverLimit(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("--- a/f\n+++ b/f\n@@ -1 +1 @@\n")
+	for i := range 600 {
+		fmt.Fprintf(&b, "+line %d\n", i)
+	}
+	diff := b.String()
+
+	got := TruncateDiff(diff, 10)
+	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+	if len(lines) != 11 { // 10 retained + 1 truncation note
+		t.Errorf("expected 11 lines, got %d", len(lines))
+	}
+	last := lines[len(lines)-1]
+	if !strings.Contains(last, "lines truncated") {
+		t.Errorf("expected truncation message, got: %q", last)
+	}
+}
+
+func TestTruncateDiff_Empty(t *testing.T) {
+	got := TruncateDiff("", 500)
+	if got != "" {
+		t.Errorf("expected empty, got: %q", got)
 	}
 }
 

--- a/internal/ui/printer.go
+++ b/internal/ui/printer.go
@@ -330,7 +330,7 @@ func (p *StandardPrinter) PrintDiffBlock(diff string) {
 		return
 	}
 	ind := Indent(IndentSub)
-	for _, line := range strings.Split(strings.TrimSuffix(diff, "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSuffix(diff, "\n"), "\n") {
 		fmt.Fprintf(p.out, "%s%s\n", ind, colorDiffLine(line, 0))
 	}
 	fmt.Fprintln(p.out)

--- a/internal/ui/printer.go
+++ b/internal/ui/printer.go
@@ -58,6 +58,7 @@ type Printer interface {
 	SubGroupHeader(icon, name string)
 	PrintChange(item ChangeItem)
 	PrintFileChange(item FileItem)
+	PrintDiffBlock(lines []string) // emit colored unified diff lines at IndentSub indent
 	PrintResult(item ResultItem)
 	Success(name, detail string)
 	Error(name, detail string)
@@ -317,6 +318,19 @@ func (p *StandardPrinter) PrintFileChange(item FileItem) {
 	stat := formatDiffStat(item.Added, item.Removed)
 	fmt.Fprintf(p.out, "%s%s %-*s %s\n",
 		ind, icon, p.subItemWidth(), item.Path, stat)
+}
+
+// PrintDiffBlock renders a unified diff block to stdout, indented at IndentSub.
+// Each line is colored using the same scheme as the interactive diff viewer:
+// added lines ("+") in green, removed lines ("-") in red, hunk headers ("@@") in cyan,
+// file headers ("---"/"+++") in bold, context lines as-is.
+// A blank line is emitted after the block as a visual separator.
+func (p *StandardPrinter) PrintDiffBlock(lines []string) {
+	ind := Indent(IndentSub)
+	for _, line := range lines {
+		fmt.Fprintf(p.out, "%s%s\n", ind, colorDiffLineNoTrunc(line))
+	}
+	fmt.Fprintln(p.out)
 }
 
 // PrintResult prints an apply result line.

--- a/internal/ui/printer.go
+++ b/internal/ui/printer.go
@@ -58,7 +58,7 @@ type Printer interface {
 	SubGroupHeader(icon, name string)
 	PrintChange(item ChangeItem)
 	PrintFileChange(item FileItem)
-	PrintDiffBlock(lines []string) // emit colored unified diff lines at IndentSub indent
+	PrintDiffBlock(diff string) // emit colored unified diff at IndentSub indent
 	PrintResult(item ResultItem)
 	Success(name, detail string)
 	Error(name, detail string)
@@ -320,15 +320,18 @@ func (p *StandardPrinter) PrintFileChange(item FileItem) {
 		ind, icon, p.subItemWidth(), item.Path, stat)
 }
 
-// PrintDiffBlock renders a unified diff block to stdout, indented at IndentSub.
+// PrintDiffBlock renders a unified diff string to stdout, indented at IndentSub.
 // Each line is colored using the same scheme as the interactive diff viewer:
 // added lines ("+") in green, removed lines ("-") in red, hunk headers ("@@") in cyan,
 // file headers ("---"/"+++") in bold, context lines as-is.
 // A blank line is emitted after the block as a visual separator.
-func (p *StandardPrinter) PrintDiffBlock(lines []string) {
+func (p *StandardPrinter) PrintDiffBlock(diff string) {
+	if diff == "" {
+		return
+	}
 	ind := Indent(IndentSub)
-	for _, line := range lines {
-		fmt.Fprintf(p.out, "%s%s\n", ind, colorDiffLineNoTrunc(line))
+	for _, line := range strings.Split(strings.TrimSuffix(diff, "\n"), "\n") {
+		fmt.Fprintf(p.out, "%s%s\n", ind, colorDiffLine(line, 0))
 	}
 	fmt.Fprintln(p.out)
 }

--- a/internal/ui/printer_test.go
+++ b/internal/ui/printer_test.go
@@ -603,14 +603,8 @@ func TestPrintDiffBlock(t *testing.T) {
 	var buf bytes.Buffer
 	p := NewStandardPrinterWith(&buf, &buf)
 
-	lines := []string{
-		"--- a/ci.yml (current)",
-		"+++ b/ci.yml (desired)",
-		"@@ -1 +1 @@",
-		"-old content",
-		"+new content",
-	}
-	p.PrintDiffBlock(lines)
+	diff := "--- a/ci.yml (current)\n+++ b/ci.yml (desired)\n@@ -1 +1 @@\n-old content\n+new content\n"
+	p.PrintDiffBlock(diff)
 	out := buf.String()
 
 	if !strings.Contains(out, "old content") {
@@ -632,9 +626,8 @@ func TestPrintDiffBlock(t *testing.T) {
 func TestPrintDiffBlock_Empty(t *testing.T) {
 	var buf bytes.Buffer
 	p := NewStandardPrinterWith(&buf, &buf)
-	p.PrintDiffBlock(nil)
-	// Empty block: only the trailing blank line
-	if buf.String() != "\n" {
-		t.Errorf("expected only blank line for empty block, got:\n%q", buf.String())
+	p.PrintDiffBlock("")
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for empty diff, got:\n%q", buf.String())
 	}
 }

--- a/internal/ui/printer_test.go
+++ b/internal/ui/printer_test.go
@@ -594,3 +594,47 @@ func TestSetColumnWidth(t *testing.T) {
 		t.Errorf("default itemWidth = %d, want 30", p.itemWidth())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// PrintDiffBlock
+// ---------------------------------------------------------------------------
+
+func TestPrintDiffBlock(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewStandardPrinterWith(&buf, &buf)
+
+	lines := []string{
+		"--- a/ci.yml (current)",
+		"+++ b/ci.yml (desired)",
+		"@@ -1 +1 @@",
+		"-old content",
+		"+new content",
+	}
+	p.PrintDiffBlock(lines)
+	out := buf.String()
+
+	if !strings.Contains(out, "old content") {
+		t.Errorf("expected diff content, got:\n%s", out)
+	}
+	if !strings.Contains(out, "new content") {
+		t.Errorf("expected diff content, got:\n%s", out)
+	}
+	// Should end with a blank line
+	if !strings.HasSuffix(out, "\n\n") {
+		t.Errorf("expected trailing blank line, got:\n%q", out)
+	}
+	// Should be indented at IndentSub level (10 spaces)
+	if !strings.Contains(out, Indent(IndentSub)) {
+		t.Errorf("expected IndentSub indentation, got:\n%q", out)
+	}
+}
+
+func TestPrintDiffBlock_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewStandardPrinterWith(&buf, &buf)
+	p.PrintDiffBlock(nil)
+	// Empty block: only the trailing blank line
+	if buf.String() != "\n" {
+		t.Errorf("expected only blank line for empty block, got:\n%q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `--diff` flag to `gh infra plan` that emits colored unified diff output for each FileSet file change, alongside the existing `+N -M` line count summary.

## Background

`gh infra plan` shows precise field-level before/after values for repo settings changes but only `+N -M` line counts for FileSet file changes. There's no way to see what content is actually being written without manually fetching the remote file via the API and diffing locally. This is how the FileSet override resolution bug (#151) went undetected — the line counts looked plausible, but the actual content being pushed was wrong.

The implementation reuses the existing `GenerateDiff` machinery from the interactive diff viewer in `apply`. The unified `colorDiffLine(line, maxWidth)` function now handles both interactive (truncated) and non-interactive (full-width) contexts — pass `maxWidth=0` to skip truncation. Diff output is indented at `IndentSub` level below each file change line.

The `--diff` flag respects `--ci` mode — when both are set, ANSI color codes are stripped (via `ui.DisableStyles()`), producing plain unified diff text suitable for CI logs.

## Safety hardening

- ANSI escape sequences are stripped from diff content before rendering via `charmbracelet/x/ansi`, preventing terminal injection from file content fetched via the GitHub API (same class as CVE-2022-24795 in git)
- Diff output is capped at 500 lines with a truncation note to prevent terminal flooding on large file creates
- `PrintDiffBlock` signature takes a raw diff `string` (consistent with other `Printer` interface methods that accept domain values) rather than pre-split `[]string`

## Changes

- Add `--diff` bool flag to `cmd/plan.go`; thread through `planCommandOptions` → `PlanOptions.ShowDiff` → `printPlan`
- Add `printFileDiff` helper in `internal/infra/format.go` with 500-line cap via `TruncateDiff`
- Add `PrintDiffBlock(diff string)` to `Printer` interface + `StandardPrinter` in `internal/ui/printer.go`
- Merge `colorDiffLineNoTrunc` into `colorDiffLine(line, maxWidth)` with ANSI stripping in `internal/ui/diffviewer.go`
- Update 10 existing `printPlan` call sites; add 12 new tests covering delete diffs, identical content no-op, multi-file output, line truncation, CI/no-ANSI mode, ANSI stripping, and `colorDiffLine` routing logic

Closes #155