### PR TITLE
fix: skip noop commits, enforce paired merge strategy fields, and validate combos

### DIFF
--- a/internal/fileset/fileset_test.go
+++ b/internal/fileset/fileset_test.go
@@ -330,6 +330,88 @@ func TestApply_NoOpNotApplied(t *testing.T) {
 	}
 }
 
+// setupGitDataAPIMock creates a WildcardMockRunner for the Git Data API commit path.
+// newTreeSHA controls what POST /git/trees returns; set it equal to the base tree SHA
+// to simulate the noop case (GitHub normalized content to what was already stored).
+func setupGitDataAPIMock(repo, newTreeSHA string) *WildcardMockRunner {
+	const baseTreeSHA = "tree-sha-aaa"
+	return &WildcardMockRunner{
+		MockRunner: gh.MockRunner{
+			Responses: map[string][]byte{
+				fmt.Sprintf("repo view %s --json defaultBranchRef --jq .defaultBranchRef.name", repo): []byte("main"),
+				fmt.Sprintf("api repos/%s/git/ref/heads/main --jq .object.sha", repo):                 []byte("head123"),
+				fmt.Sprintf("api repos/%s/git/commits/head123 --jq .tree.sha", repo):                  []byte(baseTreeSHA),
+			},
+			Errors: map[string]error{},
+		},
+		DefaultResponse: []byte(newTreeSHA),
+	}
+}
+
+func TestApply_GitDataAPI_SkipsCommitWhenTreeUnchanged(t *testing.T) {
+	// newTreeSHA == baseTreeSHA: GitHub normalized content to what was already stored.
+	mock := setupGitDataAPIMock("owner/repo", "tree-sha-aaa")
+	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
+
+	changes := []Change{
+		{
+			FileSetID:  "ci-files",
+			Target:     "owner/repo",
+			Path:       "bin/tool",
+			Type:       ChangeCreate,
+			Desired:    "#!/bin/sh\necho hello",
+			Executable: true,
+		},
+	}
+
+	results := p.Apply(context.Background(), changes, ApplyOptions{FileSetID: "test"}, ui.NoopReporter{})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Errorf("unexpected error: %v", results[0].Err)
+	}
+
+	// The noop guard should have fired: no ref update means no commit was created.
+	callLog := strings.Join(flattenCalls(mock.Called), " | ")
+	if strings.Contains(callLog, "git/refs") {
+		t.Errorf("expected no ref update (noop), but git/refs was called: %s", callLog)
+	}
+}
+
+func TestApply_GitDataAPI_CommitsWhenTreeChanged(t *testing.T) {
+	// newTreeSHA != baseTreeSHA: content genuinely changed, commit should proceed.
+	mock := setupGitDataAPIMock("owner/repo", "tree-sha-bbb")
+	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
+
+	changes := []Change{
+		{
+			FileSetID:  "ci-files",
+			Target:     "owner/repo",
+			Path:       "bin/tool",
+			Type:       ChangeCreate,
+			Desired:    "#!/bin/sh\necho hello",
+			Executable: true,
+		},
+	}
+
+	results := p.Apply(context.Background(), changes, ApplyOptions{FileSetID: "test"}, ui.NoopReporter{})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Errorf("unexpected error: %v", results[0].Err)
+	}
+
+	// The guard should NOT have fired: ref update confirms the commit was created.
+	callLog := strings.Join(flattenCalls(mock.Called), " | ")
+	if !strings.Contains(callLog, "git/refs") {
+		t.Errorf("expected ref update after commit, but git/refs was not called: %s", callLog)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // HasChanges tests
 // ---------------------------------------------------------------------------

--- a/internal/fileset/fileset_test.go
+++ b/internal/fileset/fileset_test.go
@@ -208,10 +208,13 @@ func TestPlan_MultipleFilesDiffer(t *testing.T) {
 // Apply tests
 // ---------------------------------------------------------------------------
 
-// WildcardMockRunner extends MockRunner to return a default response for unmatched keys.
+// WildcardMockRunner extends MockRunner to return responses for unmatched keys.
+// Resolution order: Responses (exact key) → ContainsResponses (substring) → DefaultResponse.
 type WildcardMockRunner struct {
 	gh.MockRunner
-	DefaultResponse []byte
+	// ContainsResponses maps a substring to a response; first match wins.
+	ContainsResponses map[string][]byte
+	DefaultResponse   []byte
 }
 
 func (m *WildcardMockRunner) Run(_ context.Context, args ...string) ([]byte, error) {
@@ -223,26 +226,39 @@ func (m *WildcardMockRunner) Run(_ context.Context, args ...string) ([]byte, err
 	if resp, ok := m.Responses[key]; ok {
 		return resp, nil
 	}
-	// Return default response for unmatched calls (Git Data API calls with dynamic args)
+	for substr, resp := range m.ContainsResponses {
+		if strings.Contains(key, substr) {
+			return resp, nil
+		}
+	}
 	return m.DefaultResponse, nil
 }
 
 // setupGraphQLMock creates a WildcardMockRunner for the GraphQL-based commit path.
+// The noop check (isContentNoop) creates a proposed tree and compares SHAs;
+// the mock returns a different new tree SHA so the noop guard does NOT fire and
+// the GraphQL mutation is reached.
 func setupGraphQLMock(repo string) *WildcardMockRunner {
-	mock := &WildcardMockRunner{
+	const baseTreeSHA = "tree-sha-aaa"
+	return &WildcardMockRunner{
 		MockRunner: gh.MockRunner{
 			Responses: map[string][]byte{
 				// Get default branch
 				fmt.Sprintf("repo view %s --json defaultBranchRef --jq .defaultBranchRef.name", repo): []byte("main"),
 				// Get HEAD SHA
 				fmt.Sprintf("api repos/%s/git/ref/heads/main --jq .object.sha", repo): []byte("head123"),
+				// isContentNoop: fetch current tree SHA
+				fmt.Sprintf("api repos/%s/git/commits/head123 --jq .tree.sha", repo): []byte(baseTreeSHA),
 			},
 			Errors: map[string]error{},
 		},
-		// Default response for GraphQL mutation and other dynamic calls
+		// isContentNoop tree creation returns a different SHA → noop guard does not fire.
+		ContainsResponses: map[string][]byte{
+			"git/trees": []byte("tree-sha-bbb"),
+		},
+		// Default response for the GraphQL mutation (and any other unmatched dynamic calls).
 		DefaultResponse: []byte(`{"data":{"createCommitOnBranch":{"commit":{"oid":"new-sha-456"}}}}`),
 	}
-	return mock
 }
 
 func TestApply_CreateFile(t *testing.T) {
@@ -345,6 +361,87 @@ func setupGitDataAPIMock(repo, newTreeSHA string) *WildcardMockRunner {
 			Errors: map[string]error{},
 		},
 		DefaultResponse: []byte(newTreeSHA),
+	}
+}
+
+// setupGraphQLNoopMock creates a WildcardMockRunner for the GraphQL path where
+// isContentNoop returns true (proposed tree SHA == current tree SHA).
+func setupGraphQLNoopMock(repo string) *WildcardMockRunner {
+	const baseTreeSHA = "tree-sha-aaa"
+	return &WildcardMockRunner{
+		MockRunner: gh.MockRunner{
+			Responses: map[string][]byte{
+				fmt.Sprintf("repo view %s --json defaultBranchRef --jq .defaultBranchRef.name", repo): []byte("main"),
+				fmt.Sprintf("api repos/%s/git/ref/heads/main --jq .object.sha", repo):                 []byte("head123"),
+				fmt.Sprintf("api repos/%s/git/commits/head123 --jq .tree.sha", repo):                  []byte(baseTreeSHA),
+			},
+			Errors: map[string]error{},
+		},
+		// Same SHA as baseTreeSHA → noop guard fires.
+		ContainsResponses: map[string][]byte{
+			"git/trees": []byte(baseTreeSHA),
+		},
+		DefaultResponse: []byte(`{"data":{"createCommitOnBranch":{"commit":{"oid":"new-sha-456"}}}}`),
+	}
+}
+
+func TestApply_GraphQL_SkipsCommitWhenTreeUnchanged(t *testing.T) {
+	mock := setupGraphQLNoopMock("owner/repo")
+	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
+
+	changes := []Change{
+		{
+			FileSetID: "ci-files",
+			Target:    "owner/repo",
+			Path:      ".github/ci.yml",
+			Type:      ChangeCreate,
+			Desired:   "name: CI",
+		},
+	}
+
+	results := p.Apply(context.Background(), changes, ApplyOptions{FileSetID: "test"}, ui.NoopReporter{})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Errorf("unexpected error: %v", results[0].Err)
+	}
+
+	// Noop guard fired: GraphQL mutation must not have been called.
+	callLog := strings.Join(flattenCalls(mock.Called), " | ")
+	if strings.Contains(callLog, "api graphql") {
+		t.Errorf("expected no GraphQL mutation (noop), but it was called: %s", callLog)
+	}
+}
+
+func TestApply_GraphQL_CommitsWhenTreeChanged(t *testing.T) {
+	mock := setupGraphQLMock("owner/repo")
+	p := NewProcessor(mock, ui.NewStandardPrinterWith(&bytes.Buffer{}, &bytes.Buffer{}))
+
+	changes := []Change{
+		{
+			FileSetID: "ci-files",
+			Target:    "owner/repo",
+			Path:      ".github/ci.yml",
+			Type:      ChangeCreate,
+			Desired:   "name: CI",
+		},
+	}
+
+	results := p.Apply(context.Background(), changes, ApplyOptions{FileSetID: "test"}, ui.NoopReporter{})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Errorf("unexpected error: %v", results[0].Err)
+	}
+
+	// Noop guard did not fire: GraphQL mutation must have been called.
+	callLog := strings.Join(flattenCalls(mock.Called), " | ")
+	if !strings.Contains(callLog, "api graphql") {
+		t.Errorf("expected GraphQL mutation call, got: %s", callLog)
 	}
 }
 

--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -11,8 +11,24 @@ import (
 	"github.com/babarot/gh-infra/internal/manifest"
 )
 
-// applyToRepo creates a verified commit for all file changes using the GitHub GraphQL
-// createCommitOnBranch mutation. Falls back to Contents API for empty repositories.
+// needsGitDataAPI reports whether any change requires the Git Data API
+// (i.e., has executable mode 100755, which createCommitOnBranch does not support).
+func needsGitDataAPI(changes []Change) bool {
+	for _, c := range changes {
+		if c.Executable {
+			return true
+		}
+	}
+	return false
+}
+
+// commitFunc is a function that commits changes to a branch using a specific strategy.
+type commitFunc func(ctx context.Context, repo, branch, headSHA, message string, changes []Change) error
+
+// applyToRepo creates a verified commit for all file changes. Uses the GitHub
+// GraphQL createCommitOnBranch mutation unless any file requires executable mode,
+// in which case the Git Data API is used. Falls back to Contents API for empty
+// repositories.
 // Returns (prURL, error); prURL is non-empty only for pull_request strategy.
 func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
 	headSHA, defaultBranch, err := p.getHeadSHA(ctx, repo)
@@ -22,12 +38,16 @@ func (p *Processor) applyToRepo(ctx context.Context, repo string, changes []Chan
 		}
 		return "", fmt.Errorf("get HEAD: %w", err)
 	}
