### PR TITLE
fix: expand all env vars in secret values, not just ENV_-prefixed

### DIFF
--- a/internal/infra/plan.go
+++ b/internal/infra/plan.go
@@ -84,7 +84,9 @@ func Plan(opts PlanOptions) (*PlanResult, error) {
 	}
 
 	if !opts.DryRun {
-		manifest.ResolveSecrets(parsed.Repositories)
+		for _, w := range manifest.ResolveSecrets(parsed.Repositories) {
+			p.Warning("secrets", w)
+		}
 	}
 
 	var resolverOwner string

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -726,21 +726,28 @@ func mergeSelectedActions(base, override *SelectedActions) *SelectedActions {
 	return &result
 }
 
-// expandEnvVars replaces ${ENV_*} references with actual environment variables.
+// expandEnvVars replaces ${VAR} references with environment variable values.
 func expandEnvVars(s string) string {
-	return os.Expand(s, func(key string) string {
-		if strings.HasPrefix(key, "ENV_") {
-			return os.Getenv(key)
-		}
-		return "${" + key + "}"
-	})
+	return os.Expand(s, os.Getenv)
 }
 
 // ResolveSecrets expands environment variable references in secret values.
-func ResolveSecrets(repos []*Repository) {
+// Returns warnings for secret values that contained ${VAR} references but
+// resolved to empty string, indicating a missing or unset environment variable.
+func ResolveSecrets(repos []*Repository) []string {
+	var warnings []string
 	for _, repo := range repos {
 		for i := range repo.Spec.Secrets {
-			repo.Spec.Secrets[i].Value = expandEnvVars(repo.Spec.Secrets[i].Value)
+			original := repo.Spec.Secrets[i].Value
+			resolved := expandEnvVars(original)
+			repo.Spec.Secrets[i].Value = resolved
+			if strings.Contains(original, "${") && resolved == "" {
+				warnings = append(warnings, fmt.Sprintf(
+					"repo %s: secret %q resolved to empty string — check that the referenced env var is set",
+					repo.Metadata.Name, repo.Spec.Secrets[i].Name,
+				))
+			}
 		}
 	}
+	return warnings
 }

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -629,9 +629,10 @@ repositories:
 }
 
 func TestResolveSecrets_ExpandsEnvVars(t *testing.T) {
-	// Set test environment variables
 	t.Setenv("ENV_SECRET_TOKEN", "my-secret-value")
 	t.Setenv("ENV_API_KEY", "api-key-123")
+	t.Setenv("NOT_ENV_PREFIX", "no-prefix-value")
+	t.Setenv("RELEASE_APP_PRIVATE_KEY", "pem-key-data")
 
 	repos := []*Repository{
 		{
@@ -642,6 +643,7 @@ func TestResolveSecrets_ExpandsEnvVars(t *testing.T) {
 					{Name: "API_KEY", Value: "${ENV_API_KEY}"},
 					{Name: "LITERAL", Value: "plain-value"},
 					{Name: "NON_ENV", Value: "${NOT_ENV_PREFIX}"},
+					{Name: "APP_KEY", Value: "${RELEASE_APP_PRIVATE_KEY}"},
 				},
 			},
 		},
@@ -656,7 +658,8 @@ func TestResolveSecrets_ExpandsEnvVars(t *testing.T) {
 		{0, "my-secret-value"},
 		{1, "api-key-123"},
 		{2, "plain-value"},
-		{3, "${NOT_ENV_PREFIX}"},
+		{3, "no-prefix-value"},
+		{4, "pem-key-data"},
 	}
 
 	for _, tt := range tests {
@@ -664,6 +667,34 @@ func TestResolveSecrets_ExpandsEnvVars(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("secret[%d].Value = %q, want %q", tt.idx, got, tt.want)
 		}
+	}
+}
+
+func TestResolveSecrets_WarnOnEmptyResolution(t *testing.T) {
+	repos := []*Repository{
+		{
+			Metadata: RepositoryMetadata{Name: "myrepo", Owner: "org"},
+			Spec: RepositorySpec{
+				Secrets: []Secret{
+					{Name: "MISSING", Value: "${UNSET_VAR_XYZ}"},
+					{Name: "PRESENT", Value: "${ENV_SECRET_TOKEN}"},
+					{Name: "LITERAL", Value: "plain"},
+				},
+			},
+		},
+	}
+	t.Setenv("ENV_SECRET_TOKEN", "tok")
+
+	warnings := ResolveSecrets(repos)
+
+	if len(warnings) != 1 {
+		t.Fatalf("want 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "MISSING") {
+		t.Errorf("warning should mention secret name MISSING, got: %s", warnings[0])
+	}
+	if repos[0].Spec.Secrets[0].Value != "" {
+		t.Errorf("unset var should resolve to empty string, got %q", repos[0].Spec.Secrets[0].Value)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `expandEnvVars` previously only expanded `${ENV_*}` variables, leaving all other `${VAR}` references as literal strings
- Secret values using names without the `ENV_` prefix (e.g. `${RELEASE_APP_PRIVATE_KEY}`) were stored as-is in GitHub Secrets, silently corrupting them on first apply
- `ResolveSecrets` now returns `[]string` warnings so the caller can surface empty resolutions at apply time rather than discovering the problem after the fact

## Changes

- `expandEnvVars`: replace the `ENV_`-prefix guard with `os.Expand(s, os.Getenv)` — expands all `${VAR}` references
- `ResolveSecrets`: returns `[]string` warnings for secrets that contained `${...}` but resolved to empty string (missing env var)
- `plan.go`: emit returned warnings via `p.Warning("secrets", w)`
- Tests: update `TestResolveSecrets_ExpandsEnvVars` to reflect correct expansion behavior; add `TestResolveSecrets_WarnOnEmptyResolution`

https://claude.ai/code/session_012sEU39bECAKR2XvzBtfvNj