### PR TITLE
feat: support executable file mode in FileSet

### DIFF
--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -11,8 +11,24 @@ import (
 	"github.com/babarot/gh-infra/internal/manifest"
 )
 
-// applyToRepo creates a verified commit for all file changes using the GitHub GraphQL
-// createCommitOnBranch mutation. Falls back to Contents API for empty repositories.
+// needsGitDataAPI reports whether any change requires the Git Data API
+// (i.e., has executable mode 100755, which createCommitOnBranch does not support).
+func needsGitDataAPI(changes []Change) bool {
+	for _, c := range changes {
+		if c.Executable {
+			return true
+		}
+	}
+	return false
+}
+
+// commitFunc is a function that commits changes to a branch using a specific strategy.
+type commitFunc func(ctx context.Context, repo, branch, headSHA, message string, changes []Change) error
+
+// applyToRepo creates a verified commit for all file changes. Uses the GitHub
+// GraphQL createCommitOnBranch mutation unless any file requires executable mode,
+// in which case the Git Data API is used. Falls back to Contents API for empty
+// repositories.
 // Returns (prURL, error); prURL is non-empty only for pull_request strategy.
 func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
 	headSHA, defaultBranch, err := p.getHeadSHA(ctx, repo)
@@ -22,12 +38,16 @@ func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Chan
 		}
 		return "", fmt.Errorf("get HEAD: %w", err)
 	}
-	return p.applyViaGraphQL(ctx, repo, defaultBranch, headSHA, changes, opts, statusFn)
+	commit := commitFunc(p.commitViaGraphQL)
+	if needsGitDataAPI(changes) {
+		commit = p.commitViaGitDataAPI
+	}
+	return p.applyViaCommitFunc(ctx, repo, defaultBranch, headSHA, changes, opts, statusFn, commit)
 }
 
