### PR TITLE
fix: retry on HEAD conflict in createCommitOnBranch

### DIFF
--- a/internal/fileset/fileset_test.go
+++ b/internal/fileset/fileset_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/babarot/gh-infra/internal/gh"
@@ -574,6 +575,7 @@ func TestIsHeadConflict(t *testing.T) {
 	}{
 		{fmt.Errorf("graphql: is at abc123 but expected def456"), true},
 		{fmt.Errorf("graphql: some other error"), false},
+		{fmt.Errorf("value must be X but expected Y"), false},
 		{nil, false},
 	}
 	for _, tt := range tests {
@@ -589,6 +591,7 @@ type SequenceMockRunner struct {
 	DefaultResponse []byte
 	sequences       map[string][]sequenceEntry
 	callCounts      map[string]int
+	mu              sync.Mutex
 }
 
 type sequenceEntry struct {
@@ -598,23 +601,27 @@ type sequenceEntry struct {
 
 func (m *SequenceMockRunner) Run(_ context.Context, args ...string) ([]byte, error) {
 	key := strings.Join(args, " ")
+	m.mu.Lock()
 	m.Called = append(m.Called, args)
+	m.CalledStdin = append(m.CalledStdin, nil)
+	for prefix, entries := range m.sequences {
+		if strings.HasPrefix(key, prefix) {
+			idx := m.callCounts[prefix]
+			m.callCounts[prefix]++
+			m.mu.Unlock()
+			if idx < len(entries) {
+				e := entries[idx]
+				return e.response, e.err
+			}
+			return m.DefaultResponse, nil
+		}
+	}
+	m.mu.Unlock()
 	if err, ok := m.Errors[key]; ok {
 		return nil, err
 	}
 	if resp, ok := m.Responses[key]; ok {
 		return resp, nil
-	}
-	// Check sequences by prefix match
-	for prefix, entries := range m.sequences {
-		if strings.HasPrefix(key, prefix) {
-			idx := m.callCounts[prefix]
-			m.callCounts[prefix]++
-			if idx < len(entries) {
-				e := entries[idx]
-				return e.response, e.err
-			}
-		}
 	}
 	return m.DefaultResponse, nil
 }
@@ -625,7 +632,6 @@ func TestApply_RetryOnHeadConflict(t *testing.T) {
 		MockRunner: gh.MockRunner{
 			Responses: map[string][]byte{
 				fmt.Sprintf("repo view %s --json defaultBranchRef --jq .defaultBranchRef.name", repo): []byte("main"),
-				fmt.Sprintf("api repos/%s/git/ref/heads/main --jq .object.sha", repo):                 []byte("head123"),
 			},
 			Errors: map[string]error{},
 		},
@@ -634,6 +640,10 @@ func TestApply_RetryOnHeadConflict(t *testing.T) {
 			"api graphql": {
 				{response: []byte(`{"errors":[{"message":"is at newsha but expected head123"}]}`), err: nil},
 				{response: []byte(`{"data":{"createCommitOnBranch":{"commit":{"oid":"final-sha"}}}}`), err: nil},
+			},
+			"api repos/owner/repo/git/ref/heads/main": {
+				{response: []byte("head123"), err: nil},
+				{response: []byte("head456"), err: nil},
 			},
 		},
 		callCounts: make(map[string]int),
@@ -657,5 +667,12 @@ func TestApply_RetryOnHeadConflict(t *testing.T) {
 	}
 	if results[0].Err != nil {
 		t.Errorf("expected success after retry, got error: %v", results[0].Err)
+	}
+
+	if got := mock.callCounts["api graphql"]; got != 2 {
+		t.Errorf("expected 2 graphql calls (1 failure + 1 retry), got %d", got)
+	}
+	if got := mock.callCounts["api repos/owner/repo/git/ref/heads/main"]; got != 2 {
+		t.Errorf("expected 2 HEAD SHA fetches (initial + retry), got %d", got)
 	}
 }

--- a/internal/fileset/fileset_test.go
+++ b/internal/fileset/fileset_test.go
@@ -625,7 +625,7 @@ func TestApply_RetryOnHeadConflict(t *testing.T) {
 		MockRunner: gh.MockRunner{
 			Responses: map[string][]byte{
 				fmt.Sprintf("repo view %s --json defaultBranchRef --jq .defaultBranchRef.name", repo): []byte("main"),
-				fmt.Sprintf("api repos/%s/git/ref/heads/main --jq .object.sha", repo):                []byte("head123"),
+				fmt.Sprintf("api repos/%s/git/ref/heads/main --jq .object.sha", repo):                 []byte("head123"),
 			},
 			Errors: map[string]error{},
 		},

--- a/internal/fileset/fileset_test.go
+++ b/internal/fileset/fileset_test.go
@@ -562,3 +562,100 @@ func TestHasChanges_OnlyDeletes(t *testing.T) {
 		t.Error("expected HasChanges=true when only ChangeDelete changes exist")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// isHeadConflict and retry tests
+// ---------------------------------------------------------------------------
+
+func TestIsHeadConflict(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{fmt.Errorf("graphql: is at abc123 but expected def456"), true},
+		{fmt.Errorf("graphql: some other error"), false},
+		{nil, false},
+	}
+	for _, tt := range tests {
+		if got := isHeadConflict(tt.err); got != tt.want {
+			t.Errorf("isHeadConflict(%v) = %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}
+
+// SequenceMockRunner returns different responses for successive calls matching a prefix.
+type SequenceMockRunner struct {
+	gh.MockRunner
+	DefaultResponse []byte
+	sequences       map[string][]sequenceEntry
+	callCounts      map[string]int
+}
+
+type sequenceEntry struct {
+	response []byte
+	err      error
+}
+
+func (m *SequenceMockRunner) Run(_ context.Context, args ...string) ([]byte, error) {
+	key := strings.Join(args, " ")
+	m.Called = append(m.Called, args)
+	if err, ok := m.Errors[key]; ok {
+		return nil, err
+	}
+	if resp, ok := m.Responses[key]; ok {
+		return resp, nil
+	}
+	// Check sequences by prefix match
+	for prefix, entries := range m.sequences {
+		if strings.HasPrefix(key, prefix) {
+			idx := m.callCounts[prefix]
+			m.callCounts[prefix]++
+			if idx < len(entries) {
+				e := entries[idx]
+				return e.response, e.err
+			}
+		}
+	}
+	return m.DefaultResponse, nil
+}
+
+func TestApply_RetryOnHeadConflict(t *testing.T) {
+	repo := "owner/repo"
+	mock := &SequenceMockRunner{
+		MockRunner: gh.MockRunner{
+			Responses: map[string][]byte{
+				fmt.Sprintf("repo view %s --json defaultBranchRef --jq .defaultBranchRef.name", repo): []byte("main"),
+				fmt.Sprintf("api repos/%s/git/ref/heads/main --jq .object.sha", repo):                []byte("head123"),
+			},
+			Errors: map[string]error{},
+		},
+		DefaultResponse: []byte(`{"data":{"createCommitOnBranch":{"commit":{"oid":"new-sha"}}}}`),
+		sequences: map[string][]sequenceEntry{
+			"api graphql": {
+				{response: []byte(`{"errors":[{"message":"is at newsha but expected head123"}]}`), err: nil},
+				{response: []byte(`{"data":{"createCommitOnBranch":{"commit":{"oid":"final-sha"}}}}`), err: nil},
+			},
+		},
+		callCounts: make(map[string]int),
+	}
+
+	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
+	changes := []Change{
+		{
+			FileSetID: "test",
+			Target:    repo,
+			Path:      ".github/ci.yml",
+			Type:      ChangeUpdate,
+			Desired:   "name: CI",
+		},
+	}
+
+	results := p.Apply(context.Background(), changes, ApplyOptions{FileSetID: "test"}, ui.NoopReporter{})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Errorf("expected success after retry, got error: %v", results[0].Err)
+	}
+}

--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -17,6 +17,8 @@ const maxCommitRetries = 3
 // createCommitOnBranch mutation. Falls back to Contents API for empty repositories.
 // Returns (prURL, error); prURL is non-empty only for pull_request strategy.
 // Retries up to maxCommitRetries times on HEAD conflict errors caused by concurrent commits.
+// For pull_request mode, branch creation and PR opening happen outside the retry loop so
+// that only the commit itself is retried on conflict.
 func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
 	headSHA, defaultBranch, err := p.getHeadSHA(ctx, repo)
 	if err != nil {
@@ -26,32 +28,6 @@ func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Chan
 		return "", fmt.Errorf("get HEAD: %w", err)
 	}
 
-	for attempt := range maxCommitRetries {
-		prURL, err := p.applyViaGraphQL(ctx, repo, defaultBranch, headSHA, changes, opts, statusFn)
-		if err == nil {
-			return prURL, nil
-		}
-		if !isHeadConflict(err) || attempt == maxCommitRetries-1 {
-			return "", err
-		}
-		headSHA, _, err = p.getHeadSHA(ctx, repo)
-		if err != nil {
-			return "", fmt.Errorf("get HEAD for retry: %w", err)
-		}
-	}
-	return "", fmt.Errorf("commit retries exhausted for %s", repo)
-}
-
-// isHeadConflict reports whether err is a GitHub GraphQL HEAD conflict error,
-// which occurs when a concurrent commit advances the branch between our HEAD
-// fetch and our createCommitOnBranch call.
-func isHeadConflict(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "but expected")
-}
-
-// applyViaGraphQL creates a verified commit using the GitHub GraphQL createCommitOnBranch
-// mutation. All file changes are committed atomically in a single call.
-func (p *Processor) applyViaGraphQL(ctx context.Context, repo, defaultBranch, headSHA string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
 	message := resolveCommitMessage(opts)
 	targetBranch := defaultBranch
 
@@ -67,9 +43,22 @@ func (p *Processor) applyViaGraphQL(ctx context.Context, repo, defaultBranch, he
 		targetBranch = prBranch
 	}
 
-	statusFn("committing changes...")
-	if err := p.commitViaGraphQL(ctx, repo, targetBranch, headSHA, message, changes); err != nil {
-		return "", err
+	for attempt := range maxCommitRetries {
+		statusFn("committing changes...")
+		err := p.commitViaGraphQL(ctx, repo, targetBranch, headSHA, message, changes)
+		if err == nil {
+			break
+		}
+		if !isHeadConflict(err) {
+			return "", err
+		}
+		if attempt == maxCommitRetries-1 {
+			return "", fmt.Errorf("commit retries exhausted for %s: %w", repo, err)
+		}
+		headSHA, _, err = p.getHeadSHA(ctx, repo)
+		if err != nil {
+			return "", fmt.Errorf("get HEAD for retry: %w", err)
+		}
 	}
 
 	if opts.Via == manifest.ViaPullRequest {
@@ -77,6 +66,17 @@ func (p *Processor) applyViaGraphQL(ctx context.Context, repo, defaultBranch, he
 		return p.openPR(ctx, repo, defaultBranch, targetBranch, opts)
 	}
 	return "", nil
+}
+
+// isHeadConflict reports whether err is a GitHub GraphQL HEAD conflict error,
+// which occurs when a concurrent commit advances the branch between our HEAD
+// fetch and our createCommitOnBranch call.
+func isHeadConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "is at ") && strings.Contains(msg, "but expected")
 }
 
 // commitViaGraphQL sends a createCommitOnBranch GraphQL mutation.

--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -11,9 +11,12 @@ import (
 	"github.com/babarot/gh-infra/internal/manifest"
 )
 
+const maxCommitRetries = 3
+
 // applyToRepo creates a verified commit for all file changes using the GitHub GraphQL
 // createCommitOnBranch mutation. Falls back to Contents API for empty repositories.
 // Returns (prURL, error); prURL is non-empty only for pull_request strategy.
+// Retries up to maxCommitRetries times on HEAD conflict errors caused by concurrent commits.
 func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
 	headSHA, defaultBranch, err := p.getHeadSHA(ctx, repo)
 	if err != nil {
@@ -22,7 +25,28 @@ func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Chan
 		}
 		return "", fmt.Errorf("get HEAD: %w", err)
 	}
-	return p.applyViaGraphQL(ctx, repo, defaultBranch, headSHA, changes, opts, statusFn)
+
+	for attempt := range maxCommitRetries {
+		prURL, err := p.applyViaGraphQL(ctx, repo, defaultBranch, headSHA, changes, opts, statusFn)
+		if err == nil {
+			return prURL, nil
+		}
+		if !isHeadConflict(err) || attempt == maxCommitRetries-1 {
+			return "", err
+		}
+		headSHA, _, err = p.getHeadSHA(ctx, repo)
+		if err != nil {
+			return "", fmt.Errorf("get HEAD for retry: %w", err)
+		}
+	}
+	return "", fmt.Errorf("commit retries exhausted for %s", repo)
+}
+
+// isHeadConflict reports whether err is a GitHub GraphQL HEAD conflict error,
+// which occurs when a concurrent commit advances the branch between our HEAD
+// fetch and our createCommitOnBranch call.
+func isHeadConflict(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "but expected")
 }
 
 // applyViaGraphQL creates a verified commit using the GitHub GraphQL createCommitOnBranch


### PR DESCRIPTION
## Summary

- Add retry loop (up to 3 attempts) in `applyToRepo` for `createCommitOnBranch` HEAD conflicts caused by concurrent commits advancing the branch between HEAD fetch and commit
- Inline `applyViaGraphQL` into `applyToRepo` so that branch creation and PR opening happen once, outside the retry loop — only `commitViaGraphQL` is retried on conflict
- `isHeadConflict` matches both `"is at "` and `"but expected"` substrings from the GitHub GraphQL error to avoid false positives on unrelated error messages
- No backoff needed — the race window is milliseconds between concurrent goroutines in spinner mode
- Safe for both `push` and `pull_request` strategies