### PR TITLE
feat: support template expressions in commit messages

### DIFF
--- a/internal/fileset/apply.go
+++ b/internal/fileset/apply.go
@@ -16,6 +16,7 @@ type ApplyOptions struct {
 	FileSetID     string
 	PRTitle       string // custom PR title (pull_request only)
 	PRBody        string // custom PR body (pull_request only)
+	SourceURL     string // provenance URL for <% .Source.URL %> in templates
 }
 
 // Apply executes the planned file changes using Git Data API.
@@ -112,10 +113,15 @@ func groupChangesByTarget(changes []Change) map[string][]Change {
 	return grouped
 }
 
-// resolveCommitMessage returns the commit message from opts or a default.
-func resolveCommitMessage(opts ApplyOptions) string {
-	if opts.CommitMessage != "" {
-		return opts.CommitMessage
+// resolveCommitMessage returns the commit message from opts or a default,
+// rendering any <% %> template expressions against the given repo.
+func resolveCommitMessage(opts ApplyOptions, repo string) (string, error) {
+	msg := opts.CommitMessage
+	if msg == "" {
+		msg = fmt.Sprintf("chore: sync %s files via gh-infra", opts.FileSetID)
 	}
-	return fmt.Sprintf("chore: sync %s files via gh-infra", opts.FileSetID)
+	if !HasTemplate(msg, nil) {
+		return msg, nil
+	}
+	return RenderCommitMessage(msg, repo, opts.SourceURL)
 }

--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -28,7 +28,10 @@ func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Chan
 // applyViaGraphQL creates a verified commit using the GitHub GraphQL createCommitOnBranch
 // mutation. All file changes are committed atomically in a single call.
 func (p *Processor) applyViaGraphQL(ctx context.Context, repo, defaultBranch, headSHA string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
-	message := resolveCommitMessage(opts)
+	message, err := resolveCommitMessage(opts, repo)
+	if err != nil {
+		return "", fmt.Errorf("render commit message: %w", err)
+	}
 	targetBranch := defaultBranch
 
 	if opts.Via == manifest.ViaPullRequest {
@@ -222,11 +225,27 @@ func (p *Processor) createBranchAt(ctx context.Context, repo, branch, sha string
 func (p *Processor) openPR(ctx context.Context, repo, base, head string, opts ApplyOptions) (string, error) {
 	prTitle := opts.PRTitle
 	if prTitle == "" {
-		prTitle = resolveCommitMessage(opts)
+		var err error
+		prTitle, err = resolveCommitMessage(opts, repo)
+		if err != nil {
+			return "", fmt.Errorf("render PR title: %w", err)
+		}
+	} else if HasTemplate(prTitle, nil) {
+		var err error
+		prTitle, err = RenderCommitMessage(prTitle, repo, opts.SourceURL)
+		if err != nil {
+			return "", fmt.Errorf("render PR title: %w", err)
+		}
 	}
 	prBody := opts.PRBody
 	if prBody == "" {
 		prBody = fmt.Sprintf("Automated file sync by gh-infra FileSet `%s`.", opts.FileSetID)
+	} else if HasTemplate(prBody, nil) {
+		var err error
+		prBody, err = RenderCommitMessage(prBody, repo, opts.SourceURL)
+		if err != nil {
+			return "", fmt.Errorf("render PR body: %w", err)
+		}
 	}
 	out, err := p.runner.Run(ctx, "pr", "create",
 		"--repo", repo,

--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -86,12 +86,18 @@ func (p *Processor) commitViaGraphQL(ctx context.Context, repo, branch, headSHA,
 		}
 	}
 
+	headline, msgBody := splitCommitMessage(message)
+	msgInput := map[string]string{"headline": headline}
+	if msgBody != "" {
+		msgInput["body"] = msgBody
+	}
+
 	input := map[string]any{
 		"branch": map[string]string{
 			"repositoryNameWithOwner": repo,
 			"branchName":              branch,
 		},
-		"message":         map[string]string{"headline": message},
+		"message":         msgInput,
 		"expectedHeadOid": headSHA,
 		"fileChanges":     fileChanges{Additions: adds, Deletions: dels},
 	}
@@ -142,9 +148,9 @@ func (p *Processor) commitViaGraphQL(ctx context.Context, repo, branch, headSHA,
 // applyToEmptyRepo uses Contents API as fallback for repos with no commits.
 func (p *Processor) applyToEmptyRepo(ctx context.Context, repo string, changes []Change, opts ApplyOptions) error {
 	p.writer.Progress(fmt.Sprintf("Updating %s (empty repo, using fallback)...", repo))
-	message := opts.CommitMessage
-	if message == "" {
-		message = fmt.Sprintf("chore: sync %s files via gh-infra", opts.FileSetID)
+	message, err := resolveCommitMessage(opts, repo)
+	if err != nil {
+		return fmt.Errorf("render commit message: %w", err)
 	}
 	for _, c := range changes {
 		commitMsg := fmt.Sprintf("%s: %s", message, c.Path)
@@ -230,6 +236,7 @@ func (p *Processor) openPR(ctx context.Context, repo, base, head string, opts Ap
 		if err != nil {
 			return "", fmt.Errorf("render PR title: %w", err)
 		}
+		prTitle, _ = splitCommitMessage(prTitle)
 	} else if HasTemplate(prTitle, nil) {
 		var err error
 		prTitle, err = RenderCommitMessage(prTitle, repo, opts.SourceURL)
@@ -269,6 +276,19 @@ func (p *Processor) openPR(ctx context.Context, repo, base, head string, opts Ap
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// splitCommitMessage splits a commit message into headline and body.
+// The headline is the text before the first newline; body is everything after,
+// with leading newlines stripped. Matches standard Git commit message convention.
+func splitCommitMessage(msg string) (headline, body string) {
+	if idx := strings.Index(msg, "\n"); idx >= 0 {
+		headline = msg[:idx]
+		body = strings.TrimLeft(msg[idx+1:], "\n")
+	} else {
+		headline = msg
+	}
+	return
 }
 
 // sanitizeBranchName converts an identity string into a valid Git branch name component.

--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -282,12 +282,8 @@ func (p *Processor) openPR(ctx context.Context, repo, base, head string, opts Ap
 // The headline is the text before the first newline; body is everything after,
 // with leading newlines stripped. Matches standard Git commit message convention.
 func splitCommitMessage(msg string) (headline, body string) {
-	if idx := strings.Index(msg, "\n"); idx >= 0 {
-		headline = msg[:idx]
-		body = strings.TrimLeft(msg[idx+1:], "\n")
-	} else {
-		headline = msg
-	}
+	headline, body, _ = strings.Cut(msg, "\n")
+	body = strings.TrimLeft(body, "\n")
 	return
 }
 

--- a/internal/fileset/template.go
+++ b/internal/fileset/template.go
@@ -54,6 +54,7 @@ func RenderTemplate(content string, repo string, vars map[string]string) (string
 }
 
 // RenderCommitMessage renders a commit or PR message template with Repo and Source context.
+// Vars are not available in commit messages — use .Repo and .Source fields only.
 func RenderCommitMessage(msg string, repo string, sourceURL string) (string, error) {
 	repoCtx := buildRepoContext(repo)
 	ctx := TemplateContext{

--- a/internal/fileset/template.go
+++ b/internal/fileset/template.go
@@ -16,8 +16,14 @@ const (
 
 // TemplateContext is the data available to templates.
 type TemplateContext struct {
-	Repo RepoContext
-	Vars map[string]string
+	Repo   RepoContext
+	Vars   map[string]string
+	Source SourceContext
+}
+
+// SourceContext provides source provenance metadata to templates.
+type SourceContext struct {
+	URL string
 }
 
 // RepoContext provides repository metadata to templates.
@@ -45,6 +51,16 @@ func RenderTemplate(content string, repo string, vars map[string]string) (string
 	// Pass 2: Expand content (can reference .Repo and .Vars)
 	ctx := TemplateContext{Repo: repoCtx, Vars: expandedVars}
 	return execTemplate(content, ctx)
+}
+
+// RenderCommitMessage renders a commit or PR message template with Repo and Source context.
+func RenderCommitMessage(msg string, repo string, sourceURL string) (string, error) {
+	repoCtx := buildRepoContext(repo)
+	ctx := TemplateContext{
+		Repo:   repoCtx,
+		Source: SourceContext{URL: sourceURL},
+	}
+	return execTemplate(msg, ctx)
 }
 
 // HasTemplate returns true if the content uses <% %> template syntax or has vars.

--- a/internal/fileset/template_test.go
+++ b/internal/fileset/template_test.go
@@ -200,3 +200,39 @@ func TestRenderTemplateWithTrace_UnsupportedSyntax(t *testing.T) {
 		t.Fatal("expected error for unsupported syntax")
 	}
 }
+
+func TestRenderCommitMessage_SourceURL(t *testing.T) {
+	msg := "ci: sync files\n\nSource: <% .Source.URL %>"
+	result, err := RenderCommitMessage(msg, "org/repo", "https://github.com/org/config/pull/17")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "ci: sync files\n\nSource: https://github.com/org/config/pull/17"
+	if result != want {
+		t.Errorf("got %q, want %q", result, want)
+	}
+}
+
+func TestRenderCommitMessage_EmptySourceURL(t *testing.T) {
+	msg := "ci: sync files <% .Source.URL %>"
+	result, err := RenderCommitMessage(msg, "org/repo", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "ci: sync files "
+	if result != want {
+		t.Errorf("got %q, want %q", result, want)
+	}
+}
+
+func TestRenderCommitMessage_WithRepoContext(t *testing.T) {
+	msg := "ci: sync <% .Repo.Name %> files\n\nSource: <% .Source.URL %>"
+	result, err := RenderCommitMessage(msg, "babarot/gomi", "https://github.com/org/config/pull/17")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "ci: sync gomi files\n\nSource: https://github.com/org/config/pull/17"
+	if result != want {
+		t.Errorf("got %q, want %q", result, want)
+	}
+}

--- a/internal/fileset/template_test.go
+++ b/internal/fileset/template_test.go
@@ -201,6 +201,26 @@ func TestRenderTemplateWithTrace_UnsupportedSyntax(t *testing.T) {
 	}
 }
 
+func TestSplitCommitMessage(t *testing.T) {
+	tests := []struct {
+		msg          string
+		wantHeadline string
+		wantBody     string
+	}{
+		{"single line", "single line", ""},
+		{"headline\n\nbody text", "headline", "body text"},
+		{"headline\nbody without blank line", "headline", "body without blank line"},
+		{"headline\n\nfirst para\n\nsecond para", "headline", "first para\n\nsecond para"},
+	}
+	for _, tt := range tests {
+		h, b := splitCommitMessage(tt.msg)
+		if h != tt.wantHeadline || b != tt.wantBody {
+			t.Errorf("splitCommitMessage(%q) = (%q, %q), want (%q, %q)",
+				tt.msg, h, b, tt.wantHeadline, tt.wantBody)
+		}
+	}
+}
+
 func TestRenderCommitMessage_SourceURL(t *testing.T) {
 	msg := "ci: sync files\n\nSource: <% .Source.URL %>"
 	result, err := RenderCommitMessage(msg, "org/repo", "https://github.com/org/config/pull/17")

--- a/internal/infra/apply.go
+++ b/internal/infra/apply.go
@@ -3,6 +3,7 @@ package infra
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -190,6 +191,7 @@ func fileSetApplyArgs(fs *manifest.FileSet, allChanges []fileset.Change) ([]file
 		FileSetID:     fs.Identity(),
 		PRTitle:       fs.Spec.PRTitle,
 		PRBody:        fs.Spec.PRBody,
+		SourceURL:     os.Getenv("GH_INFRA_SOURCE_URL"),
 	}
 	return fsChanges, opts
 }


### PR DESCRIPTION
## Summary

- Add `SourceContext` (with `URL` field) to the template system, making `<% .Source.URL %>` available in `commit_message`, `pr_title`, and `pr_body` fields
- Read source URL from `GH_INFRA_SOURCE_URL` environment variable in `fileSetApplyArgs`
- Update `resolveCommitMessage` to render templates when `<% %>` delimiters are present, with the full `Repo` and `Source` context
- Split multi-line commit messages into `headline` and `body` fields for the GraphQL `createCommitOnBranch` mutation, so body content (e.g., `Source: <% .Source.URL %>`) is preserved in commits
- Use headline-only when falling back to PR title from commit message, since GitHub PR titles don't support newlines
- Render templates in `openPR` for both PR title and body fields
- Use `resolveCommitMessage` in `applyToEmptyRepo` so template rendering is consistent across all code paths