-// applyViaGraphQL creates a verified commit using the GitHub GraphQL createCommitOnBranch
-// mutation. All file changes are committed atomically in a single call.
-func (p *Processor) applyViaGraphQL(ctx context.Context, repo, defaultBranch, headSHA string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
+// applyViaCommitFunc handles the shared orchestration for both commit strategies:
+// optional PR branch creation, committing, and optional PR opening.
+func (p *Processor) applyViaCommitFunc(ctx context.Context, repo, defaultBranch, headSHA string, changes []Change, opts ApplyOptions, statusFn func(string), commit commitFunc) (string, error) {
 	message := resolveCommitMessage(opts)
 	targetBranch := defaultBranch
 
@@ -44,7 +64,7 @@ func (p *Processor) applyViaGraphQL(ctx context.Context, repo, defaultBranch, he
 	}
 
 	statusFn("committing changes...")
-	if err := p.commitViaGraphQL(ctx, repo, targetBranch, headSHA, message, changes); err != nil {
+	if err := commit(ctx, repo, targetBranch, headSHA, message, changes); err != nil {
 		return "", err
 	}
 
@@ -53,6 +73,111 @@ func (p *Processor) applyViaGraphQL(ctx context.Context, repo, defaultBranch, he
 		return p.openPR(ctx, repo, defaultBranch, targetBranch, opts)
 	}
 	return "", nil
+}
+
+// commitViaGitDataAPI commits changes using three REST calls:
+// create tree → create commit → update ref.
+// This path is used when any file requires mode 100755 (executable), since
+// the createCommitOnBranch GraphQL mutation only supports mode 100644.
+func (p *Processor) commitViaGitDataAPI(ctx context.Context, repo, branch, headSHA, message string, changes []Change) error {
+	out, err := p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/commits/%s", repo, headSHA), "--jq", ".tree.sha")
+	if err != nil {
+		return fmt.Errorf("get tree SHA: %w", err)
+	}
+	treeSHA := strings.TrimSpace(string(out))
+
+	// Use map[string]any so that nil sha marshals as JSON null (not omitted),
+	// which is what the Trees API requires for deletion.
+	var entries []map[string]any
+	for _, c := range changes {
+		if c.Type == ChangeDelete {
+			// sha: null tells the Trees API to remove this path from the tree.
+			entries = append(entries, map[string]any{"path": c.Path, "sha": nil})
+		} else {
+			mode := "100644"
+			if c.Executable {
+				mode = "100755"
+			}
+			entries = append(entries, map[string]any{
+				"path":    c.Path,
+				"mode":    mode,
+				"type":    "blob",
+				"content": c.Desired,
+			})
+		}
+	}
+
+	treeBody, err := json.Marshal(map[string]any{
+		"base_tree": treeSHA,
+		"tree":      entries,
+	})
+	if err != nil {
+		return err
+	}
+	newTreeSHA, err := p.postJSON(ctx, fmt.Sprintf("repos/%s/git/trees", repo), treeBody, ".sha")
+	if err != nil {
+		return fmt.Errorf("create tree: %w", err)
+	}
+
+	commitBody, err := json.Marshal(map[string]any{
+		"message": message,
+		"tree":    newTreeSHA,
+		"parents": []string{headSHA},
+	})
+	if err != nil {
+		return err
+	}
+	newCommitSHA, err := p.postJSON(ctx, fmt.Sprintf("repos/%s/git/commits", repo), commitBody, ".sha")
+	if err != nil {
+		return fmt.Errorf("create commit: %w", err)
+	}
+
+	refBody, err := json.Marshal(map[string]any{
+		"sha": newCommitSHA,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = p.patchJSON(ctx, fmt.Sprintf("repos/%s/git/refs/heads/%s", repo, branch), refBody)
+	if err != nil {
+		return fmt.Errorf("update ref: %w", err)
+	}
+
+	return nil
+}
+
+func (p *Processor) postJSON(ctx context.Context, endpoint string, body []byte, jqFilter string) (string, error) {
+	tmpFile, err := os.CreateTemp("", "gh-infra-api-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.Write(body); err != nil {
+		tmpFile.Close()
+		return "", fmt.Errorf("write temp file: %w", err)
+	}
+	tmpFile.Close()
+
+	out, err := p.runner.Run(ctx, "api", endpoint, "--method", "POST", "--input", tmpFile.Name(), "--jq", jqFilter)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (p *Processor) patchJSON(ctx context.Context, endpoint string, body []byte) ([]byte, error) {
+	tmpFile, err := os.CreateTemp("", "gh-infra-api-*.json")
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.Write(body); err != nil {
+		tmpFile.Close()
+		return nil, fmt.Errorf("write temp file: %w", err)
+	}
+	tmpFile.Close()
+
+	return p.runner.Run(ctx, "api", endpoint, "--method", "PATCH", "--input", tmpFile.Name())
 }
 
 // commitViaGraphQL sends a createCommitOnBranch GraphQL mutation.

--- a/internal/fileset/gitapi_test.go
+++ b/internal/fileset/gitapi_test.go
@@ -1,0 +1,40 @@
+package fileset
+
+import "testing"
+
+func TestNeedsGitDataAPI_ReturnsFalse_WhenNoExecutable(t *testing.T) {
+	changes := []Change{
+		{Path: "a.txt", Type: ChangeCreate, Executable: false},
+		{Path: "b.txt", Type: ChangeUpdate, Executable: false},
+		{Path: "c.txt", Type: ChangeDelete, Executable: false},
+	}
+	if needsGitDataAPI(changes) {
+		t.Error("needsGitDataAPI = true, want false when no change has Executable set")
+	}
+}
+
+func TestNeedsGitDataAPI_ReturnsTrue_WhenAnyExecutable(t *testing.T) {
+	changes := []Change{
+		{Path: "a.txt", Type: ChangeCreate, Executable: false},
+		{Path: "bin/tool", Type: ChangeCreate, Executable: true},
+	}
+	if !needsGitDataAPI(changes) {
+		t.Error("needsGitDataAPI = false, want true when at least one change has Executable set")
+	}
+}
+
+func TestNeedsGitDataAPI_ReturnsTrue_WhenAllExecutable(t *testing.T) {
+	changes := []Change{
+		{Path: "bin/a", Type: ChangeCreate, Executable: true},
+		{Path: "bin/b", Type: ChangeCreate, Executable: true},
+	}
+	if !needsGitDataAPI(changes) {
+		t.Error("needsGitDataAPI = false, want true when all changes have Executable set")
+	}
+}
+
+func TestNeedsGitDataAPI_ReturnsFalse_WhenEmpty(t *testing.T) {
+	if needsGitDataAPI(nil) {
+		t.Error("needsGitDataAPI = true, want false for empty change list")
+	}
+}

--- a/internal/fileset/plan.go
+++ b/internal/fileset/plan.go
@@ -187,23 +187,29 @@ func (p *Processor) Plan(ctx context.Context, fileSets []*manifest.FileSet, filt
 	return changes, nil
 }
 
+func boolVal(b *bool) bool {
+	return b != nil && *b
+}
+
 // planCreateOnly handles reconcile: create_only — create if missing, NoOp if exists.
 func (p *Processor) planCreateOnly(ctx context.Context, fileSetName, repo string, file manifest.FileEntry) Change {
 	current, err := p.fetchFileContent(ctx, repo, file.Path)
 	if err != nil || !current.Exists {
 		return Change{
-			FileSetID: fileSetName,
-			Target:    repo,
-			Path:      file.Path,
-			Type:      ChangeCreate,
-			Desired:   file.Content,
+			FileSetID:  fileSetName,
+			Target:     repo,
+			Path:       file.Path,
+			Type:       ChangeCreate,
+			Desired:    file.Content,
+			Executable: boolVal(file.Executable),
 		}
 	}
 	return Change{
-		FileSetID: fileSetName,
-		Target:    repo,
-		Path:      file.Path,
-		Type:      ChangeNoOp,
+		FileSetID:  fileSetName,
+		Target:     repo,
+		Path:       file.Path,
+		Type:       ChangeNoOp,
+		Executable: boolVal(file.Executable),
 	}
 }
 
@@ -211,11 +217,12 @@ func (p *Processor) planFile(ctx context.Context, fileSetName, repo string, file
 	current, err := p.fetchFileContent(ctx, repo, file.Path)
 	if err != nil || !current.Exists {
 		return Change{
-			FileSetID: fileSetName,
-			Target:    repo,
-			Path:      file.Path,
-			Type:      ChangeCreate,
-			Desired:   file.Content,
+			FileSetID:  fileSetName,
+			Target:     repo,
+			Path:       file.Path,
+			Type:       ChangeCreate,
+			Desired:    file.Content,
+			Executable: boolVal(file.Executable),
 		}
 	}
 
@@ -225,22 +232,24 @@ func (p *Processor) planFile(ctx context.Context, fileSetName, repo string, file
 
 	if currentContent == desiredContent {
 		return Change{
-			FileSetID: fileSetName,
-			Target:    repo,
-			Path:      file.Path,
-			Type:      ChangeNoOp,
+			FileSetID:  fileSetName,
+			Target:     repo,
+			Path:       file.Path,
+			Type:       ChangeNoOp,
+			Executable: boolVal(file.Executable),
 		}
 	}
 
 	// Content differs — update
 	return Change{
-		FileSetID: fileSetName,
-		Target:    repo,
-		Path:      file.Path,
-		Type:      ChangeUpdate,
-		Current:   current.Content,
-		Desired:   file.Content,
-		SHA:       current.SHA,
+		FileSetID:  fileSetName,
+		Target:     repo,
+		Path:       file.Path,
+		Type:       ChangeUpdate,
+		Current:    current.Content,
+		Desired:    file.Content,
+		SHA:        current.SHA,
+		Executable: boolVal(file.Executable),
 	}
 }
 

--- a/internal/fileset/resolve.go
+++ b/internal/fileset/resolve.go
@@ -38,6 +38,9 @@ func ResolveFiles(fs *manifest.FileSet, target manifest.FileSetRepository) []man
 			if override.OriginalSource == "" {
 				override.OriginalSource = f.OriginalSource
 			}
+			if override.Executable == nil && f.Executable != nil {
+				override.Executable = f.Executable
+			}
 			result = append(result, override)
 		} else {
 			result = append(result, f)

--- a/internal/fileset/resolve_test.go
+++ b/internal/fileset/resolve_test.go
@@ -227,3 +227,64 @@ func TestResolveFiles_InheritsContentAndSource(t *testing.T) {
 		t.Errorf("Vars.Description = %q, want %q", v, "overwrite message")
 	}
 }
+
+func TestResolveFiles_InheritsExecutable(t *testing.T) {
+	execTrue := true
+	fs := &manifest.FileSet{
+		Spec: manifest.FileSetSpec{
+			Files: []manifest.FileEntry{
+				{Path: "bin/tool", Content: "#!/bin/sh\necho hello", Executable: &execTrue},
+			},
+		},
+	}
+	target := manifest.FileSetRepository{
+		Name: "repo",
+		Overrides: []manifest.FileEntry{
+			// Content override but Executable is nil — should inherit from base.
+			{Path: "bin/tool", Content: "#!/bin/sh\necho world"},
+		},
+	}
+
+	result := ResolveFiles(fs, target)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(result))
+	}
+	if result[0].Executable == nil {
+		t.Fatal("Executable should be inherited (non-nil), got nil")
+	}
+	if !*result[0].Executable {
+		t.Errorf("Executable = false, want true (inherited from base)")
+	}
+}
+
+func TestResolveFiles_ExecutableNotInherited_WhenOverrideExplicitlySetsIt(t *testing.T) {
+	execTrue := true
+	execFalse := false
+	fs := &manifest.FileSet{
+		Spec: manifest.FileSetSpec{
+			Files: []manifest.FileEntry{
+				{Path: "bin/tool", Content: "#!/bin/sh\necho hello", Executable: &execTrue},
+			},
+		},
+	}
+	target := manifest.FileSetRepository{
+		Name: "repo",
+		Overrides: []manifest.FileEntry{
+			// Override explicitly sets Executable: false — must NOT be overwritten.
+			{Path: "bin/tool", Content: "#!/bin/sh\necho world", Executable: &execFalse},
+		},
+	}
+
+	result := ResolveFiles(fs, target)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(result))
+	}
+	if result[0].Executable == nil {
+		t.Fatal("Executable should be non-nil")
+	}
+	if *result[0].Executable {
+		t.Errorf("Executable = true, want false (override should take precedence)")
+	}
+}

--- a/internal/fileset/types.go
+++ b/internal/fileset/types.go
@@ -10,14 +10,15 @@ type State struct {
 
 // Change represents a planned change for a file.
 type Change struct {
-	FileSetID string // org/owner that owns this FileSet
-	Target    string // owner/repo
-	Path      string
-	Type      ChangeType
-	Current   string // current content (if exists)
-	Desired   string // desired content
-	SHA       string // current SHA (for updates)
-	Via       string // "push" or "pull_request" (from FileSet spec)
+	FileSetID  string // org/owner that owns this FileSet
+	Target     string // owner/repo
+	Path       string
+	Type       ChangeType
+	Current    string // current content (if exists)
+	Desired    string // desired content
+	SHA        string // current SHA (for updates)
+	Executable bool
+	Via        string // "push" or "pull_request" (from FileSet spec)
 }
 
 type ChangeType string

--- a/internal/manifest/file_types.go
+++ b/internal/manifest/file_types.go
@@ -93,6 +93,7 @@ type FileEntry struct {
 	Patches        []string          `yaml:"patches,omitempty"`
 	Vars           map[string]string `yaml:"vars,omitempty"`
 	Reconcile      string            `yaml:"reconcile,omitempty" validate:"omitempty,oneof=additive authoritative create_only"`
+	Executable     *bool             `yaml:"executable,omitempty"`
 	DirScope       string            `yaml:"-"`
 	OriginalSource string            `yaml:"-"` // local file path set during source resolution (import --into)
 

--- a/internal/manifest/fileset_test.go
+++ b/internal/manifest/fileset_test.go
@@ -64,3 +64,35 @@ overrides:
 		t.Errorf("override content = %q, want %q", target.Overrides[0].Content, "custom content")
 	}
 }
+
+func TestFileEntry_UnmarshalYAML_ExecutableTrue(t *testing.T) {
+	input := `
+path: bin/tool
+content: "#!/bin/sh\necho hello"
+executable: true
+`
+	var entry FileEntry
+	if err := yaml.Unmarshal([]byte(input), &entry); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.Executable == nil {
+		t.Fatal("Executable should be non-nil when set to true in YAML")
+	}
+	if !*entry.Executable {
+		t.Errorf("Executable = false, want true")
+	}
+}
+
+func TestFileEntry_UnmarshalYAML_ExecutableOmitted(t *testing.T) {
+	input := `
+path: some/file.txt
+content: "hello"
+`
+	var entry FileEntry
+	if err := yaml.Unmarshal([]byte(input), &entry); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.Executable != nil {
+		t.Errorf("Executable should be nil when omitted from YAML, got %v", *entry.Executable)
+	}
+}


### PR DESCRIPTION
## Summary

The `createCommitOnBranch` GraphQL mutation creates all files as mode `100644` (non-executable). This makes it impossible to distribute shell scripts and git hooks via FileSet, since those require mode `100755` to be invoked by the OS.

This PR adds an `executable: true` option to the FileSet `files` spec. When any file in a batch has `executable: true`, gh-infra uses the Git Data API (create tree → create commit → update ref) instead of the GraphQL mutation, which supports arbitrary file modes via the tree entry `mode` field.

Related: #169 (stacked — adds a noop guard to `commitViaGitDataAPI`)

## Usage

```yaml
kind: FileSet
spec:
  files:
    - path: .hooks/pre-commit
      source: ./templates/pre-commit-hook
      executable: true   # committed as mode 100755
    - path: Justfile
      source: ./templates/Justfile
      # no executable: defaults to 100644
```

## Implementation

- `manifest.FileEntry` gets a new `executable` YAML field (`*bool` — nil means "not set", inherits from base entry in override resolution)
- `fileset.Change` carries `Executable bool` from plan time through to apply
- `applyToRepo` routes through `applyViaGitDataAPI` when any change in the batch has `Executable: true`; otherwise the existing `applyViaGraphQL` path is used unchanged
- `commitViaGitDataAPI` builds a tree with per-entry `mode` fields (`100755` / `100644`), creates a commit, and advances the branch ref
- Deletions in the Data API path use `"sha": null` in the tree entry, which signals file removal to GitHub's Trees API
- Mode drift detection (detecting when an existing file's mode is wrong) is not in scope for this PR — the mode is set on create/update and the GraphQL path is unaffected for non-executable files