-	return p.applyViaGraphQL(ctx, repo, defaultBranch, headSHA, changes, opts, statusFn)
+	commit := commitFunc(p.commitViaGraphQL)
+	if needsGitDataAPI(changes) {
+		commit = p.commitViaGitDataAPI
+	}
+	return p.applyViaCommitFunc(ctx, repo, defaultBranch, headSHA, changes, opts, statusFn, commit)
 }
 
-// applyViaGraphQL creates a verified commit using the GitHub GraphQL createCommitOnBranch
-// mutation. All file changes are committed atomically in a single call.
-func (p *Processor) applyViaGraphQL(ctx context.Context, repo, defaultBranch, headSHA string, changes []Change, opts ApplyOptions, statusFn func(string)) (string, error) {
+// applyViaCommitFunc handles the shared orchestration for both commit strategies:
+// optional PR branch creation, committing, and optional PR opening.
+func (p *Processor) applyViaCommitFunc(ctx context.Context, repo, defaultBranch, headSHA string, changes []Change, opts ApplyOptions, statusFn func(string), commit commitFunc) (string, error) {
 	message := resolveCommitMessage(opts)
 	targetBranch := defaultBranch
 
@@ -44,7 +64,7 @@ func (p *Processor) applyViaGraphQL(ctx context.Context, repo, defaultBranch, he
 	}
 
 	statusFn("committing changes...")
-	if err := p.commitViaGraphQL(ctx, repo, targetBranch, headSHA, message, changes); err != nil {
+	if err := commit(ctx, repo, targetBranch, headSHA, message, changes); err != nil {
 		return "", err
 	}
 
@@ -53,6 +73,111 @@ func (p *Processor) applyViaGraphQL(ctx context.Context, repo, defaultBranch, he
 		return p.openPR(ctx, repo, defaultBranch, targetBranch, opts)
 	}
 	return "", nil
+}
+
+// commitViaGitDataAPI commits changes using three REST calls:
+// create tree → create commit → update ref.
+// This path is used when any file requires mode 100755 (executable), since
+// the createCommitOnBranch GraphQL mutation only supports mode 100644.
+func (p *Processor) commitViaGitDataAPI(ctx context.Context, repo, branch, headSHA, message string, changes []Change) error {
+	out, err := p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/commits/%s", repo, headSHA), "--jq", ".tree.sha")
+	if err != nil {
+		return fmt.Errorf("get tree SHA: %w", err)
+	}
+	treeSHA := strings.TrimSpace(string(out))
+
+	// Use map[string]any so that nil sha marshals as JSON null (not omitted),
+	// which is what the Trees API requires for deletion.
+	var entries []map[string]any
+	for _, c := range changes {
+		if c.Type == ChangeDelete {
+			// sha: null tells the Trees API to remove this path from the tree.
+			entries = append(entries, map[string]any{"path": c.Path, "sha": nil})
+		} else {
+			mode := "100644"
+			if c.Executable {
+				mode = "100755"
+			}
+			entries = append(entries, map[string]any{
+				"path":    c.Path,
+				"mode":    mode,
+				"type":    "blob",
+				"content": c.Desired,
+			})
+		}
+	}
+
+	treeBody, err := json.Marshal(map[string]any{
+		"base_tree": treeSHA,
+		"tree":      entries,
+	})
+	if err != nil {
+		return err
+	}
+	newTreeSHA, err := p.postJSON(ctx, fmt.Sprintf("repos/%s/git/trees", repo), treeBody, ".sha")
+	if err != nil {
+		return fmt.Errorf("create tree: %w", err)
+	}
+
+	commitBody, err := json.Marshal(map[string]any{
+		"message": message,
+		"tree":    newTreeSHA,
+		"parents": []string{headSHA},
+	})
+	if err != nil {
+		return err
+	}
+	newCommitSHA, err := p.postJSON(ctx, fmt.Sprintf("repos/%s/git/commits", repo), commitBody, ".sha")
+	if err != nil {
+		return fmt.Errorf("create commit: %w", err)
+	}
+
+	refBody, err := json.Marshal(map[string]any{
+		"sha": newCommitSHA,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = p.patchJSON(ctx, fmt.Sprintf("repos/%s/git/refs/heads/%s", repo, branch), refBody)
+	if err != nil {
+		return fmt.Errorf("update ref: %w", err)
+	}
+
+	return nil
+}
+
+func (p *Processor) postJSON(ctx context.Context, endpoint string, body []byte, jqFilter string) (string, error) {
+	tmpFile, err := os.CreateTemp("", "gh-infra-api-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.Write(body); err != nil {
+		tmpFile.Close()
+		return "", fmt.Errorf("write temp file: %w", err)
+	}
+	tmpFile.Close()
+
+	out, err := p.runner.Run(ctx, "api", endpoint, "--method", "POST", "--input", tmpFile.Name(), "--jq", jqFilter)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (p *Processor) patchJSON(ctx context.Context, endpoint string, body []byte) ([]byte, error) {
+	tmpFile, err := os.CreateTemp("", "gh-infra-api-*.json")
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.Write(body); err != nil {
+		tmpFile.Close()
+		return nil, fmt.Errorf("write temp file: %w", err)
+	}
+	tmpFile.Close()
+
+	return p.runner.Run(ctx, "api", endpoint, "--method", "PATCH", "--input", tmpFile.Name())
 }
 
 // commitViaGraphQL sends a createCommitOnBranch GraphQL mutation.

--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -63,6 +63,15 @@ func (p *Processor) applyViaCommitFunc(ctx context.Context, repo, defaultBranch,
 		targetBranch = prBranch
 	}
 
+	noop, err := p.isContentNoop(ctx, repo, headSHA, changes)
+	if err != nil {
+		return "", fmt.Errorf("noop check: %w", err)
+	}
+	if noop {
+		statusFn("no content change after GitHub normalization — skipping commit")
+		return "", nil
+	}
+
 	statusFn("committing changes...")
 	if err := commit(ctx, repo, targetBranch, headSHA, message, changes); err != nil {
 		return "", err
@@ -73,6 +82,48 @@ func (p *Processor) applyViaCommitFunc(ctx context.Context, repo, defaultBranch,
 		return p.openPR(ctx, repo, defaultBranch, targetBranch, opts)
 	}
 	return "", nil
+}
+
+// isContentNoop reports whether the proposed changes produce an identical tree to
+// the current HEAD. This guards both commit paths against empty commits that arise
+// when GitHub normalizes file content (e.g. trailing whitespace) on ingest.
+func (p *Processor) isContentNoop(ctx context.Context, repo, headSHA string, changes []Change) (bool, error) {
+	out, err := p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s/git/commits/%s", repo, headSHA), "--jq", ".tree.sha")
+	if err != nil {
+		return false, fmt.Errorf("get tree SHA: %w", err)
+	}
+	treeSHA := strings.TrimSpace(string(out))
+
+	var entries []map[string]any
+	for _, c := range changes {
+		if c.Type == ChangeDelete {
+			entries = append(entries, map[string]any{"path": c.Path, "sha": nil})
+		} else {
+			mode := "100644"
+			if c.Executable {
+				mode = "100755"
+			}
+			entries = append(entries, map[string]any{
+				"path":    c.Path,
+				"mode":    mode,
+				"type":    "blob",
+				"content": c.Desired,
+			})
+		}
+	}
+
+	treeBody, err := json.Marshal(map[string]any{
+		"base_tree": treeSHA,
+		"tree":      entries,
+	})
+	if err != nil {
+		return false, err
+	}
+	newTreeSHA, err := p.postJSON(ctx, fmt.Sprintf("repos/%s/git/trees", repo), treeBody, ".sha")
+	if err != nil {
+		return false, fmt.Errorf("create tree: %w", err)
+	}
+	return newTreeSHA == treeSHA, nil
 }
 
 // commitViaGitDataAPI commits changes using three REST calls:
@@ -117,10 +168,6 @@ func (p *Processor) commitViaGitDataAPI(ctx context.Context, repo, branch, headS
 	newTreeSHA, err := p.postJSON(ctx, fmt.Sprintf("repos/%s/git/trees", repo), treeBody, ".sha")
 	if err != nil {
 		return fmt.Errorf("create tree: %w", err)
-	}
-	if newTreeSHA == treeSHA {
-		// GitHub normalized the content to what was already stored — skip the commit.
-		return nil
 	}
 
 	commitBody, err := json.Marshal(map[string]any{

--- a/internal/fileset/gitapi.go
+++ b/internal/fileset/gitapi.go
@@ -118,6 +118,10 @@ func (p *Processor) commitViaGitDataAPI(ctx context.Context, repo, branch, headS
 	if err != nil {
 		return fmt.Errorf("create tree: %w", err)
 	}
+	if newTreeSHA == treeSHA {
+		// GitHub normalized the content to what was already stored — skip the commit.
+		return nil
+	}
 
 	commitBody, err := json.Marshal(map[string]any{
 		"message": message,

--- a/internal/fileset/gitapi_test.go
+++ b/internal/fileset/gitapi_test.go
@@ -1,0 +1,40 @@
+package fileset
+
+import "testing"
+
+func TestNeedsGitDataAPI_ReturnsFalse_WhenNoExecutable(t *testing.T) {
+	changes := []Change{
+		{Path: "a.txt", Type: ChangeCreate, Executable: false},
+		{Path: "b.txt", Type: ChangeUpdate, Executable: false},
+		{Path: "c.txt", Type: ChangeDelete, Executable: false},
+	}
+	if needsGitDataAPI(changes) {
+		t.Error("needsGitDataAPI = true, want false when no change has Executable set")
+	}
+}
+
+func TestNeedsGitDataAPI_ReturnsTrue_WhenAnyExecutable(t *testing.T) {
+	changes := []Change{
+		{Path: "a.txt", Type: ChangeCreate, Executable: false},
+		{Path: "bin/tool", Type: ChangeCreate, Executable: true},
+	}
+	if !needsGitDataAPI(changes) {
+		t.Error("needsGitDataAPI = false, want true when at least one change has Executable set")
+	}
+}
+
+func TestNeedsGitDataAPI_ReturnsTrue_WhenAllExecutable(t *testing.T) {
+	changes := []Change{
+		{Path: "bin/a", Type: ChangeCreate, Executable: true},
+		{Path: "bin/b", Type: ChangeCreate, Executable: true},
+	}
+	if !needsGitDataAPI(changes) {
+		t.Error("needsGitDataAPI = false, want true when all changes have Executable set")
+	}
+}
+
+func TestNeedsGitDataAPI_ReturnsFalse_WhenEmpty(t *testing.T) {
+	if needsGitDataAPI(nil) {
+		t.Error("needsGitDataAPI = true, want false for empty change list")
+	}
+}

--- a/internal/fileset/plan.go
+++ b/internal/fileset/plan.go
@@ -187,23 +187,29 @@ func (p *Processor) Plan(ctx context.Context, fileSets []*manifest.FileSet, filt
 	return changes, nil
 }
 
+func boolVal(b *bool) bool {
+	return b != nil && *b
+}
+
 // planCreateOnly handles reconcile: create_only — create if missing, NoOp if exists.
 func (p *Processor) planCreateOnly(ctx context.Context, fileSetName, repo string, file manifest.FileEntry) Change {
 	current, err := p.fetchFileContent(ctx, repo, file.Path)
 	if err != nil || !current.Exists {
 		return Change{
-			FileSetID: fileSetName,
-			Target:    repo,
-			Path:      file.Path,
-			Type:      ChangeCreate,
-			Desired:   file.Content,
+			FileSetID:  fileSetName,
+			Target:     repo,
+			Path:       file.Path,
+			Type:       ChangeCreate,
+			Desired:    file.Content,
+			Executable: boolVal(file.Executable),
 		}
 	}
 	return Change{
-		FileSetID: fileSetName,
-		Target:    repo,
-		Path:      file.Path,
-		Type:      ChangeNoOp,
+		FileSetID:  fileSetName,
+		Target:     repo,
+		Path:       file.Path,
+		Type:       ChangeNoOp,
+		Executable: boolVal(file.Executable),
 	}
 }
 
@@ -211,11 +217,12 @@ func (p *Processor) planFile(ctx context.Context, fileSetName, repo string, file
 	current, err := p.fetchFileContent(ctx, repo, file.Path)
 	if err != nil || !current.Exists {
 		return Change{
-			FileSetID: fileSetName,
-			Target:    repo,
-			Path:      file.Path,
-			Type:      ChangeCreate,
-			Desired:   file.Content,
+			FileSetID:  fileSetName,
+			Target:     repo,
+			Path:       file.Path,
+			Type:       ChangeCreate,
+			Desired:    file.Content,
+			Executable: boolVal(file.Executable),
 		}
 	}
 
@@ -225,22 +232,24 @@ func (p *Processor) planFile(ctx context.Context, fileSetName, repo string, file
 
 	if currentContent == desiredContent {
 		return Change{
-			FileSetID: fileSetName,
-			Target:    repo,
-			Path:      file.Path,
-			Type:      ChangeNoOp,
+			FileSetID:  fileSetName,
+			Target:     repo,
+			Path:       file.Path,
+			Type:       ChangeNoOp,
+			Executable: boolVal(file.Executable),
 		}
 	}
 
 	// Content differs — update
 	return Change{
-		FileSetID: fileSetName,
-		Target:    repo,
-		Path:      file.Path,
-		Type:      ChangeUpdate,
-		Current:   current.Content,
-		Desired:   file.Content,
-		SHA:       current.SHA,
+		FileSetID:  fileSetName,
+		Target:     repo,
+		Path:       file.Path,
+		Type:       ChangeUpdate,
+		Current:    current.Content,
+		Desired:    file.Content,
+		SHA:        current.SHA,
+		Executable: boolVal(file.Executable),
 	}
 }
 

--- a/internal/fileset/resolve.go
+++ b/internal/fileset/resolve.go
@@ -38,6 +38,9 @@ func ResolveFiles(fs *manifest.FileSet, target manifest.FileSetRepository) []man
 			if override.OriginalSource == "" {
 				override.OriginalSource = f.OriginalSource
 			}
+			if override.Executable == nil && f.Executable != nil {
+				override.Executable = f.Executable
+			}
 			result = append(result, override)
 		} else {
 			result = append(result, f)

--- a/internal/fileset/resolve_test.go
+++ b/internal/fileset/resolve_test.go
@@ -227,3 +227,64 @@ func TestResolveFiles_InheritsContentAndSource(t *testing.T) {
 		t.Errorf("Vars.Description = %q, want %q", v, "overwrite message")
 	}
 }
+
+func TestResolveFiles_InheritsExecutable(t *testing.T) {
+	execTrue := true
+	fs := &manifest.FileSet{
+		Spec: manifest.FileSetSpec{
+			Files: []manifest.FileEntry{
+				{Path: "bin/tool", Content: "#!/bin/sh\necho hello", Executable: &execTrue},
+			},
+		},
+	}
+	target := manifest.FileSetRepository{
+		Name: "repo",
+		Overrides: []manifest.FileEntry{
+			// Content override but Executable is nil — should inherit from base.
+			{Path: "bin/tool", Content: "#!/bin/sh\necho world"},
+		},
+	}
+
+	result := ResolveFiles(fs, target)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(result))
+	}
+	if result[0].Executable == nil {
+		t.Fatal("Executable should be inherited (non-nil), got nil")
+	}
+	if !*result[0].Executable {
+		t.Errorf("Executable = false, want true (inherited from base)")
+	}
+}
+
+func TestResolveFiles_ExecutableNotInherited_WhenOverrideExplicitlySetsIt(t *testing.T) {
+	execTrue := true
+	execFalse := false
+	fs := &manifest.FileSet{
+		Spec: manifest.FileSetSpec{
+			Files: []manifest.FileEntry{
+				{Path: "bin/tool", Content: "#!/bin/sh\necho hello", Executable: &execTrue},
+			},
+		},
+	}
+	target := manifest.FileSetRepository{
+		Name: "repo",
+		Overrides: []manifest.FileEntry{
+			// Override explicitly sets Executable: false — must NOT be overwritten.
+			{Path: "bin/tool", Content: "#!/bin/sh\necho world", Executable: &execFalse},
+		},
+	}
+
+	result := ResolveFiles(fs, target)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(result))
+	}
+	if result[0].Executable == nil {
+		t.Fatal("Executable should be non-nil")
+	}
+	if *result[0].Executable {
+		t.Errorf("Executable = true, want false (override should take precedence)")
+	}
+}

--- a/internal/fileset/types.go
+++ b/internal/fileset/types.go
@@ -10,14 +10,15 @@ type State struct {
 
 // Change represents a planned change for a file.
 type Change struct {
-	FileSetID string // org/owner that owns this FileSet
-	Target    string // owner/repo
-	Path      string
-	Type      ChangeType
-	Current   string // current content (if exists)
-	Desired   string // desired content
-	SHA       string // current SHA (for updates)
-	Via       string // "push" or "pull_request" (from FileSet spec)
+	FileSetID  string // org/owner that owns this FileSet
+	Target     string // owner/repo
+	Path       string
+	Type       ChangeType
+	Current    string // current content (if exists)
+	Desired    string // desired content
+	SHA        string // current SHA (for updates)
+	Executable bool
+	Via        string // "push" or "pull_request" (from FileSet spec)
 }
 
 type ChangeType string

--- a/internal/manifest/file_types.go
+++ b/internal/manifest/file_types.go
@@ -93,6 +93,7 @@ type FileEntry struct {
 	Patches        []string          `yaml:"patches,omitempty"`
 	Vars           map[string]string `yaml:"vars,omitempty"`
 	Reconcile      string            `yaml:"reconcile,omitempty" validate:"omitempty,oneof=additive authoritative create_only"`
+	Executable     *bool             `yaml:"executable,omitempty"`
 	DirScope       string            `yaml:"-"`
 	OriginalSource string            `yaml:"-"` // local file path set during source resolution (import --into)
 

--- a/internal/manifest/fileset_test.go
+++ b/internal/manifest/fileset_test.go
@@ -64,3 +64,35 @@ overrides:
 		t.Errorf("override content = %q, want %q", target.Overrides[0].Content, "custom content")
 	}
 }
+
+func TestFileEntry_UnmarshalYAML_ExecutableTrue(t *testing.T) {
+	input := `
+path: bin/tool
+content: "#!/bin/sh\necho hello"
+executable: true
+`
+	var entry FileEntry
+	if err := yaml.Unmarshal([]byte(input), &entry); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.Executable == nil {
+		t.Fatal("Executable should be non-nil when set to true in YAML")
+	}
+	if !*entry.Executable {
+		t.Errorf("Executable = false, want true")
+	}
+}
+
+func TestFileEntry_UnmarshalYAML_ExecutableOmitted(t *testing.T) {
+	input := `
+path: some/file.txt
+content: "hello"
+`
+	var entry FileEntry
+	if err := yaml.Unmarshal([]byte(input), &entry); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry.Executable != nil {
+		t.Errorf("Executable should be nil when omitted from YAML, got %v", *entry.Executable)
+	}
+}

--- a/internal/repository/apply.go
+++ b/internal/repository/apply.go
@@ -370,6 +370,11 @@ func (p *Processor) applyRepoPatch(ctx context.Context, fullName string, repo *m
 // applyMergeStrategyBatch batches merge strategy children into a single repos
 // PATCH call. Used during updates when multiple merge strategy fields change
 // together.
+//
+// GitHub requires squash_merge_commit_title and squash_merge_commit_message to
+// be sent together, and merge_commit_title and merge_commit_message to be sent
+// together. If only one half of a coupled pair appears in the diff, fetch the
+// current value of the companion from GitHub so both are always present.
 func (p *Processor) applyMergeStrategyBatch(ctx context.Context, c Change) ApplyResult {
 	fullName := c.Name
 	payload := map[string]any{}
@@ -380,6 +385,32 @@ func (p *Processor) applyMergeStrategyBatch(ctx context.Context, c Change) Apply
 		default:
 			payload[child.Field] = child.NewValue
 		}
+	}
+
+	// Coupled pairs: GitHub rejects a PATCH that sets one field without the other.
+	// If only one half is present, fetch the current value of the missing companion.
+	type coupledPair struct{ title, message string }
+	pairs := []coupledPair{
+		{"squash_merge_commit_title", "squash_merge_commit_message"},
+		{"merge_commit_title", "merge_commit_message"},
+	}
+	for _, pair := range pairs {
+		_, hasTitle := payload[pair.title]
+		_, hasMessage := payload[pair.message]
+		if hasTitle == hasMessage {
+			// Both present or both absent — nothing to fix.
+			continue
+		}
+		// One half is missing; fetch its current value from GitHub.
+		missing := pair.message
+		if hasMessage {
+			missing = pair.title
+		}
+		out, err := p.runner.Run(ctx, "api", fmt.Sprintf("repos/%s", fullName), "--jq", "."+missing)
+		if err != nil {
+			return ApplyResult{Change: c, Err: wrapError(err, fullName, "merge_strategy")}
+		}
+		payload[missing] = strings.TrimSpace(string(out))
 	}
 
 	body, err := json.Marshal(payload)

--- a/internal/repository/apply_test.go
+++ b/internal/repository/apply_test.go
@@ -1202,7 +1202,13 @@ func TestApplyRepoPatch_Empty(t *testing.T) {
 }
 
 func TestApplyMergeStrategyBatch(t *testing.T) {
-	mock := &gh.MockRunner{}
+	// squash_merge_commit_title is present but squash_merge_commit_message is not,
+	// so the fix fetches the companion message before issuing the PATCH.
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo --jq .squash_merge_commit_message": []byte("COMMIT_MESSAGES\n"),
+		},
+	}
 	proc := NewProcessor(mock, nil)
 
 	repo := newTestRepo("myorg", "myrepo")
@@ -1233,14 +1239,14 @@ func TestApplyMergeStrategyBatch(t *testing.T) {
 		t.Fatalf("unexpected error: %v", results[0].Err)
 	}
 
-	// Should be exactly 1 API call (batched PATCH)
-	if len(mock.Called) != 1 {
-		t.Fatalf("expected 1 gh call, got %d", len(mock.Called))
+	// Expect 2 calls: 1 fetch for the missing companion + 1 batched PATCH.
+	if len(mock.Called) != 2 {
+		t.Fatalf("expected 2 gh calls, got %d", len(mock.Called))
 	}
 
-	body := mock.CalledStdin[0]
+	body := mock.CalledStdin[1]
 	if body == nil {
-		t.Fatal("expected stdin body, got nil")
+		t.Fatal("expected stdin body on PATCH call, got nil")
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(body, &payload); err != nil {
@@ -1251,6 +1257,9 @@ func TestApplyMergeStrategyBatch(t *testing.T) {
 	}
 	if payload["squash_merge_commit_title"] != "PR_TITLE" {
 		t.Errorf("squash_merge_commit_title = %v, want PR_TITLE", payload["squash_merge_commit_title"])
+	}
+	if payload["squash_merge_commit_message"] != "COMMIT_MESSAGES" {
+		t.Errorf("squash_merge_commit_message = %v, want COMMIT_MESSAGES (fetched companion)", payload["squash_merge_commit_message"])
 	}
 	// auto_delete_head_branches should be mapped to delete_branch_on_merge
 	if payload["delete_branch_on_merge"] != true {
@@ -1655,6 +1664,156 @@ func TestApplyLabel_UpdateWithChildren(t *testing.T) {
 	call := strings.Join(mock.Called[0], " ")
 	if !strings.Contains(call, "label edit enhancement") {
 		t.Errorf("expected 'label edit enhancement', got: %s", call)
+	}
+}
+
+func TestApplyMergeStrategyBatch_PairedSquashFields(t *testing.T) {
+	// When only squash_merge_commit_message changes, GitHub requires the
+	// companion squash_merge_commit_title to be sent in the same PATCH.
+	// The batch function must fetch the current title and include it.
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo --jq .squash_merge_commit_title": []byte("PR_TITLE\n"),
+		},
+	}
+	proc := NewProcessor(mock, nil)
+
+	repo := newTestRepo("myorg", "myrepo")
+	changes := []Change{
+		{
+			Type:     ChangeUpdate,
+			Resource: "Repository",
+			Name:     "myorg/myrepo",
+			Field:    "merge_strategy",
+			Children: []Change{
+				{Field: "squash_merge_commit_message", NewValue: "PR_BODY"},
+			},
+		},
+	}
+
+	results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("unexpected error: %v", results[0].Err)
+	}
+
+	// Expect: 1 gh api fetch for the companion title + 1 PATCH
+	if len(mock.Called) != 2 {
+		t.Fatalf("expected 2 gh calls (fetch companion + PATCH), got %d: %v", len(mock.Called), mock.Called)
+	}
+
+	// First call fetches the missing companion.
+	fetchCall := strings.Join(mock.Called[0], " ")
+	if !strings.Contains(fetchCall, "--jq .squash_merge_commit_title") {
+		t.Errorf("expected jq fetch for squash_merge_commit_title, got: %s", fetchCall)
+	}
+
+	// Second call is the PATCH; its payload must include both fields.
+	body := mock.CalledStdin[1]
+	if body == nil {
+		t.Fatal("expected stdin body on PATCH call, got nil")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("failed to parse PATCH payload: %v", err)
+	}
+	if payload["squash_merge_commit_message"] != "PR_BODY" {
+		t.Errorf("squash_merge_commit_message = %v, want PR_BODY", payload["squash_merge_commit_message"])
+	}
+	if payload["squash_merge_commit_title"] != "PR_TITLE" {
+		t.Errorf("squash_merge_commit_title = %v, want PR_TITLE (fetched companion)", payload["squash_merge_commit_title"])
+	}
+}
+
+func TestApplyMergeStrategyBatch_PairedMergeFields(t *testing.T) {
+	// When only merge_commit_title changes, the companion merge_commit_message
+	// must be fetched and sent together.
+	mock := &gh.MockRunner{
+		Responses: map[string][]byte{
+			"api repos/myorg/myrepo --jq .merge_commit_message": []byte("PR_BODY\n"),
+		},
+	}
+	proc := NewProcessor(mock, nil)
+
+	repo := newTestRepo("myorg", "myrepo")
+	changes := []Change{
+		{
+			Type:     ChangeUpdate,
+			Resource: "Repository",
+			Name:     "myorg/myrepo",
+			Field:    "merge_strategy",
+			Children: []Change{
+				{Field: "merge_commit_title", NewValue: "PR_TITLE"},
+			},
+		},
+	}
+
+	results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+	if results[0].Err != nil {
+		t.Fatalf("unexpected error: %v", results[0].Err)
+	}
+
+	// First call fetches merge_commit_message, second is the PATCH.
+	if len(mock.Called) != 2 {
+		t.Fatalf("expected 2 gh calls, got %d: %v", len(mock.Called), mock.Called)
+	}
+
+	body := mock.CalledStdin[1]
+	if body == nil {
+		t.Fatal("expected stdin body on PATCH call, got nil")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("failed to parse PATCH payload: %v", err)
+	}
+	if payload["merge_commit_title"] != "PR_TITLE" {
+		t.Errorf("merge_commit_title = %v, want PR_TITLE", payload["merge_commit_title"])
+	}
+	if payload["merge_commit_message"] != "PR_BODY" {
+		t.Errorf("merge_commit_message = %v, want PR_BODY (fetched companion)", payload["merge_commit_message"])
+	}
+}
+
+func TestApplyMergeStrategyBatch_BothFieldsPresent_NoExtraFetch(t *testing.T) {
+	// When both fields of a pair are present in the diff, no extra fetch is needed.
+	mock := &gh.MockRunner{}
+	proc := NewProcessor(mock, nil)
+
+	repo := newTestRepo("myorg", "myrepo")
+	changes := []Change{
+		{
+			Type:     ChangeUpdate,
+			Resource: "Repository",
+			Name:     "myorg/myrepo",
+			Field:    "merge_strategy",
+			Children: []Change{
+				{Field: "squash_merge_commit_title", NewValue: "PR_TITLE"},
+				{Field: "squash_merge_commit_message", NewValue: "PR_BODY"},
+			},
+		},
+	}
+
+	results := proc.Apply(context.Background(), changes, []*manifest.Repository{repo}, ui.NoopReporter{})
+	if results[0].Err != nil {
+		t.Fatalf("unexpected error: %v", results[0].Err)
+	}
+
+	// Only the PATCH — no extra fetch.
+	if len(mock.Called) != 1 {
+		t.Fatalf("expected 1 gh call (no extra fetch), got %d: %v", len(mock.Called), mock.Called)
+	}
+	body := mock.CalledStdin[0]
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("failed to parse payload: %v", err)
+	}
+	if payload["squash_merge_commit_title"] != "PR_TITLE" {
+		t.Errorf("squash_merge_commit_title = %v, want PR_TITLE", payload["squash_merge_commit_title"])
+	}
+	if payload["squash_merge_commit_message"] != "PR_BODY" {
+		t.Errorf("squash_merge_commit_message = %v, want PR_BODY", payload["squash_merge_commit_message"])
 	}
 }
 

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -107,6 +107,8 @@ func (dc diffContext) group(field string, childFn func(cc *[]Change)) []Change {
 //   - actions.fork_pr_approval is unsupported for private repositories.
 //   - security.automated_security_fixes requires security.vulnerability_alerts
 //     to be effectively true. Required by the GitHub API.
+//   - merge_strategy squash/merge commit title+message must be a valid pairing
+//     per the GitHub API.
 func ValidateDependencies(desired *manifest.Repository, current *CurrentState) error {
 	if desired.Spec.Actions != nil && desired.Spec.Actions.ForkPRApproval != nil && effectiveVisibility(desired, current) == manifest.VisibilityPrivate {
 		return fmt.Errorf("actions.fork_pr_approval is not supported for private repositories (remove actions.fork_pr_approval or make the repository public/internal)")
@@ -117,15 +119,78 @@ func ValidateDependencies(desired *manifest.Repository, current *CurrentState) e
 	}
 
 	s := desired.Spec.Security
-	if s == nil || s.AutomatedSecurityFixes == nil || !*s.AutomatedSecurityFixes {
+	if s != nil && s.AutomatedSecurityFixes != nil && *s.AutomatedSecurityFixes {
+		effectiveAlerts := current.Security.VulnerabilityAlerts
+		if s.VulnerabilityAlerts != nil {
+			effectiveAlerts = *s.VulnerabilityAlerts
+		}
+		if !effectiveAlerts {
+			return fmt.Errorf("security.automated_security_fixes: true requires security.vulnerability_alerts to be enabled (current state is disabled and the manifest does not enable it)")
+		}
+	}
+
+	return validateMergeCommitPairs(desired, current)
+}
+
+// validSquashCombinations lists all GitHub-accepted (title, message) pairs for
+// squash merges. The same set applies to regular merge commits.
+var validMergeCommitCombinations = map[[2]string]bool{
+	{"PR_TITLE", "PR_BODY"}:                   true,
+	{"PR_TITLE", "BLANK"}:                     true,
+	{"PR_TITLE", "COMMIT_MESSAGES"}:           true,
+	{"COMMIT_OR_PR_TITLE", "COMMIT_MESSAGES"}: true,
+}
+
+// validateMergeCommitPairs checks that the effective squash/merge commit
+// title+message combinations are valid per the GitHub API.
+func validateMergeCommitPairs(desired *manifest.Repository, current *CurrentState) error {
+	ms := desired.Spec.MergeStrategy
+	if ms == nil {
 		return nil
 	}
-	effectiveAlerts := current.Security.VulnerabilityAlerts
-	if s.VulnerabilityAlerts != nil {
-		effectiveAlerts = *s.VulnerabilityAlerts
+
+	type pair struct {
+		scope          string
+		desiredTitle   *string
+		desiredMessage *string
+		currentTitle   string
+		currentMessage string
 	}
-	if !effectiveAlerts {
-		return fmt.Errorf("security.automated_security_fixes: true requires security.vulnerability_alerts to be enabled (current state is disabled and the manifest does not enable it)")
+	pairs := []pair{
+		{
+			scope:          "merge_strategy.squash_merge_commit",
+			desiredTitle:   ms.SquashMergeCommitTitle,
+			desiredMessage: ms.SquashMergeCommitMessage,
+			currentTitle:   current.MergeStrategy.SquashMergeCommitTitle,
+			currentMessage: current.MergeStrategy.SquashMergeCommitMessage,
+		},
+		{
+			scope:          "merge_strategy.merge_commit",
+			desiredTitle:   ms.MergeCommitTitle,
+			desiredMessage: ms.MergeCommitMessage,
+			currentTitle:   current.MergeStrategy.MergeCommitTitle,
+			currentMessage: current.MergeStrategy.MergeCommitMessage,
+		},
+	}
+
+	for _, p := range pairs {
+		// Neither field set — nothing to validate.
+		if p.desiredTitle == nil && p.desiredMessage == nil {
+			continue
+		}
+		effectiveTitle := p.currentTitle
+		if p.desiredTitle != nil {
+			effectiveTitle = *p.desiredTitle
+		}
+		effectiveMessage := p.currentMessage
+		if p.desiredMessage != nil {
+			effectiveMessage = *p.desiredMessage
+		}
+		key := [2]string{effectiveTitle, effectiveMessage}
+		if !validMergeCommitCombinations[key] {
+			return fmt.Errorf("%s: invalid combination title=%q message=%q; valid pairs are PR_TITLE+PR_BODY, PR_TITLE+BLANK, PR_TITLE+COMMIT_MESSAGES, COMMIT_OR_PR_TITLE+COMMIT_MESSAGES",
+				p.scope, effectiveTitle, effectiveMessage)
+		}
 	}
 	return nil
 }

--- a/internal/repository/diff.go
+++ b/internal/repository/diff.go
@@ -133,24 +133,48 @@ func ValidateDependencies(desired *manifest.Repository, current *CurrentState) e
 }
 
 // validSquashCombinations lists all GitHub-accepted (title, message) pairs for
-// squash merges. The same set applies to regular merge commits.
-var validMergeCommitCombinations = map[[2]string]bool{
+// squash merges.
+var validSquashCombinations = map[[2]string]bool{
 	{"PR_TITLE", "PR_BODY"}:                   true,
 	{"PR_TITLE", "BLANK"}:                     true,
 	{"PR_TITLE", "COMMIT_MESSAGES"}:           true,
 	{"COMMIT_OR_PR_TITLE", "COMMIT_MESSAGES"}: true,
 }
 
+// validMergeCombinations lists all GitHub-accepted (title, message) pairs for
+// regular merge commits.
+var validMergeCombinations = map[[2]string]bool{
+	{"PR_TITLE", "PR_BODY"}:       true,
+	{"PR_TITLE", "BLANK"}:         true,
+	{"PR_TITLE", "PR_TITLE"}:      true,
+	{"MERGE_MESSAGE", "PR_TITLE"}: true,
+	{"MERGE_MESSAGE", "PR_BODY"}:  true,
+	{"MERGE_MESSAGE", "BLANK"}:    true,
+}
+
 // validateMergeCommitPairs checks that the effective squash/merge commit
-// title+message combinations are valid per the GitHub API.
+// title+message combinations are valid per the GitHub API. Validation is
+// skipped for a merge type when it is effectively disabled, because GitHub
+// ignores those fields when the type is off.
 func validateMergeCommitPairs(desired *manifest.Repository, current *CurrentState) error {
 	ms := desired.Spec.MergeStrategy
 	if ms == nil {
 		return nil
 	}
 
+	// Resolve the effective enabled state for each merge type: desired overrides
+	// current; if neither specifies, the current state is authoritative.
+	effectiveBool := func(desired *bool, current bool) bool {
+		if desired != nil {
+			return *desired
+		}
+		return current
+	}
+
 	type pair struct {
 		scope          string
+		allowEnabled   bool
+		validCombos    map[[2]string]bool
 		desiredTitle   *string
 		desiredMessage *string
 		currentTitle   string
@@ -159,6 +183,8 @@ func validateMergeCommitPairs(desired *manifest.Repository, current *CurrentStat
 	pairs := []pair{
 		{
 			scope:          "merge_strategy.squash_merge_commit",
+			allowEnabled:   effectiveBool(ms.AllowSquashMerge, current.MergeStrategy.AllowSquashMerge),
+			validCombos:    validSquashCombinations,
 			desiredTitle:   ms.SquashMergeCommitTitle,
 			desiredMessage: ms.SquashMergeCommitMessage,
 			currentTitle:   current.MergeStrategy.SquashMergeCommitTitle,
@@ -166,6 +192,8 @@ func validateMergeCommitPairs(desired *manifest.Repository, current *CurrentStat
 		},
 		{
 			scope:          "merge_strategy.merge_commit",
+			allowEnabled:   effectiveBool(ms.AllowMergeCommit, current.MergeStrategy.AllowMergeCommit),
+			validCombos:    validMergeCombinations,
 			desiredTitle:   ms.MergeCommitTitle,
 			desiredMessage: ms.MergeCommitMessage,
 			currentTitle:   current.MergeStrategy.MergeCommitTitle,
@@ -178,6 +206,10 @@ func validateMergeCommitPairs(desired *manifest.Repository, current *CurrentStat
 		if p.desiredTitle == nil && p.desiredMessage == nil {
 			continue
 		}
+		// GitHub ignores title/message fields when the merge type is disabled.
+		if !p.allowEnabled {
+			continue
+		}
 		effectiveTitle := p.currentTitle
 		if p.desiredTitle != nil {
 			effectiveTitle = *p.desiredTitle
@@ -187,8 +219,8 @@ func validateMergeCommitPairs(desired *manifest.Repository, current *CurrentStat
 			effectiveMessage = *p.desiredMessage
 		}
 		key := [2]string{effectiveTitle, effectiveMessage}
-		if !validMergeCommitCombinations[key] {
-			return fmt.Errorf("%s: invalid combination title=%q message=%q; valid pairs are PR_TITLE+PR_BODY, PR_TITLE+BLANK, PR_TITLE+COMMIT_MESSAGES, COMMIT_OR_PR_TITLE+COMMIT_MESSAGES",
+		if !p.validCombos[key] {
+			return fmt.Errorf("%s: invalid combination title=%q message=%q",
 				p.scope, effectiveTitle, effectiveMessage)
 		}
 	}

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -2143,6 +2143,7 @@ func TestValidateDependencies_MergeCommitPairs(t *testing.T) {
 		{
 			name: "squash: PR_TITLE+PR_BODY is valid",
 			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.AllowSquashMerge = manifest.Ptr(true)
 				ms.SquashMergeCommitTitle = manifest.Ptr("PR_TITLE")
 				ms.SquashMergeCommitMessage = manifest.Ptr("PR_BODY")
 			},
@@ -2151,6 +2152,7 @@ func TestValidateDependencies_MergeCommitPairs(t *testing.T) {
 		{
 			name: "squash: PR_TITLE+BLANK is valid",
 			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.AllowSquashMerge = manifest.Ptr(true)
 				ms.SquashMergeCommitTitle = manifest.Ptr("PR_TITLE")
 				ms.SquashMergeCommitMessage = manifest.Ptr("BLANK")
 			},
@@ -2159,6 +2161,7 @@ func TestValidateDependencies_MergeCommitPairs(t *testing.T) {
 		{
 			name: "squash: PR_TITLE+COMMIT_MESSAGES is valid",
 			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.AllowSquashMerge = manifest.Ptr(true)
 				ms.SquashMergeCommitTitle = manifest.Ptr("PR_TITLE")
 				ms.SquashMergeCommitMessage = manifest.Ptr("COMMIT_MESSAGES")
 			},
@@ -2167,6 +2170,7 @@ func TestValidateDependencies_MergeCommitPairs(t *testing.T) {
 		{
 			name: "squash: COMMIT_OR_PR_TITLE+COMMIT_MESSAGES is valid",
 			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.AllowSquashMerge = manifest.Ptr(true)
 				ms.SquashMergeCommitTitle = manifest.Ptr("COMMIT_OR_PR_TITLE")
 				ms.SquashMergeCommitMessage = manifest.Ptr("COMMIT_MESSAGES")
 			},
@@ -2175,6 +2179,7 @@ func TestValidateDependencies_MergeCommitPairs(t *testing.T) {
 		{
 			name: "squash: COMMIT_OR_PR_TITLE+PR_BODY is invalid",
 			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.AllowSquashMerge = manifest.Ptr(true)
 				ms.SquashMergeCommitTitle = manifest.Ptr("COMMIT_OR_PR_TITLE")
 				ms.SquashMergeCommitMessage = manifest.Ptr("PR_BODY")
 			},
@@ -2184,6 +2189,7 @@ func TestValidateDependencies_MergeCommitPairs(t *testing.T) {
 		{
 			name: "squash: COMMIT_OR_PR_TITLE+BLANK is invalid",
 			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.AllowSquashMerge = manifest.Ptr(true)
 				ms.SquashMergeCommitTitle = manifest.Ptr("COMMIT_OR_PR_TITLE")
 				ms.SquashMergeCommitMessage = manifest.Ptr("BLANK")
 			},
@@ -2194,27 +2200,50 @@ func TestValidateDependencies_MergeCommitPairs(t *testing.T) {
 		{
 			name: "merge: PR_TITLE+PR_BODY is valid",
 			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.AllowMergeCommit = manifest.Ptr(true)
 				ms.MergeCommitTitle = manifest.Ptr("PR_TITLE")
 				ms.MergeCommitMessage = manifest.Ptr("PR_BODY")
 			},
 			wantErr: false,
 		},
 		{
-			name: "merge: COMMIT_OR_PR_TITLE+COMMIT_MESSAGES is valid",
+			name: "merge: MERGE_MESSAGE+PR_TITLE is valid",
 			setupMS: func(ms *manifest.MergeStrategy) {
-				ms.MergeCommitTitle = manifest.Ptr("COMMIT_OR_PR_TITLE")
-				ms.MergeCommitMessage = manifest.Ptr("COMMIT_MESSAGES")
+				ms.AllowMergeCommit = manifest.Ptr(true)
+				ms.MergeCommitTitle = manifest.Ptr("MERGE_MESSAGE")
+				ms.MergeCommitMessage = manifest.Ptr("PR_TITLE")
 			},
 			wantErr: false,
 		},
 		{
+			name: "merge: COMMIT_OR_PR_TITLE+COMMIT_MESSAGES is invalid for merge (squash-only)",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.AllowMergeCommit = manifest.Ptr(true)
+				ms.MergeCommitTitle = manifest.Ptr("COMMIT_OR_PR_TITLE")
+				ms.MergeCommitMessage = manifest.Ptr("COMMIT_MESSAGES")
+			},
+			wantErr:     true,
+			wantErrText: "merge_commit",
+		},
+		{
 			name: "merge: COMMIT_OR_PR_TITLE+PR_BODY is invalid",
 			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.AllowMergeCommit = manifest.Ptr(true)
 				ms.MergeCommitTitle = manifest.Ptr("COMMIT_OR_PR_TITLE")
 				ms.MergeCommitMessage = manifest.Ptr("PR_BODY")
 			},
 			wantErr:     true,
 			wantErrText: "merge_commit",
+		},
+		{
+			name: "merge: validation skipped when allow_merge_commit is false",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.AllowMergeCommit = manifest.Ptr(false)
+				// MERGE_MESSAGE+PR_TITLE is valid, but GitHub ignores these when disabled
+				ms.MergeCommitTitle = manifest.Ptr("MERGE_MESSAGE")
+				ms.MergeCommitMessage = manifest.Ptr("PR_TITLE")
+			},
+			wantErr: false,
 		},
 		// --- effective value: one field omitted, falls back to current ---
 		{
@@ -2223,7 +2252,7 @@ func TestValidateDependencies_MergeCommitPairs(t *testing.T) {
 				ms.SquashMergeCommitMessage = manifest.Ptr("PR_BODY")
 				// title omitted → effective = current = "PR_TITLE" → PR_TITLE+PR_BODY is valid
 			},
-			currentMS: CurrentMergeStrategy{SquashMergeCommitTitle: "PR_TITLE"},
+			currentMS: CurrentMergeStrategy{AllowSquashMerge: true, SquashMergeCommitTitle: "PR_TITLE"},
 			wantErr:   false,
 		},
 		{
@@ -2232,7 +2261,7 @@ func TestValidateDependencies_MergeCommitPairs(t *testing.T) {
 				ms.SquashMergeCommitMessage = manifest.Ptr("PR_BODY")
 				// title omitted → effective = current = "COMMIT_OR_PR_TITLE" → COMMIT_OR_PR_TITLE+PR_BODY is invalid
 			},
-			currentMS:   CurrentMergeStrategy{SquashMergeCommitTitle: "COMMIT_OR_PR_TITLE"},
+			currentMS:   CurrentMergeStrategy{AllowSquashMerge: true, SquashMergeCommitTitle: "COMMIT_OR_PR_TITLE"},
 			wantErr:     true,
 			wantErrText: "squash_merge_commit",
 		},

--- a/internal/repository/diff_test.go
+++ b/internal/repository/diff_test.go
@@ -2131,6 +2131,143 @@ func TestDiffActions_DetectsChanges(t *testing.T) {
 	}
 }
 
+func TestValidateDependencies_MergeCommitPairs(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupMS     func(ms *manifest.MergeStrategy)
+		currentMS   CurrentMergeStrategy
+		wantErr     bool
+		wantErrText string
+	}{
+		// --- squash pair ---
+		{
+			name: "squash: PR_TITLE+PR_BODY is valid",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.SquashMergeCommitTitle = manifest.Ptr("PR_TITLE")
+				ms.SquashMergeCommitMessage = manifest.Ptr("PR_BODY")
+			},
+			wantErr: false,
+		},
+		{
+			name: "squash: PR_TITLE+BLANK is valid",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.SquashMergeCommitTitle = manifest.Ptr("PR_TITLE")
+				ms.SquashMergeCommitMessage = manifest.Ptr("BLANK")
+			},
+			wantErr: false,
+		},
+		{
+			name: "squash: PR_TITLE+COMMIT_MESSAGES is valid",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.SquashMergeCommitTitle = manifest.Ptr("PR_TITLE")
+				ms.SquashMergeCommitMessage = manifest.Ptr("COMMIT_MESSAGES")
+			},
+			wantErr: false,
+		},
+		{
+			name: "squash: COMMIT_OR_PR_TITLE+COMMIT_MESSAGES is valid",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.SquashMergeCommitTitle = manifest.Ptr("COMMIT_OR_PR_TITLE")
+				ms.SquashMergeCommitMessage = manifest.Ptr("COMMIT_MESSAGES")
+			},
+			wantErr: false,
+		},
+		{
+			name: "squash: COMMIT_OR_PR_TITLE+PR_BODY is invalid",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.SquashMergeCommitTitle = manifest.Ptr("COMMIT_OR_PR_TITLE")
+				ms.SquashMergeCommitMessage = manifest.Ptr("PR_BODY")
+			},
+			wantErr:     true,
+			wantErrText: "squash_merge_commit",
+		},
+		{
+			name: "squash: COMMIT_OR_PR_TITLE+BLANK is invalid",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.SquashMergeCommitTitle = manifest.Ptr("COMMIT_OR_PR_TITLE")
+				ms.SquashMergeCommitMessage = manifest.Ptr("BLANK")
+			},
+			wantErr:     true,
+			wantErrText: "squash_merge_commit",
+		},
+		// --- merge pair ---
+		{
+			name: "merge: PR_TITLE+PR_BODY is valid",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.MergeCommitTitle = manifest.Ptr("PR_TITLE")
+				ms.MergeCommitMessage = manifest.Ptr("PR_BODY")
+			},
+			wantErr: false,
+		},
+		{
+			name: "merge: COMMIT_OR_PR_TITLE+COMMIT_MESSAGES is valid",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.MergeCommitTitle = manifest.Ptr("COMMIT_OR_PR_TITLE")
+				ms.MergeCommitMessage = manifest.Ptr("COMMIT_MESSAGES")
+			},
+			wantErr: false,
+		},
+		{
+			name: "merge: COMMIT_OR_PR_TITLE+PR_BODY is invalid",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.MergeCommitTitle = manifest.Ptr("COMMIT_OR_PR_TITLE")
+				ms.MergeCommitMessage = manifest.Ptr("PR_BODY")
+			},
+			wantErr:     true,
+			wantErrText: "merge_commit",
+		},
+		// --- effective value: one field omitted, falls back to current ---
+		{
+			name: "squash: desired message only, current title valid combo",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.SquashMergeCommitMessage = manifest.Ptr("PR_BODY")
+				// title omitted → effective = current = "PR_TITLE" → PR_TITLE+PR_BODY is valid
+			},
+			currentMS: CurrentMergeStrategy{SquashMergeCommitTitle: "PR_TITLE"},
+			wantErr:   false,
+		},
+		{
+			name: "squash: desired message only, current title invalid combo",
+			setupMS: func(ms *manifest.MergeStrategy) {
+				ms.SquashMergeCommitMessage = manifest.Ptr("PR_BODY")
+				// title omitted → effective = current = "COMMIT_OR_PR_TITLE" → COMMIT_OR_PR_TITLE+PR_BODY is invalid
+			},
+			currentMS:   CurrentMergeStrategy{SquashMergeCommitTitle: "COMMIT_OR_PR_TITLE"},
+			wantErr:     true,
+			wantErrText: "squash_merge_commit",
+		},
+		// --- nil merge_strategy: no error ---
+		{
+			name:    "nil merge_strategy: ok",
+			setupMS: nil,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &manifest.Repository{Spec: manifest.RepositorySpec{}}
+			if tt.setupMS != nil {
+				d.Spec.MergeStrategy = &manifest.MergeStrategy{}
+				tt.setupMS(d.Spec.MergeStrategy)
+			}
+			c := &CurrentState{MergeStrategy: tt.currentMS}
+
+			err := ValidateDependencies(d, c)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantErrText, err)
+				}
+			} else if err != nil {
+				t.Errorf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestDiffActions_ChildOrder(t *testing.T) {
 	// Verify enabled/allowed_actions come before selected_actions
 	desired := baseDesired()


### PR DESCRIPTION
Fixes #168. Stacked on #167.

## Problem

Three independent apply-time failures:

1. **Empty commits.** Content comparison used `strings.TrimRight(content, "\n")`, catching trailing-newline differences but missing other normalizations GitHub applies on ingest (trailing spaces, `\r\n` endings, template artifacts). A false `ChangeUpdate` would then commit identical bytes, producing a commit whose tree SHA equals its parent — observed across all 8 repos in a single apply run.

2. **422 on partial merge strategy update.** GitHub's PATCH `repos/{owner}/{repo}` rejects a request that sets `squash_merge_commit_message` without also setting `squash_merge_commit_title` (and vice versa), and the same coupling applies to `merge_commit_title` / `merge_commit_message`. `applyMergeStrategyBatch` only sent changed fields, so applying `squash_merge_commit_message: PR_BODY` alone produced a 422.

3. **422 from plan-time validation using wrong combo map.** `validateMergeCommitPairs` used a single combinations map for both squash and merge commits, but the valid pairs differ. It also ran validation even when the merge type was disabled (`allow_merge_commit: false`), flagging repos that had `MERGE_MESSAGE+PR_TITLE` stored alongside a disabled merge commit — a valid GitHub state that GitHub ignores.

## Fix

**Noop guard (both commit paths):** A new `isContentNoop` method in `applyViaCommitFunc` — the shared orchestration layer — covers both `commitViaGitDataAPI` and `commitViaGraphQL` before either path runs. `commitViaGitDataAPI` additionally compares tree SHAs after `POST /git/trees` as a second defense.

**Paired merge strategy fields:** `applyMergeStrategyBatch` checks for incomplete coupled pairs after building the payload. If only one half of a squash or merge commit title+message pair is present, it fetches the current value of the missing companion and adds it before issuing the PATCH.

**Separate combo maps and disabled-type skip:** `validateMergeCommitPairs` now uses `validSquashCombinations` and `validMergeCombinations` as separate maps reflecting each type's actual valid pairs. Validation is skipped for a pair when the corresponding merge type is effectively disabled (resolving desired-overrides-current).

## Valid combinations

**Squash merge commits:**

| Title | Message |
|---|---|
| `PR_TITLE` | `PR_BODY` |
| `PR_TITLE` | `BLANK` |
| `PR_TITLE` | `COMMIT_MESSAGES` |
| `COMMIT_OR_PR_TITLE` | `COMMIT_MESSAGES` |

**Regular merge commits:**

| Title | Message |
|---|---|
| `PR_TITLE` | `PR_BODY` |
| `PR_TITLE` | `BLANK` |
| `PR_TITLE` | `PR_TITLE` |
| `MERGE_MESSAGE` | `PR_TITLE` |
| `MERGE_MESSAGE` | `PR_BODY` |
| `MERGE_MESSAGE` | `BLANK` |