### PR TITLE
refactor: extract mergeByKey generic and polish #158 follow-ups

### DIFF
--- a/docs/src/content/docs/resources/repository-set/defaults.md
+++ b/docs/src/content/docs/resources/repository-set/defaults.md
@@ -141,9 +141,9 @@ repositories:
           enforcement: evaluate   # replaces the entire default ruleset entry
 ```
 
-#### Secrets & Variables
+#### Secrets
 
-Same-name entries are replaced; new entries are appended; default entries not referenced are inherited.
+Same-name entries are replaced; new entries are appended; default entries not referenced are inherited. Variables follow the same rules.
 
 ```yaml
 defaults:

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -608,9 +608,16 @@ func mergeActions(base, override *Actions) *Actions {
 	return &result
 }
 
-// mergeLabels merges two label slices by name. Override labels take precedence
-// for entries with the same name; new labels are appended.
-func mergeLabels(base, override []Label) []Label {
+// mergeByKey merges two slices by a string key derived from each entry. Entries
+// from override with a matching key in base replace the base entry; new entries
+// are appended. Order of base entries is preserved.
+func mergeByKey[T any](base, override []T, key func(T) string) []T {
+	return mergeByKeyWith(base, override, key, func(_, o T) T { return o })
+}
+
+// mergeByKeyWith is like mergeByKey but combines matching entries through a
+// caller-supplied merge function instead of replacing them.
+func mergeByKeyWith[T any](base, override []T, key func(T) string, merge func(base, override T) T) []T {
 	if len(base) == 0 {
 		return override
 	}
@@ -619,49 +626,37 @@ func mergeLabels(base, override []Label) []Label {
 	}
 
 	index := make(map[string]int, len(base))
-	result := make([]Label, len(base))
+	result := make([]T, len(base))
 	copy(result, base)
-	for i, l := range result {
-		index[l.Name] = i
+	for i, x := range result {
+		index[key(x)] = i
 	}
 
-	for _, l := range override {
-		if i, ok := index[l.Name]; ok {
-			result[i] = l
+	for _, x := range override {
+		k := key(x)
+		if i, ok := index[k]; ok {
+			result[i] = merge(result[i], x)
 		} else {
-			index[l.Name] = len(result)
-			result = append(result, l)
+			index[k] = len(result)
+			result = append(result, x)
 		}
 	}
 	return result
 }
 
+// mergeLabels merges two label slices by name. Override labels take precedence
+// for entries with the same name; new labels are appended.
+func mergeLabels(base, override []Label) []Label {
+	return mergeByKey(base, override, func(l Label) string { return l.Name })
+}
+
 // mergeBranchProtection merges two branch protection slices by pattern.
 // Same-pattern entries are merged at the field level; new patterns are appended.
 func mergeBranchProtection(base, override []BranchProtection) []BranchProtection {
-	if len(base) == 0 {
-		return override
-	}
-	if len(override) == 0 {
-		return base
-	}
-
-	index := make(map[string]int, len(base))
-	result := make([]BranchProtection, len(base))
-	copy(result, base)
-	for i, bp := range result {
-		index[bp.Pattern] = i
-	}
-
-	for _, bp := range override {
-		if i, ok := index[bp.Pattern]; ok {
-			result[i] = mergeBranchProtectionEntry(result[i], bp)
-		} else {
-			index[bp.Pattern] = len(result)
-			result = append(result, bp)
-		}
-	}
-	return result
+	return mergeByKeyWith(base, override,
+		func(bp BranchProtection) string { return bp.Pattern },
+		mergeBranchProtectionEntry,
+	)
 }
 
 func mergeBranchProtectionEntry(base, override BranchProtection) BranchProtection {
@@ -696,85 +691,19 @@ func mergeBranchProtectionEntry(base, override BranchProtection) BranchProtectio
 // mergeRulesets merges two ruleset slices by name. Override rulesets take precedence
 // for entries with the same name; new rulesets are appended.
 func mergeRulesets(base, override []Ruleset) []Ruleset {
-	if len(base) == 0 {
-		return override
-	}
-	if len(override) == 0 {
-		return base
-	}
-
-	index := make(map[string]int, len(base))
-	result := make([]Ruleset, len(base))
-	copy(result, base)
-	for i, rs := range result {
-		index[rs.Name] = i
-	}
-
-	for _, rs := range override {
-		if i, ok := index[rs.Name]; ok {
-			result[i] = rs
-		} else {
-			index[rs.Name] = len(result)
-			result = append(result, rs)
-		}
-	}
-	return result
+	return mergeByKey(base, override, func(rs Ruleset) string { return rs.Name })
 }
 
 // mergeSecrets merges two secret slices by name. Override secrets take precedence
 // for entries with the same name; new secrets are appended.
 func mergeSecrets(base, override []Secret) []Secret {
-	if len(base) == 0 {
-		return override
-	}
-	if len(override) == 0 {
-		return base
-	}
-
-	index := make(map[string]int, len(base))
-	result := make([]Secret, len(base))
-	copy(result, base)
-	for i, s := range result {
-		index[s.Name] = i
-	}
-
-	for _, s := range override {
-		if i, ok := index[s.Name]; ok {
-			result[i] = s
-		} else {
-			index[s.Name] = len(result)
-			result = append(result, s)
-		}
-	}
-	return result
+	return mergeByKey(base, override, func(s Secret) string { return s.Name })
 }
 
 // mergeVariables merges two variable slices by name. Override variables take precedence
 // for entries with the same name; new variables are appended.
 func mergeVariables(base, override []Variable) []Variable {
-	if len(base) == 0 {
-		return override
-	}
-	if len(override) == 0 {
-		return base
-	}
-
-	index := make(map[string]int, len(base))
-	result := make([]Variable, len(base))
-	copy(result, base)
-	for i, v := range result {
-		index[v.Name] = i
-	}
-
-	for _, v := range override {
-		if i, ok := index[v.Name]; ok {
-			result[i] = v
-		} else {
-			index[v.Name] = len(result)
-			result = append(result, v)
-		}
-	}
-	return result
+	return mergeByKey(base, override, func(v Variable) string { return v.Name })
 }
 
 func mergeSelectedActions(base, override *SelectedActions) *SelectedActions {

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -2481,13 +2481,22 @@ repositories:
 	if len(repos[1].Spec.Variables) != 3 {
 		t.Fatalf("adds-variable: expected 3 variables, got %d", len(repos[1].Spec.Variables))
 	}
-	varNames := make(map[string]bool)
 	for _, v := range repos[1].Spec.Variables {
-		varNames[v.Name] = true
-	}
-	for _, want := range []string{"APP_ENV", "REGION", "EXTRA_VAR"} {
-		if !varNames[want] {
-			t.Errorf("adds-variable: missing variable %q", want)
+		switch v.Name {
+		case "APP_ENV":
+			if v.Value != "production" {
+				t.Errorf("adds-variable: APP_ENV value = %q, want production (inherited)", v.Value)
+			}
+		case "REGION":
+			if v.Value != "us-east-1" {
+				t.Errorf("adds-variable: REGION value = %q, want us-east-1 (inherited)", v.Value)
+			}
+		case "EXTRA_VAR":
+			if v.Value != "custom-value" {
+				t.Errorf("adds-variable: EXTRA_VAR value = %q, want custom-value", v.Value)
+			}
+		default:
+			t.Errorf("adds-variable: unexpected variable %q", v.Name)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #158. Bundles three small items: a refactor that collapses the now-duplicated by-key merge functions, a docs heading fix, and a test assertion tightening.

## Background

After #158 landed, four structurally-identical functions (`mergeLabels`, `mergeRulesets`, `mergeSecrets`, `mergeVariables`) sit next to each other doing the same map-index dance; `mergeBranchProtection` follows the same shape but uses a per-entry merge function. Extracting the shared core into a single generic helper removes the duplication while keeping the named entry points that call sites and grep rely on.

Two minor issues also slipped in with #158:

- `defaults.md` introduced a `#### Secrets & Variables` heading that contained only the secrets example, while the variables example sat under a separate `#### Variables` heading.
- The `adds-variable` case in `TestRepositorySet_VariablesMerge` checked only the variable names, while its symmetric `adds-secret` case verified inherited values.

## Changes

- Add `mergeByKey[T]` and `mergeByKeyWith[T]` generic helpers in `parser.go`. `mergeByKeyWith` is the core implementation; `mergeByKey` is a thin wrapper that uses an override-replaces-base merge function.
- Reduce `mergeLabels`, `mergeRulesets`, `mergeSecrets`, `mergeVariables` to one-line wrappers around `mergeByKey`. Behavior is unchanged.
- Route `mergeBranchProtection` through `mergeByKeyWith` with `mergeBranchProtectionEntry` as the merge function. Behavior is unchanged.
- Fix the `defaults.md` heading structure so the secrets and variables sections each have their own heading.
- Tighten `adds-variable` to verify inherited `APP_ENV` and `REGION` values plus the appended `EXTRA_VAR`, mirroring the existing `adds-secret` assertions.